### PR TITLE
feat: introduce module layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run unit tests
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     ]
   },
   "scripts": {
-    "build": "echo 'No build step configured yet'",
+    "build": "tsc --project tsconfig.json",
     "lint": "eslint .",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",

--- a/src/__tests__/example.test.ts
+++ b/src/__tests__/example.test.ts
@@ -1,9 +1,22 @@
 import { describe, expect, it } from "vitest";
 
-import toduPiExtensions from "@/index";
+import { createTaskListItem } from "@/ui/components/task-list";
 
-describe("toduPiExtensions", () => {
-  it("exports an extension entrypoint", () => {
-    expect(typeof toduPiExtensions).toBe("function");
+describe("task list UI scaffolding", () => {
+  it("creates a list item view model from a task summary", () => {
+    const item = createTaskListItem({
+      id: "task-123",
+      title: "Implement module layout",
+      status: "active",
+      priority: "high",
+      projectId: "proj-1",
+      labels: ["foundation"],
+    });
+
+    expect(item).toEqual({
+      value: "task-123",
+      label: "Implement module layout",
+      description: "active • high • proj-1",
+    });
   });
 });

--- a/src/__tests__/module-layout.test.ts
+++ b/src/__tests__/module-layout.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { registerCommands } from "@/extension/register-commands";
+import { registerEvents } from "@/extension/register-events";
+import { registerTools } from "@/extension/register-tools";
+import { registerUi } from "@/extension/register-ui";
+import toduPiExtensions from "@/index";
+
+describe("module layout", () => {
+  it("exports the extension entrypoint and registration modules", () => {
+    expect(typeof toduPiExtensions).toBe("function");
+    expect(typeof registerCommands).toBe("function");
+    expect(typeof registerTools).toBe("function");
+    expect(typeof registerUi).toBe("function");
+    expect(typeof registerEvents).toBe("function");
+  });
+});

--- a/src/__tests__/task-session-store.test.ts
+++ b/src/__tests__/task-session-store.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { pickCurrentTask } from "@/flows/pick-current-task";
+import { createInMemoryTaskSessionStore } from "@/services/task-session-store";
+
+describe("task session store", () => {
+  it("tracks the current task through the flow boundary", () => {
+    const taskSessionStore = createInMemoryTaskSessionStore();
+
+    pickCurrentTask({ taskSessionStore }, "task-123");
+    expect(taskSessionStore.getState()).toEqual({ currentTaskId: "task-123" });
+
+    taskSessionStore.clearCurrentTask();
+    expect(taskSessionStore.getState()).toEqual({ currentTaskId: null });
+  });
+});

--- a/src/__tests__/todu-task-service.test.ts
+++ b/src/__tests__/todu-task-service.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { TaskDetail, TaskFilter } from "@/domain/task";
+import { browseTasks } from "@/flows/browse-tasks";
+import { createToduTaskService } from "@/services/todu/todu-task-service";
+
+describe("createToduTaskService", () => {
+  it("delegates flow-facing task operations to the daemon client", async () => {
+    const taskDetail: TaskDetail = {
+      id: "task-123",
+      title: "Set up foundation",
+      status: "active",
+      priority: "high",
+      projectId: "proj-1",
+      labels: ["foundation"],
+      description: "Create the initial module layout",
+      comments: [],
+    };
+    const filter: TaskFilter = { statuses: ["active"] };
+    const client = {
+      listTasks: vi.fn().mockResolvedValue([taskDetail]),
+      getTask: vi.fn().mockResolvedValue(taskDetail),
+      createTask: vi.fn().mockResolvedValue(taskDetail),
+      updateTask: vi.fn().mockResolvedValue(taskDetail),
+      addTaskComment: vi.fn().mockResolvedValue({
+        id: "comment-1",
+        taskId: taskDetail.id,
+        content: "Looks good",
+        author: "user",
+        createdAt: "2026-03-18T00:00:00.000Z",
+      }),
+      on: vi.fn(),
+    };
+    const taskService = createToduTaskService({ client });
+
+    await expect(browseTasks({ taskService }, filter)).resolves.toEqual([taskDetail]);
+    expect(client.listTasks).toHaveBeenCalledWith(filter);
+  });
+});

--- a/src/domain/task-actions.ts
+++ b/src/domain/task-actions.ts
@@ -1,0 +1,42 @@
+import type { TaskId, TaskPriority, TaskStatus } from "@/domain/task";
+
+export type TaskFlowId =
+  | "browse-tasks"
+  | "show-task-detail"
+  | "create-task"
+  | "update-task"
+  | "comment-on-task"
+  | "pick-current-task";
+
+export interface SetCurrentTaskAction {
+  kind: "set-current";
+  taskId: TaskId;
+}
+
+export interface UpdateTaskStatusAction {
+  kind: "update-status";
+  taskId: TaskId;
+  status: TaskStatus;
+}
+
+export interface UpdateTaskPriorityAction {
+  kind: "update-priority";
+  taskId: TaskId;
+  priority: TaskPriority;
+}
+
+export interface CommentOnTaskAction {
+  kind: "comment";
+  taskId: TaskId;
+}
+
+export interface CreateTaskAction {
+  kind: "create";
+}
+
+export type TaskAction =
+  | SetCurrentTaskAction
+  | UpdateTaskStatusAction
+  | UpdateTaskPriorityAction
+  | CommentOnTaskAction
+  | CreateTaskAction;

--- a/src/domain/task.ts
+++ b/src/domain/task.ts
@@ -1,0 +1,36 @@
+export type TaskId = string;
+export type ProjectId = string;
+export type TaskCommentId = string;
+
+export type TaskStatus = "active" | "inprogress" | "waiting" | "done" | "cancelled";
+
+export type TaskPriority = "low" | "medium" | "high";
+
+export interface TaskComment {
+  id: TaskCommentId;
+  taskId: TaskId;
+  content: string;
+  author: string;
+  createdAt: string;
+}
+
+export interface TaskSummary {
+  id: TaskId;
+  title: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  projectId: ProjectId | null;
+  labels: string[];
+}
+
+export interface TaskDetail extends TaskSummary {
+  description: string | null;
+  comments: TaskComment[];
+}
+
+export interface TaskFilter {
+  projectId?: ProjectId | null;
+  statuses?: TaskStatus[];
+  priorities?: TaskPriority[];
+  query?: string;
+}

--- a/src/extension/register-commands.ts
+++ b/src/extension/register-commands.ts
@@ -1,0 +1,7 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const registerCommands = (_pi: ExtensionAPI): void => {
+  // Commands are introduced in follow-up tasks.
+};
+
+export { registerCommands };

--- a/src/extension/register-events.ts
+++ b/src/extension/register-events.ts
@@ -1,0 +1,7 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const registerEvents = (_pi: ExtensionAPI): void => {
+  // Event hooks are introduced in follow-up tasks.
+};
+
+export { registerEvents };

--- a/src/extension/register-tools.ts
+++ b/src/extension/register-tools.ts
@@ -1,0 +1,7 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const registerTools = (_pi: ExtensionAPI): void => {
+  // LLM-facing tools are introduced in follow-up tasks.
+};
+
+export { registerTools };

--- a/src/extension/register-ui.ts
+++ b/src/extension/register-ui.ts
@@ -1,0 +1,7 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const registerUi = (_pi: ExtensionAPI): void => {
+  // Widgets, status lines, and renderers are introduced in follow-up tasks.
+};
+
+export { registerUi };

--- a/src/flows/browse-tasks.ts
+++ b/src/flows/browse-tasks.ts
@@ -1,0 +1,13 @@
+import type { TaskFilter, TaskSummary } from "@/domain/task";
+import type { TaskService } from "@/services/task-service";
+
+export interface BrowseTasksDependencies {
+  taskService: TaskService;
+}
+
+const browseTasks = async (
+  { taskService }: BrowseTasksDependencies,
+  filter: TaskFilter = {}
+): Promise<TaskSummary[]> => taskService.listTasks(filter);
+
+export { browseTasks };

--- a/src/flows/comment-on-task.ts
+++ b/src/flows/comment-on-task.ts
@@ -1,0 +1,13 @@
+import type { TaskComment } from "@/domain/task";
+import type { AddTaskCommentInput, TaskService } from "@/services/task-service";
+
+export interface CommentOnTaskDependencies {
+  taskService: TaskService;
+}
+
+const commentOnTask = async (
+  { taskService }: CommentOnTaskDependencies,
+  input: AddTaskCommentInput
+): Promise<TaskComment> => taskService.addTaskComment(input);
+
+export { commentOnTask };

--- a/src/flows/create-task.ts
+++ b/src/flows/create-task.ts
@@ -1,0 +1,13 @@
+import type { TaskDetail } from "@/domain/task";
+import type { CreateTaskInput, TaskService } from "@/services/task-service";
+
+export interface CreateTaskDependencies {
+  taskService: TaskService;
+}
+
+const createTask = async (
+  { taskService }: CreateTaskDependencies,
+  input: CreateTaskInput
+): Promise<TaskDetail> => taskService.createTask(input);
+
+export { createTask };

--- a/src/flows/pick-current-task.ts
+++ b/src/flows/pick-current-task.ts
@@ -1,0 +1,15 @@
+import type { TaskId } from "@/domain/task";
+import type { TaskSessionStore } from "@/services/task-session-store";
+
+export interface PickCurrentTaskDependencies {
+  taskSessionStore: TaskSessionStore;
+}
+
+const pickCurrentTask = (
+  { taskSessionStore }: PickCurrentTaskDependencies,
+  taskId: TaskId | null
+): void => {
+  taskSessionStore.setCurrentTask(taskId);
+};
+
+export { pickCurrentTask };

--- a/src/flows/show-task-detail.ts
+++ b/src/flows/show-task-detail.ts
@@ -1,0 +1,13 @@
+import type { TaskDetail, TaskId } from "@/domain/task";
+import type { TaskService } from "@/services/task-service";
+
+export interface ShowTaskDetailDependencies {
+  taskService: TaskService;
+}
+
+const showTaskDetail = async (
+  { taskService }: ShowTaskDetailDependencies,
+  taskId: TaskId
+): Promise<TaskDetail | null> => taskService.getTask(taskId);
+
+export { showTaskDetail };

--- a/src/flows/update-task.ts
+++ b/src/flows/update-task.ts
@@ -1,0 +1,13 @@
+import type { TaskDetail } from "@/domain/task";
+import type { TaskService, UpdateTaskInput } from "@/services/task-service";
+
+export interface UpdateTaskDependencies {
+  taskService: TaskService;
+}
+
+const updateTask = async (
+  { taskService }: UpdateTaskDependencies,
+  input: UpdateTaskInput
+): Promise<TaskDetail> => taskService.updateTask(input);
+
+export { updateTask };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,15 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
-const toduPiExtensions = (_pi: ExtensionAPI): void => {
-  // Intentionally empty during project initialization.
-  // Feature work should add extensions, tools, and TUI components in follow-up tasks.
+import { registerCommands } from "@/extension/register-commands";
+import { registerEvents } from "@/extension/register-events";
+import { registerTools } from "@/extension/register-tools";
+import { registerUi } from "@/extension/register-ui";
+
+const toduPiExtensions = (pi: ExtensionAPI): void => {
+  registerCommands(pi);
+  registerTools(pi);
+  registerUi(pi);
+  registerEvents(pi);
 };
 
 export { toduPiExtensions };

--- a/src/services/task-service.ts
+++ b/src/services/task-service.ts
@@ -1,0 +1,36 @@
+import type {
+  TaskComment,
+  TaskDetail,
+  TaskFilter,
+  TaskId,
+  TaskPriority,
+  TaskStatus,
+  TaskSummary,
+} from "@/domain/task";
+
+export interface CreateTaskInput {
+  title: string;
+  description?: string | null;
+  projectId?: string | null;
+  labels?: string[];
+}
+
+export interface UpdateTaskInput {
+  taskId: TaskId;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  description?: string | null;
+}
+
+export interface AddTaskCommentInput {
+  taskId: TaskId;
+  content: string;
+}
+
+export interface TaskService {
+  listTasks(filter?: TaskFilter): Promise<TaskSummary[]>;
+  getTask(taskId: TaskId): Promise<TaskDetail | null>;
+  createTask(input: CreateTaskInput): Promise<TaskDetail>;
+  updateTask(input: UpdateTaskInput): Promise<TaskDetail>;
+  addTaskComment(input: AddTaskCommentInput): Promise<TaskComment>;
+}

--- a/src/services/task-session-store.ts
+++ b/src/services/task-session-store.ts
@@ -1,0 +1,33 @@
+import type { TaskId } from "@/domain/task";
+
+export interface TaskSessionState {
+  currentTaskId: TaskId | null;
+}
+
+export interface TaskSessionStore {
+  getState(): TaskSessionState;
+  setCurrentTask(taskId: TaskId | null): void;
+  clearCurrentTask(): void;
+}
+
+const createTaskSessionState = (overrides: Partial<TaskSessionState> = {}): TaskSessionState => ({
+  currentTaskId: overrides.currentTaskId ?? null,
+});
+
+const createInMemoryTaskSessionStore = (
+  initialState: Partial<TaskSessionState> = {}
+): TaskSessionStore => {
+  let state = createTaskSessionState(initialState);
+
+  return {
+    getState: () => ({ ...state }),
+    setCurrentTask: (taskId) => {
+      state = createTaskSessionState({ currentTaskId: taskId });
+    },
+    clearCurrentTask: () => {
+      state = createTaskSessionState();
+    },
+  };
+};
+
+export { createInMemoryTaskSessionStore, createTaskSessionState };

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -1,0 +1,16 @@
+import type { TaskComment, TaskDetail, TaskFilter, TaskId, TaskSummary } from "@/domain/task";
+import type {
+  AddTaskCommentInput,
+  CreateTaskInput,
+  UpdateTaskInput,
+} from "@/services/task-service";
+import type { ToduDaemonEventName, ToduDaemonSubscription } from "@/services/todu/daemon-events";
+
+export interface ToduDaemonClient {
+  listTasks(filter?: TaskFilter): Promise<TaskSummary[]>;
+  getTask(taskId: TaskId): Promise<TaskDetail | null>;
+  createTask(input: CreateTaskInput): Promise<TaskDetail>;
+  updateTask(input: UpdateTaskInput): Promise<TaskDetail>;
+  addTaskComment(input: AddTaskCommentInput): Promise<TaskComment>;
+  on(eventName: ToduDaemonEventName, listener: () => void): ToduDaemonSubscription;
+}

--- a/src/services/todu/daemon-config.ts
+++ b/src/services/todu/daemon-config.ts
@@ -1,0 +1,9 @@
+export interface ToduDaemonConfig {
+  configPath: string;
+  dataDir: string;
+  socketPath: string;
+}
+
+const resolveDaemonSocketPath = (config: ToduDaemonConfig): string => config.socketPath;
+
+export { resolveDaemonSocketPath };

--- a/src/services/todu/daemon-connection.ts
+++ b/src/services/todu/daemon-connection.ts
@@ -1,0 +1,24 @@
+import type { ToduDaemonSubscription } from "@/services/todu/daemon-events";
+
+export type ToduDaemonConnectionStatus =
+  | "disconnected"
+  | "connecting"
+  | "connected"
+  | "reconnecting";
+
+export interface ToduDaemonConnectionState {
+  status: ToduDaemonConnectionStatus;
+}
+
+export interface ToduDaemonConnection {
+  getState(): ToduDaemonConnectionState;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  subscribe(listener: () => void): ToduDaemonSubscription;
+}
+
+const createDisconnectedDaemonConnectionState = (): ToduDaemonConnectionState => ({
+  status: "disconnected",
+});
+
+export { createDisconnectedDaemonConnectionState };

--- a/src/services/todu/daemon-events.ts
+++ b/src/services/todu/daemon-events.ts
@@ -1,0 +1,12 @@
+export const TODU_DAEMON_EVENT_NAMES = ["data.changed", "sync.statusChanged"] as const;
+
+export type ToduDaemonEventName = (typeof TODU_DAEMON_EVENT_NAMES)[number];
+
+export interface ToduDaemonEvent {
+  name: ToduDaemonEventName;
+  payload?: Record<string, unknown>;
+}
+
+export interface ToduDaemonSubscription {
+  unsubscribe(): void;
+}

--- a/src/services/todu/todu-task-service.ts
+++ b/src/services/todu/todu-task-service.ts
@@ -1,0 +1,16 @@
+import type { TaskService } from "@/services/task-service";
+import type { ToduDaemonClient } from "@/services/todu/daemon-client";
+
+export interface ToduTaskServiceDependencies {
+  client: ToduDaemonClient;
+}
+
+const createToduTaskService = ({ client }: ToduTaskServiceDependencies): TaskService => ({
+  listTasks: (filter) => client.listTasks(filter),
+  getTask: (taskId) => client.getTask(taskId),
+  createTask: (input) => client.createTask(input),
+  updateTask: (input) => client.updateTask(input),
+  addTaskComment: (input) => client.addTaskComment(input),
+});
+
+export { createToduTaskService };

--- a/src/ui/components/loaders.ts
+++ b/src/ui/components/loaders.ts
@@ -1,0 +1,11 @@
+export interface TaskLoaderViewModel {
+  label: string;
+  isLoading: boolean;
+}
+
+const createTaskLoaderViewModel = (label: string): TaskLoaderViewModel => ({
+  label,
+  isLoading: true,
+});
+
+export { createTaskLoaderViewModel };

--- a/src/ui/components/task-detail.ts
+++ b/src/ui/components/task-detail.ts
@@ -1,0 +1,16 @@
+import type { TaskDetail } from "@/domain/task";
+import { formatTaskDetail } from "@/utils/task-format";
+
+export interface TaskDetailViewModel {
+  title: string;
+  body: string;
+  commentCount: number;
+}
+
+const createTaskDetailViewModel = (task: TaskDetail): TaskDetailViewModel => ({
+  title: task.title,
+  body: formatTaskDetail(task),
+  commentCount: task.comments.length,
+});
+
+export { createTaskDetailViewModel };

--- a/src/ui/components/task-list.ts
+++ b/src/ui/components/task-list.ts
@@ -1,0 +1,16 @@
+import type { TaskId, TaskSummary } from "@/domain/task";
+import { formatTaskSummary } from "@/utils/task-format";
+
+export interface TaskListItem {
+  value: TaskId;
+  label: string;
+  description: string;
+}
+
+const createTaskListItem = (task: TaskSummary): TaskListItem => ({
+  value: task.id,
+  label: task.title,
+  description: formatTaskSummary(task),
+});
+
+export { createTaskListItem };

--- a/src/ui/components/task-settings.ts
+++ b/src/ui/components/task-settings.ts
@@ -1,0 +1,20 @@
+import type { TaskPriority, TaskStatus } from "@/domain/task";
+
+export interface TaskSettingOption<TValue extends string> {
+  label: string;
+  value: TValue;
+}
+
+export const taskStatusOptions: TaskSettingOption<TaskStatus>[] = [
+  { label: "Active", value: "active" },
+  { label: "In Progress", value: "inprogress" },
+  { label: "Waiting", value: "waiting" },
+  { label: "Done", value: "done" },
+  { label: "Cancelled", value: "cancelled" },
+];
+
+export const taskPriorityOptions: TaskSettingOption<TaskPriority>[] = [
+  { label: "Low", value: "low" },
+  { label: "Medium", value: "medium" },
+  { label: "High", value: "high" },
+];

--- a/src/ui/renderers/task-tool-renderer.ts
+++ b/src/ui/renderers/task-tool-renderer.ts
@@ -1,0 +1,9 @@
+import type { TaskDetail, TaskSummary } from "@/domain/task";
+import { formatTaskDetail, formatTaskSummary } from "@/utils/task-format";
+
+const renderTaskList = (tasks: TaskSummary[]): string =>
+  tasks.map((task) => `- ${task.title} (${formatTaskSummary(task)})`).join("\n");
+
+const renderTaskDetail = (task: TaskDetail): string => formatTaskDetail(task);
+
+export { renderTaskDetail, renderTaskList };

--- a/src/ui/widgets/current-task-widget.ts
+++ b/src/ui/widgets/current-task-widget.ts
@@ -1,0 +1,15 @@
+import type { TaskSummary } from "@/domain/task";
+
+export interface CurrentTaskWidgetViewModel {
+  title: string;
+  subtitle: string;
+}
+
+const createCurrentTaskWidgetViewModel = (
+  task: TaskSummary | null
+): CurrentTaskWidgetViewModel => ({
+  title: task?.title ?? "No current task",
+  subtitle: task?.status ?? "Select a task to set context",
+});
+
+export { createCurrentTaskWidgetViewModel };

--- a/src/ui/widgets/next-actions-widget.ts
+++ b/src/ui/widgets/next-actions-widget.ts
@@ -1,0 +1,13 @@
+import type { TaskSummary } from "@/domain/task";
+
+export interface NextActionsWidgetViewModel {
+  title: string;
+  items: string[];
+}
+
+const createNextActionsWidgetViewModel = (tasks: TaskSummary[]): NextActionsWidgetViewModel => ({
+  title: "Next actions",
+  items: tasks.map((task) => task.title),
+});
+
+export { createNextActionsWidgetViewModel };

--- a/src/utils/key-hints.ts
+++ b/src/utils/key-hints.ts
@@ -1,0 +1,8 @@
+export interface KeyHint {
+  key: string;
+  description: string;
+}
+
+const formatKeyHint = ({ key, description }: KeyHint): string => `${key}: ${description}`;
+
+export { formatKeyHint };

--- a/src/utils/task-filters.ts
+++ b/src/utils/task-filters.ts
@@ -1,0 +1,10 @@
+import type { TaskFilter } from "@/domain/task";
+
+const mergeTaskFilter = (baseFilter: TaskFilter, overrideFilter: TaskFilter = {}): TaskFilter => ({
+  ...baseFilter,
+  ...overrideFilter,
+  statuses: overrideFilter.statuses ?? baseFilter.statuses,
+  priorities: overrideFilter.priorities ?? baseFilter.priorities,
+});
+
+export { mergeTaskFilter };

--- a/src/utils/task-format.ts
+++ b/src/utils/task-format.ts
@@ -1,0 +1,11 @@
+import type { TaskDetail, TaskSummary } from "@/domain/task";
+
+const formatTaskSummary = (task: TaskSummary): string =>
+  [task.status, task.priority, task.projectId ?? "no-project"].join(" • ");
+
+const formatTaskDetail = (task: TaskDetail): string => {
+  const description = task.description?.trim() ?? "No description";
+  return `${task.title}\n${description}`;
+};
+
+export { formatTaskDetail, formatTaskSummary };


### PR DESCRIPTION
## Summary
- split the extension entrypoint into the initial internal module layout from the architecture doc
- add initial domain, service, flow, UI, and utility scaffolding for future todu integration work
- add branch CI that runs build, lint, and unit tests on push and pull request

## Verification
- npm run build
- npm run lint
- npm test
- make pre-pr

Task: #task-d43bd530