### PR TITLE
feat: add current task context

### DIFF
--- a/src/__tests__/current-task-context.test.ts
+++ b/src/__tests__/current-task-context.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { TaskDetail } from "@/domain/task";
+import {
+  createCurrentTaskContextController,
+  CURRENT_TASK_STATUS_KEY,
+  CURRENT_TASK_WIDGET_KEY,
+} from "@/extension/current-task-context";
+import { TASK_SESSION_ENTRY_TYPE } from "@/services/task-session-store";
+
+const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
+  id: overrides.id ?? "task-123",
+  title: overrides.title ?? "Implement current task context",
+  status: overrides.status ?? "active",
+  priority: overrides.priority ?? "high",
+  projectId: overrides.projectId ?? "proj-1",
+  projectName: overrides.projectName ?? "Todu Pi Extensions",
+  labels: overrides.labels ?? ["ui"],
+  description: overrides.description ?? "Persist and restore current task context",
+  comments: overrides.comments ?? [],
+});
+
+const createContext = (
+  branchEntries: Array<{ type: string; customType?: string; data?: unknown }> = []
+) => ({
+  hasUI: true,
+  sessionManager: {
+    getBranch: vi.fn().mockReturnValue(branchEntries),
+  },
+  ui: {
+    setStatus: vi.fn(),
+    setWidget: vi.fn(),
+  },
+});
+
+describe("createCurrentTaskContextController", () => {
+  it("restores current task state from session entries and updates ambient UI", async () => {
+    const task = createTaskDetail();
+    const getTask = vi.fn().mockResolvedValue(task);
+    const clientOn = vi.fn().mockResolvedValue({ unsubscribe: vi.fn() });
+    const runtime = {
+      ensureConnected: vi.fn().mockResolvedValue({ getTask }),
+      client: {
+        on: clientOn,
+      },
+    };
+    const appendEntry = vi.fn();
+    const ctx = createContext([
+      {
+        type: "custom",
+        customType: TASK_SESSION_ENTRY_TYPE,
+        data: { currentTaskId: task.id },
+      },
+    ]);
+
+    const controller = createCurrentTaskContextController(
+      { appendEntry },
+      { runtime: runtime as never }
+    );
+
+    await controller.restoreFromBranch(ctx as never);
+
+    expect(runtime.ensureConnected).toHaveBeenCalledTimes(1);
+    expect(getTask).toHaveBeenCalledWith(task.id);
+    expect(clientOn).toHaveBeenCalledWith("data.changed", expect.any(Function));
+    expect(ctx.ui.setStatus).toHaveBeenCalledWith(
+      CURRENT_TASK_STATUS_KEY,
+      `${task.id} • ${task.title}`
+    );
+    expect(ctx.ui.setWidget).toHaveBeenCalledWith(CURRENT_TASK_WIDGET_KEY, [
+      task.title,
+      "active • high • Todu Pi Extensions",
+    ]);
+    expect(appendEntry).not.toHaveBeenCalled();
+    expect(controller.getState()).toEqual({ currentTaskId: task.id, currentTask: task });
+  });
+
+  it("persists current task changes and clears ambient UI when reset", async () => {
+    const task = createTaskDetail();
+    const clientOn = vi.fn().mockResolvedValue({ unsubscribe: vi.fn() });
+    const appendEntry = vi.fn();
+    const ctx = createContext();
+    const controller = createCurrentTaskContextController(
+      { appendEntry },
+      {
+        runtime: {
+          ensureConnected: vi.fn(),
+          client: { on: clientOn },
+        } as never,
+      }
+    );
+
+    await controller.setCurrentTask(ctx as never, task);
+
+    expect(appendEntry).toHaveBeenCalledWith(TASK_SESSION_ENTRY_TYPE, {
+      currentTaskId: task.id,
+    });
+    expect(ctx.ui.setStatus).toHaveBeenCalledWith(
+      CURRENT_TASK_STATUS_KEY,
+      `${task.id} • ${task.title}`
+    );
+    expect(ctx.ui.setWidget).toHaveBeenCalledWith(CURRENT_TASK_WIDGET_KEY, [
+      task.title,
+      "active • high • Todu Pi Extensions",
+    ]);
+
+    await controller.clearCurrentTask(ctx as never);
+
+    expect(appendEntry).toHaveBeenLastCalledWith(TASK_SESSION_ENTRY_TYPE, {
+      currentTaskId: null,
+    });
+    expect(ctx.ui.setStatus).toHaveBeenLastCalledWith(CURRENT_TASK_STATUS_KEY, undefined);
+    expect(ctx.ui.setWidget).toHaveBeenLastCalledWith(CURRENT_TASK_WIDGET_KEY, undefined);
+  });
+
+  it("refreshes the focused task after daemon invalidation", async () => {
+    const initialTask = createTaskDetail();
+    const refreshedTask = createTaskDetail({
+      title: "Current task context refreshed",
+      priority: "medium",
+    });
+    const getTask = vi.fn().mockResolvedValue(refreshedTask);
+    const ctx = createContext();
+    const controller = createCurrentTaskContextController(
+      { appendEntry: vi.fn() },
+      {
+        runtime: {
+          ensureConnected: vi.fn().mockResolvedValue({ getTask }),
+          client: { on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }) },
+        } as never,
+      }
+    );
+
+    await controller.setCurrentTask(ctx as never, initialTask);
+    await controller.handleDataChanged();
+
+    expect(getTask).toHaveBeenCalledWith(initialTask.id);
+    expect(controller.getState()).toEqual({
+      currentTaskId: initialTask.id,
+      currentTask: refreshedTask,
+    });
+    expect(ctx.ui.setWidget).toHaveBeenLastCalledWith(CURRENT_TASK_WIDGET_KEY, [
+      refreshedTask.title,
+      "active • medium • Todu Pi Extensions",
+    ]);
+  });
+});

--- a/src/__tests__/task-session-store.test.ts
+++ b/src/__tests__/task-session-store.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { pickCurrentTask } from "@/flows/pick-current-task";
-import { createInMemoryTaskSessionStore } from "@/services/task-session-store";
+import {
+  createInMemoryTaskSessionStore,
+  persistTaskSessionState,
+  restoreTaskSessionState,
+  TASK_SESSION_ENTRY_TYPE,
+} from "@/services/task-session-store";
 
 describe("task session store", () => {
   it("tracks the current task through the flow boundary", () => {
@@ -12,5 +17,32 @@ describe("task session store", () => {
 
     taskSessionStore.clearCurrentTask();
     expect(taskSessionStore.getState()).toEqual({ currentTaskId: null });
+  });
+
+  it("restores the latest persisted current task from session entries", () => {
+    expect(
+      restoreTaskSessionState([
+        {
+          type: "custom",
+          customType: TASK_SESSION_ENTRY_TYPE,
+          data: { currentTaskId: "task-1" },
+        },
+        {
+          type: "custom",
+          customType: TASK_SESSION_ENTRY_TYPE,
+          data: { currentTaskId: "task-2" },
+        },
+      ])
+    ).toEqual({ currentTaskId: "task-2" });
+  });
+
+  it("persists current task state through appendEntry", () => {
+    const appendEntry = vi.fn();
+
+    persistTaskSessionState(appendEntry, { currentTaskId: "task-123" });
+
+    expect(appendEntry).toHaveBeenCalledWith(TASK_SESSION_ENTRY_TYPE, {
+      currentTaskId: "task-123",
+    });
   });
 });

--- a/src/__tests__/tasks-command.test.ts
+++ b/src/__tests__/tasks-command.test.ts
@@ -36,6 +36,7 @@ const createCommandContext = () => ({
 describe("registerCommands", () => {
   it("registers the /tasks command", () => {
     const pi = {
+      appendEntry: vi.fn(),
       registerCommand: vi.fn(),
     };
 
@@ -144,16 +145,18 @@ describe("createTasksCommandHandler", () => {
 });
 
 describe("openSelectedTaskDetail", () => {
-  it("loads the task detail into the editor", async () => {
+  it("loads the task detail into the editor and sets the current task", async () => {
     const context = createCommandContext();
     const taskDetail = createTaskDetail();
+    const setCurrentTask = vi.fn().mockResolvedValue(undefined);
     const taskService = {
       getTask: vi.fn().mockResolvedValue(taskDetail),
     } as unknown as TaskService;
 
-    await openSelectedTaskDetail(context as never, taskService, taskDetail.id);
+    await openSelectedTaskDetail(context as never, taskService, taskDetail.id, setCurrentTask);
 
     expect(taskService.getTask).toHaveBeenCalledWith(taskDetail.id);
+    expect(setCurrentTask).toHaveBeenCalledWith(context, taskDetail);
     expect(context.ui.setEditorText).toHaveBeenCalledWith(
       "Implement /tasks\nBuild the first task browse flow"
     );
@@ -165,13 +168,15 @@ describe("openSelectedTaskDetail", () => {
 
   it("warns when the selected task disappears", async () => {
     const context = createCommandContext();
+    const setCurrentTask = vi.fn().mockResolvedValue(undefined);
     const taskService = {
       getTask: vi.fn().mockResolvedValue(null),
     } as unknown as TaskService;
 
-    await openSelectedTaskDetail(context as never, taskService, "task-123");
+    await openSelectedTaskDetail(context as never, taskService, "task-123", setCurrentTask);
 
     expect(context.ui.notify).toHaveBeenCalledWith("Selected task no longer exists", "warning");
+    expect(setCurrentTask).not.toHaveBeenCalled();
     expect(context.ui.setEditorText).not.toHaveBeenCalled();
   });
 });

--- a/src/extension/current-task-context.ts
+++ b/src/extension/current-task-context.ts
@@ -1,0 +1,213 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+import type { TaskDetail, TaskId } from "../domain/task";
+import {
+  createInMemoryTaskSessionStore,
+  persistTaskSessionState,
+  restoreTaskSessionState,
+  type TaskSessionStore,
+} from "../services/task-session-store";
+import {
+  getDefaultToduTaskServiceRuntime,
+  type ToduTaskServiceRuntime,
+} from "../services/todu/default-task-service";
+import type { ToduDaemonSubscription } from "../services/todu/daemon-events";
+import { createCurrentTaskWidgetViewModel } from "../ui/widgets/current-task-widget";
+
+const CURRENT_TASK_STATUS_KEY = "todu-current-task";
+const CURRENT_TASK_WIDGET_KEY = "todu-current-task";
+
+export interface CurrentTaskContextState {
+  currentTaskId: TaskId | null;
+  currentTask: TaskDetail | null;
+}
+
+export interface CurrentTaskContextController {
+  getState(): CurrentTaskContextState;
+  restoreFromBranch(ctx: ExtensionContext): Promise<void>;
+  setCurrentTask(ctx: ExtensionContext, task: TaskDetail | null): Promise<void>;
+  clearCurrentTask(ctx: ExtensionContext): Promise<void>;
+  handleDataChanged(): Promise<void>;
+  dispose(): Promise<void>;
+}
+
+export interface CreateCurrentTaskContextControllerDependencies {
+  runtime?: Pick<ToduTaskServiceRuntime, "client" | "ensureConnected">;
+  taskSessionStore?: TaskSessionStore;
+}
+
+const createCurrentTaskContextController = (
+  pi: Pick<ExtensionAPI, "appendEntry">,
+  dependencies: CreateCurrentTaskContextControllerDependencies = {}
+): CurrentTaskContextController => {
+  const runtime = dependencies.runtime ?? getDefaultToduTaskServiceRuntime();
+  const taskSessionStore = dependencies.taskSessionStore ?? createInMemoryTaskSessionStore();
+
+  let currentTask: TaskDetail | null = null;
+  let activeContext: ExtensionContext | null = null;
+  let dataChangedSubscription: ToduDaemonSubscription | null = null;
+  let subscribePromise: Promise<ToduDaemonSubscription> | null = null;
+
+  const updateAmbientUi = (ctx: ExtensionContext): void => {
+    if (!ctx.hasUI) {
+      return;
+    }
+
+    const { currentTaskId } = taskSessionStore.getState();
+    if (!currentTaskId && !currentTask) {
+      ctx.ui.setStatus(CURRENT_TASK_STATUS_KEY, undefined);
+      ctx.ui.setWidget(CURRENT_TASK_WIDGET_KEY, undefined);
+      return;
+    }
+
+    const viewModel = createCurrentTaskWidgetViewModel(currentTask, currentTaskId);
+    ctx.ui.setWidget(CURRENT_TASK_WIDGET_KEY, [viewModel.title, viewModel.subtitle]);
+
+    if (currentTask) {
+      ctx.ui.setStatus(CURRENT_TASK_STATUS_KEY, `${currentTask.id} • ${currentTask.title}`);
+      return;
+    }
+
+    ctx.ui.setStatus(CURRENT_TASK_STATUS_KEY, currentTaskId ?? undefined);
+  };
+
+  const ensureDataChangedSubscription = async (): Promise<void> => {
+    if (dataChangedSubscription) {
+      return;
+    }
+
+    if (subscribePromise) {
+      await subscribePromise;
+      return;
+    }
+
+    subscribePromise = runtime.client
+      .on("data.changed", () => {
+        void controller.handleDataChanged();
+      })
+      .then((subscription) => {
+        dataChangedSubscription = subscription;
+        return subscription;
+      })
+      .finally(() => {
+        subscribePromise = null;
+      });
+
+    await subscribePromise;
+  };
+
+  const refreshCurrentTask = async (ctx: ExtensionContext): Promise<void> => {
+    const { currentTaskId } = taskSessionStore.getState();
+    if (!currentTaskId) {
+      currentTask = null;
+      updateAmbientUi(ctx);
+      return;
+    }
+
+    try {
+      const taskService = await runtime.ensureConnected();
+      const task = await taskService.getTask(currentTaskId);
+      if (!task) {
+        currentTask = null;
+        taskSessionStore.clearCurrentTask();
+        persistTaskSessionState(pi.appendEntry, taskSessionStore.getState());
+        updateAmbientUi(ctx);
+        return;
+      }
+
+      currentTask = task;
+      updateAmbientUi(ctx);
+    } catch {
+      currentTask = null;
+      updateAmbientUi(ctx);
+    }
+  };
+
+  const controller: CurrentTaskContextController = {
+    getState: (): CurrentTaskContextState => ({
+      currentTaskId: taskSessionStore.getState().currentTaskId,
+      currentTask,
+    }),
+
+    async restoreFromBranch(ctx: ExtensionContext): Promise<void> {
+      activeContext = ctx;
+      taskSessionStore.replaceState(restoreTaskSessionState(ctx.sessionManager.getBranch()));
+
+      if (taskSessionStore.getState().currentTaskId) {
+        await ensureDataChangedSubscription();
+      }
+
+      await refreshCurrentTask(ctx);
+    },
+
+    async setCurrentTask(ctx: ExtensionContext, task: TaskDetail | null): Promise<void> {
+      activeContext = ctx;
+      currentTask = task;
+
+      if (task) {
+        taskSessionStore.setCurrentTask(task.id);
+        await ensureDataChangedSubscription();
+      } else {
+        taskSessionStore.clearCurrentTask();
+      }
+
+      persistTaskSessionState(pi.appendEntry, taskSessionStore.getState());
+      updateAmbientUi(ctx);
+    },
+
+    async clearCurrentTask(ctx: ExtensionContext): Promise<void> {
+      await controller.setCurrentTask(ctx, null);
+    },
+
+    async handleDataChanged(): Promise<void> {
+      if (!activeContext) {
+        return;
+      }
+
+      await refreshCurrentTask(activeContext);
+    },
+
+    async dispose(): Promise<void> {
+      dataChangedSubscription?.unsubscribe();
+      dataChangedSubscription = null;
+      subscribePromise = null;
+      activeContext = null;
+      currentTask = null;
+    },
+  };
+
+  return controller;
+};
+
+let defaultCurrentTaskContextController: CurrentTaskContextController | null = null;
+
+const getDefaultCurrentTaskContextController = (
+  pi?: Pick<ExtensionAPI, "appendEntry">
+): CurrentTaskContextController => {
+  if (!defaultCurrentTaskContextController) {
+    if (!pi) {
+      throw new Error("Current task context controller has not been initialized");
+    }
+
+    defaultCurrentTaskContextController = createCurrentTaskContextController(pi);
+  }
+
+  return defaultCurrentTaskContextController;
+};
+
+const resetDefaultCurrentTaskContextController = async (): Promise<void> => {
+  if (!defaultCurrentTaskContextController) {
+    return;
+  }
+
+  await defaultCurrentTaskContextController.dispose();
+  defaultCurrentTaskContextController = null;
+};
+
+export {
+  createCurrentTaskContextController,
+  CURRENT_TASK_STATUS_KEY,
+  CURRENT_TASK_WIDGET_KEY,
+  getDefaultCurrentTaskContextController,
+  resetDefaultCurrentTaskContextController,
+};

--- a/src/extension/register-commands.ts
+++ b/src/extension/register-commands.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-cod
 import { BorderedLoader, DynamicBorder } from "@mariozechner/pi-coding-agent";
 import { Container, matchesKey, type SelectItem, SelectList, Text } from "@mariozechner/pi-tui";
 
-import type { TaskFilter, TaskId, TaskSummary } from "../domain/task";
+import type { TaskDetail, TaskFilter, TaskId, TaskSummary } from "../domain/task";
 import { browseTasks } from "../flows/browse-tasks";
 import { showTaskDetail } from "../flows/show-task-detail";
 import type { TaskService } from "../services/task-service";
@@ -10,6 +10,7 @@ import { getDefaultToduTaskServiceRuntime } from "../services/todu/default-task-
 import { createTaskDetailViewModel } from "../ui/components/task-detail";
 import { createTaskListItem } from "../ui/components/task-list";
 import { createTaskLoaderViewModel } from "../ui/components/loaders";
+import { getDefaultCurrentTaskContextController } from "./current-task-context";
 
 const DEFAULT_BROWSE_TASKS_FILTER: TaskFilter = {
   statuses: ["active"],
@@ -39,6 +40,7 @@ export interface RegisterCommandDependencies {
   ) => Promise<TaskBrowseLoadResult>;
   selectTask?: (ctx: ExtensionCommandContext, tasks: TaskSummary[]) => Promise<TaskId | null>;
   showEmptyState?: (ctx: ExtensionCommandContext) => Promise<void>;
+  setCurrentTask?: (ctx: ExtensionCommandContext, task: TaskDetail) => Promise<void>;
   openTaskDetail?: (
     ctx: ExtensionCommandContext,
     taskService: TaskService,
@@ -54,7 +56,14 @@ const createTasksCommandHandler = (
   const loadTasks = dependencies.loadTasks ?? loadActiveTasksWithLoader;
   const selectTask = dependencies.selectTask ?? selectTaskFromList;
   const showEmptyState = dependencies.showEmptyState ?? showEmptyTasksState;
-  const openTaskDetail = dependencies.openTaskDetail ?? openSelectedTaskDetail;
+  const setCurrentTask =
+    dependencies.setCurrentTask ??
+    ((ctx: ExtensionCommandContext, task: TaskDetail) =>
+      getDefaultCurrentTaskContextController().setCurrentTask(ctx, task));
+  const openTaskDetail =
+    dependencies.openTaskDetail ??
+    ((ctx: ExtensionCommandContext, taskService: TaskService, taskId: TaskId) =>
+      openSelectedTaskDetail(ctx, taskService, taskId, setCurrentTask));
 
   return async (_args: string, ctx: ExtensionCommandContext): Promise<void> => {
     if (!ctx.hasUI) {
@@ -98,6 +107,8 @@ const registerCommands = (
   pi: ExtensionAPI,
   dependencies: RegisterCommandDependencies = {}
 ): void => {
+  getDefaultCurrentTaskContextController(pi);
+
   pi.registerCommand("tasks", {
     description: "Browse active todu tasks",
     handler: createTasksCommandHandler(dependencies),
@@ -202,13 +213,16 @@ const showEmptyTasksState = async (ctx: ExtensionCommandContext): Promise<void> 
 const openSelectedTaskDetail = async (
   ctx: ExtensionCommandContext,
   taskService: TaskService,
-  taskId: TaskId
+  taskId: TaskId,
+  setCurrentTask: (ctx: ExtensionCommandContext, task: TaskDetail) => Promise<void>
 ): Promise<void> => {
   const task = await showTaskDetail({ taskService }, taskId);
   if (!task) {
     ctx.ui.notify("Selected task no longer exists", "warning");
     return;
   }
+
+  await setCurrentTask(ctx, task);
 
   const viewModel = createTaskDetailViewModel(task);
   ctx.ui.setEditorText(viewModel.body);

--- a/src/extension/register-events.ts
+++ b/src/extension/register-events.ts
@@ -1,7 +1,35 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 
-const registerEvents = (_pi: ExtensionAPI): void => {
-  // Event hooks are introduced in follow-up tasks.
+import {
+  getDefaultCurrentTaskContextController,
+  resetDefaultCurrentTaskContextController,
+} from "./current-task-context";
+
+const registerEvents = (pi: ExtensionAPI): void => {
+  const currentTaskContext = getDefaultCurrentTaskContextController(pi);
+  const restoreCurrentTaskContext = async (ctx: ExtensionContext): Promise<void> => {
+    await currentTaskContext.restoreFromBranch(ctx);
+  };
+
+  pi.on("session_start", async (_event, ctx) => {
+    await restoreCurrentTaskContext(ctx);
+  });
+
+  pi.on("session_switch", async (_event, ctx) => {
+    await restoreCurrentTaskContext(ctx);
+  });
+
+  pi.on("session_tree", async (_event, ctx) => {
+    await restoreCurrentTaskContext(ctx);
+  });
+
+  pi.on("session_fork", async (_event, ctx) => {
+    await restoreCurrentTaskContext(ctx);
+  });
+
+  pi.on("session_shutdown", async () => {
+    await resetDefaultCurrentTaskContextController();
+  });
 };
 
 export { registerEvents };

--- a/src/extension/register-ui.ts
+++ b/src/extension/register-ui.ts
@@ -1,7 +1,9 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
-const registerUi = (_pi: ExtensionAPI): void => {
-  // Widgets, status lines, and renderers are introduced in follow-up tasks.
+import { getDefaultCurrentTaskContextController } from "./current-task-context";
+
+const registerUi = (pi: ExtensionAPI): void => {
+  getDefaultCurrentTaskContextController(pi);
 };
 
 export { registerUi };

--- a/src/services/task-session-store.ts
+++ b/src/services/task-session-store.ts
@@ -1,33 +1,104 @@
 import type { TaskId } from "../domain/task";
 
+export const TASK_SESSION_ENTRY_TYPE = "todu-current-task";
+
 export interface TaskSessionState {
   currentTaskId: TaskId | null;
 }
 
+export interface TaskSessionEntryData {
+  currentTaskId: TaskId | null;
+}
+
+export interface TaskSessionStateListener {
+  (state: TaskSessionState): void;
+}
+
+export interface TaskSessionEntryLike {
+  type: string;
+  customType?: string;
+  data?: unknown;
+}
+
 export interface TaskSessionStore {
   getState(): TaskSessionState;
+  replaceState(state: TaskSessionState): void;
   setCurrentTask(taskId: TaskId | null): void;
   clearCurrentTask(): void;
+  subscribe(listener: TaskSessionStateListener): { unsubscribe(): void };
 }
 
 const createTaskSessionState = (overrides: Partial<TaskSessionState> = {}): TaskSessionState => ({
   currentTaskId: overrides.currentTaskId ?? null,
 });
 
+const restoreTaskSessionState = (entries: readonly TaskSessionEntryLike[]): TaskSessionState => {
+  let restoredState = createTaskSessionState();
+
+  for (const entry of entries) {
+    if (entry.type !== "custom" || entry.customType !== TASK_SESSION_ENTRY_TYPE) {
+      continue;
+    }
+
+    const data = entry.data as TaskSessionEntryData | undefined;
+    restoredState = createTaskSessionState({ currentTaskId: data?.currentTaskId ?? null });
+  }
+
+  return restoredState;
+};
+
+const persistTaskSessionState = (
+  appendEntry: (customType: string, data?: TaskSessionEntryData) => void,
+  state: TaskSessionState
+): void => {
+  appendEntry(TASK_SESSION_ENTRY_TYPE, {
+    currentTaskId: state.currentTaskId,
+  });
+};
+
 const createInMemoryTaskSessionStore = (
   initialState: Partial<TaskSessionState> = {}
 ): TaskSessionStore => {
   let state = createTaskSessionState(initialState);
+  const listeners = new Set<TaskSessionStateListener>();
+
+  const emit = (): void => {
+    const snapshot = { ...state };
+    for (const listener of listeners) {
+      listener(snapshot);
+    }
+  };
 
   return {
     getState: () => ({ ...state }),
+    replaceState: (nextState) => {
+      state = createTaskSessionState(nextState);
+      emit();
+    },
     setCurrentTask: (taskId) => {
       state = createTaskSessionState({ currentTaskId: taskId });
+      emit();
     },
     clearCurrentTask: () => {
       state = createTaskSessionState();
+      emit();
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      listener({ ...state });
+
+      return {
+        unsubscribe: () => {
+          listeners.delete(listener);
+        },
+      };
     },
   };
 };
 
-export { createInMemoryTaskSessionStore, createTaskSessionState };
+export {
+  createInMemoryTaskSessionStore,
+  createTaskSessionState,
+  persistTaskSessionState,
+  restoreTaskSessionState,
+};

--- a/src/ui/widgets/current-task-widget.ts
+++ b/src/ui/widgets/current-task-widget.ts
@@ -1,4 +1,5 @@
-import type { TaskSummary } from "../../domain/task";
+import type { TaskId, TaskSummary } from "../../domain/task";
+import { formatTaskSummary } from "../../utils/task-format";
 
 export interface CurrentTaskWidgetViewModel {
   title: string;
@@ -6,10 +7,27 @@ export interface CurrentTaskWidgetViewModel {
 }
 
 const createCurrentTaskWidgetViewModel = (
-  task: TaskSummary | null
-): CurrentTaskWidgetViewModel => ({
-  title: task?.title ?? "No current task",
-  subtitle: task?.status ?? "Select a task to set context",
-});
+  task: TaskSummary | null,
+  currentTaskId: TaskId | null = null
+): CurrentTaskWidgetViewModel => {
+  if (task) {
+    return {
+      title: task.title,
+      subtitle: formatTaskSummary(task),
+    };
+  }
+
+  if (currentTaskId) {
+    return {
+      title: "Current task unavailable",
+      subtitle: currentTaskId,
+    };
+  }
+
+  return {
+    title: "No current task",
+    subtitle: "Select a task to set context",
+  };
+};
 
 export { createCurrentTaskWidgetViewModel };


### PR DESCRIPTION
## Summary
- add session-aware current task context with persistence and branch restoration
- show the current task through ambient status/widget UI and update it from /tasks selection
- refresh the focused current task from coarse daemon invalidation events

## Verification
- npm run typecheck
- npm test
- npm run build
- make pre-pr

Task: #task-c12aa38b