### PR TITLE
chore: set up dev environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,4 @@
-# Environment variables for local development
-# Copy to .env and fill in values
+# Optional local development overrides for Procfile.dev
 
-# App
-PORT=3000
-
-# Add service-specific variables below during dev environment setup
+# Daemon log level for the isolated local dev daemon
+TODU_LOG_LEVEL=debug

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ npm-debug.log*
 # Dev environment
 .overmind.sock
 .dev/
+config/dev.todu.yaml
 
 # AI agent config
 .claude/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: dev dev-stop dev-status dev-logs dev-tail check pre-pr help
+DEV_CONFIG := ./config/dev.todu.yaml
+DEV_CLI := todu --config $(DEV_CONFIG)
+
+.PHONY: dev dev-stop dev-status dev-logs dev-tail dev-daemon-status dev-cli check pre-pr help
 
 SOCKET := ./.overmind.sock
 
@@ -6,15 +9,27 @@ help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 dev: ## Start the dev environment (daemonized)
+	@if [ ! -f $(DEV_CONFIG) ]; then \
+		echo "Creating $(DEV_CONFIG) from template..."; \
+		cp $(DEV_CONFIG).template $(DEV_CONFIG); \
+	fi
 	@if [ -S $(SOCKET) ] && overmind ps -s $(SOCKET) > /dev/null 2>&1; then \
 		echo "Dev environment already running"; \
-		overmind ps -s $(SOCKET); \
 	else \
 		rm -f $(SOCKET); \
 		overmind start -f Procfile.dev -s $(SOCKET) -D; \
-		sleep 2; \
-		overmind ps -s $(SOCKET); \
 	fi
+	@attempts=0; \
+	until [ -S $(SOCKET) ] && $(DEV_CLI) daemon status > /dev/null 2>&1; do \
+		attempts=$$((attempts + 1)); \
+		if [ $$attempts -ge 20 ]; then \
+			echo "Dev environment failed to become ready"; \
+			overmind ps -s $(SOCKET) || true; \
+			exit 1; \
+		fi; \
+		sleep 1; \
+	done
+	@overmind ps -s $(SOCKET)
 
 dev-stop: ## Stop the dev environment
 	@if [ -S $(SOCKET) ]; then overmind quit -s $(SOCKET) || true; fi
@@ -39,6 +54,13 @@ dev-tail: ## Show last 100 lines of logs (non-blocking)
 	else \
 		echo "Dev environment not running"; \
 	fi
+
+dev-daemon-status: ## Show isolated dev daemon status
+	$(DEV_CLI) daemon status
+
+dev-cli: ## Run a todu command against the isolated dev config (usage: make dev-cli CMD="daemon status")
+	@test -n "$(CMD)" || (echo "Usage: make dev-cli CMD=\"daemon status\"" && exit 1)
+	$(DEV_CLI) $(CMD)
 
 check: ## Run linting, type checking, and tests
 	npm run lint && npm run typecheck && npm test

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,5 @@
+# Local development services for todu-pi-extensions
+# Uses an isolated project-local todu config and data directory.
+
+typecheck: npm run typecheck:watch
+daemon: mkdir -p ./.dev/todu/data && todu --config ./config/dev.todu.yaml daemon run

--- a/README.md
+++ b/README.md
@@ -19,13 +19,17 @@ The initial architecture design is documented in [`docs/architecture.md`](docs/a
 - Node.js 20+
 - npm
 - [pi](https://github.com/badlogic/pi-mono) installed locally for manual extension testing
-- [overmind](https://github.com/DarthSim/overmind) for the future dev environment task
+- [overmind](https://github.com/DarthSim/overmind) for the local dev environment
+- [`todu`](https://github.com/evcraddock/todu) CLI installed locally to run the isolated dev daemon
 
 ## Installation
 
 ```bash
 npm install
+cp .env.example .env
 ```
+
+The `.env` file is optional. It currently exists for local development overrides such as daemon log level.
 
 ## How to Work on This Project
 
@@ -35,7 +39,25 @@ npm install
 make dev
 ```
 
-This will work after the dev environment is configured.
+This starts an isolated local todu daemon and a TypeScript watch process via overmind.
+
+On first run, `make dev` copies `config/dev.todu.yaml.template` to `config/dev.todu.yaml` automatically.
+
+The dev daemon uses a project-local data directory at `.dev/todu/data/`, so it does not touch your normal `~/.config/todu` state.
+
+### Check Dev Daemon Status
+
+```bash
+make dev-status
+make dev-daemon-status
+```
+
+### Run todu Commands Against the Isolated Dev Daemon
+
+```bash
+make dev-cli CMD="project list"
+make dev-cli CMD="task list"
+```
 
 ### View Logs
 
@@ -44,10 +66,10 @@ make dev-logs
 make dev-tail
 ```
 
-### Check Status
+### Stop the Dev Environment
 
 ```bash
-make dev-status
+make dev-stop
 ```
 
 ### Run Tests and Linting
@@ -75,14 +97,20 @@ make help
 
 ## Dev Environment Setup
 
-The dev environment still needs project-specific configuration. See todu task `task-3d758b6a` (`Set up dev environment`) for the follow-up work.
+The project uses an isolated local todu daemon for development. The writable dev config lives at `config/dev.todu.yaml` and is created from `config/dev.todu.yaml.template` on first `make dev`.
+
+The local daemon stores state under `.dev/todu/data/`, which is gitignored.
+
+Manual pi extension testing is still a separate step. This task sets up the backend/client-side dev environment and local feedback loop, not a full automated pi runtime.
 
 ## Project Layout
 
 ```text
+config/               Local dev daemon config template
 src/                  Extension entrypoint and future task UI code
 docs/                 Project workflow, coding standards, and architecture design
 scripts/pre-pr.sh     Local verification script
+.dev/                 Gitignored local daemon state created by make dev
 ```
 
 ## License

--- a/config/dev.todu.yaml.template
+++ b/config/dev.todu.yaml.template
@@ -1,0 +1,8 @@
+# Project-local development config for the isolated todu daemon and CLI.
+# Copy this to dev.todu.yaml if you want to edit it manually:
+#   cp config/dev.todu.yaml.template config/dev.todu.yaml
+#
+# The default data directory is project-local so local development does not
+# touch your normal ~/.config/todu state.
+
+data_dir: ../.dev/todu/data

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --noEmit --watch --preserveWatchOutput",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary
- add an isolated local todu daemon dev environment for this project
- add Procfile and Makefile helpers for starting and targeting the dev daemon
- document the local dev loop and config template usage in the README

## Verification
- make dev && make dev-daemon-status && make dev-cli CMD="project list --format json" && make dev-stop
- make pre-pr

Task: #task-3d758b6a