### PR TITLE
feat: add sync status footer UI

### DIFF
--- a/src/__tests__/sync-status-context.test.ts
+++ b/src/__tests__/sync-status-context.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createSyncStatusContextController,
+  extractSyncStatus,
+  formatSyncStatus,
+  handleConnectionStateChange,
+  normalizeSyncStatus,
+  SYNC_STATUS_KEY,
+} from "@/extension/sync-status-context";
+
+const createContext = () => ({
+  hasUI: true,
+  ui: {
+    setStatus: vi.fn(),
+  },
+});
+
+describe("createSyncStatusContextController", () => {
+  it("shows the initial unknown state and updates status from sync events", async () => {
+    let syncListener: unknown = null;
+    const subscribeToConnectionState = vi.fn().mockReturnValue({ unsubscribe: vi.fn() });
+    const connect = vi.fn().mockResolvedValue(undefined);
+    const controller = createSyncStatusContextController(
+      { appendEntry: vi.fn() },
+      {
+        runtime: {
+          client: {
+            on: vi.fn().mockImplementation(async (_eventName, listener) => {
+              syncListener = listener;
+              return { unsubscribe: vi.fn() };
+            }),
+          },
+          connection: {
+            subscribe: subscribeToConnectionState,
+            connect,
+          },
+        } as never,
+      }
+    );
+    const ctx = createContext();
+
+    await controller.attach(ctx as never);
+
+    expect(ctx.ui.setStatus).toHaveBeenCalledWith(SYNC_STATUS_KEY, "sync: unknown");
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    const registeredSyncListener = syncListener;
+    if (typeof registeredSyncListener !== "function") {
+      throw new Error("Expected sync listener to be registered");
+    }
+
+    registeredSyncListener({ name: "sync.statusChanged", payload: { status: "running" } });
+
+    expect(ctx.ui.setStatus).toHaveBeenLastCalledWith(SYNC_STATUS_KEY, "sync: running");
+    expect(controller.getState()).toEqual({ syncStatus: "running" });
+  });
+
+  it("resets to unknown when the daemon connection is not connected", async () => {
+    let connectionStateListener: unknown = null;
+    const controller = createSyncStatusContextController(
+      { appendEntry: vi.fn() },
+      {
+        runtime: {
+          client: {
+            on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
+          },
+          connection: {
+            subscribe: vi.fn().mockImplementation((listener) => {
+              connectionStateListener = listener;
+              return { unsubscribe: vi.fn() };
+            }),
+            connect: vi.fn().mockResolvedValue(undefined),
+          },
+        } as never,
+      }
+    );
+    const ctx = createContext();
+
+    await controller.attach(ctx as never);
+
+    const registeredConnectionStateListener = connectionStateListener;
+    if (typeof registeredConnectionStateListener !== "function") {
+      throw new Error("Expected connection state listener to be registered");
+    }
+
+    registeredConnectionStateListener({
+      status: "reconnecting",
+      socketPath: "/tmp/todu.sock",
+      handshake: null,
+      lastError: null,
+    });
+
+    expect(ctx.ui.setStatus).toHaveBeenLastCalledWith(SYNC_STATUS_KEY, "sync: unknown");
+    expect(controller.getState()).toEqual({ syncStatus: "unknown" });
+  });
+});
+
+describe("sync status helpers", () => {
+  it("extracts status values from supported payload shapes", () => {
+    expect(extractSyncStatus("running")).toBe("running");
+    expect(extractSyncStatus({ status: "idle" })).toBe("idle");
+    expect(extractSyncStatus({ state: "blocked" })).toBe("blocked");
+    expect(extractSyncStatus({ binding: { state: "error" } })).toBe("error");
+    expect(extractSyncStatus({ sync: { status: "running" } })).toBe("running");
+    expect(extractSyncStatus({ sync: { state: "idle" } })).toBe("idle");
+    expect(extractSyncStatus({ nope: true })).toBeNull();
+  });
+
+  it("normalizes known and unknown sync states", () => {
+    expect(normalizeSyncStatus({ payload: { status: "RUNNING" } })).toBe("running");
+    expect(normalizeSyncStatus({ payload: { state: "paused" } })).toBe("custom:paused");
+    expect(normalizeSyncStatus({ payload: {} })).toBe("unknown");
+  });
+
+  it("formats sync status values for the footer", () => {
+    expect(formatSyncStatus("unknown")).toBe("sync: unknown");
+    expect(formatSyncStatus("running")).toBe("sync: running");
+    expect(formatSyncStatus("custom:paused")).toBe("sync: paused");
+  });
+
+  it("maps disconnected connection states to unknown sync state", () => {
+    const setSyncStatus = vi.fn();
+
+    handleConnectionStateChange(
+      {
+        status: "connected",
+        socketPath: "/tmp/todu.sock",
+        handshake: null,
+        lastError: null,
+      },
+      setSyncStatus
+    );
+    handleConnectionStateChange(
+      {
+        status: "reconnecting",
+        socketPath: "/tmp/todu.sock",
+        handshake: null,
+        lastError: null,
+      },
+      setSyncStatus
+    );
+
+    expect(setSyncStatus).toHaveBeenCalledTimes(1);
+    expect(setSyncStatus).toHaveBeenCalledWith("unknown");
+  });
+});

--- a/src/extension/register-events.ts
+++ b/src/extension/register-events.ts
@@ -4,31 +4,39 @@ import {
   getDefaultCurrentTaskContextController,
   resetDefaultCurrentTaskContextController,
 } from "./current-task-context";
+import {
+  getDefaultSyncStatusContextController,
+  resetDefaultSyncStatusContextController,
+} from "./sync-status-context";
 
 const registerEvents = (pi: ExtensionAPI): void => {
   const currentTaskContext = getDefaultCurrentTaskContextController(pi);
-  const restoreCurrentTaskContext = async (ctx: ExtensionContext): Promise<void> => {
-    await currentTaskContext.restoreFromBranch(ctx);
+  const syncStatusContext = getDefaultSyncStatusContextController(pi);
+  const restoreUiContext = async (ctx: ExtensionContext): Promise<void> => {
+    await Promise.all([currentTaskContext.restoreFromBranch(ctx), syncStatusContext.attach(ctx)]);
   };
 
   pi.on("session_start", async (_event, ctx) => {
-    await restoreCurrentTaskContext(ctx);
+    await restoreUiContext(ctx);
   });
 
   pi.on("session_switch", async (_event, ctx) => {
-    await restoreCurrentTaskContext(ctx);
+    await restoreUiContext(ctx);
   });
 
   pi.on("session_tree", async (_event, ctx) => {
-    await restoreCurrentTaskContext(ctx);
+    await restoreUiContext(ctx);
   });
 
   pi.on("session_fork", async (_event, ctx) => {
-    await restoreCurrentTaskContext(ctx);
+    await restoreUiContext(ctx);
   });
 
   pi.on("session_shutdown", async () => {
-    await resetDefaultCurrentTaskContextController();
+    await Promise.all([
+      resetDefaultCurrentTaskContextController(),
+      resetDefaultSyncStatusContextController(),
+    ]);
   });
 };
 

--- a/src/extension/register-ui.ts
+++ b/src/extension/register-ui.ts
@@ -1,9 +1,11 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 import { getDefaultCurrentTaskContextController } from "./current-task-context";
+import { getDefaultSyncStatusContextController } from "./sync-status-context";
 
 const registerUi = (pi: ExtensionAPI): void => {
   getDefaultCurrentTaskContextController(pi);
+  getDefaultSyncStatusContextController(pi);
 };
 
 export { registerUi };

--- a/src/extension/sync-status-context.ts
+++ b/src/extension/sync-status-context.ts
@@ -1,0 +1,234 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+import {
+  getDefaultToduTaskServiceRuntime,
+  type ToduTaskServiceRuntime,
+} from "../services/todu/default-task-service";
+import type { ToduDaemonConnectionState } from "../services/todu/daemon-connection";
+import type { ToduDaemonEvent, ToduDaemonSubscription } from "../services/todu/daemon-events";
+
+const SYNC_STATUS_KEY = "todu-sync-status";
+const KNOWN_SYNC_STATUSES = ["running", "idle", "blocked", "error"] as const;
+
+type KnownSyncStatus = (typeof KNOWN_SYNC_STATUSES)[number];
+
+type SyncStatusValue = "unknown" | KnownSyncStatus | `custom:${string}`;
+
+export interface SyncStatusContextState {
+  syncStatus: SyncStatusValue;
+}
+
+export interface SyncStatusContextController {
+  getState(): SyncStatusContextState;
+  attach(ctx: ExtensionContext): Promise<void>;
+  dispose(): Promise<void>;
+}
+
+export interface CreateSyncStatusContextControllerDependencies {
+  runtime?: Pick<ToduTaskServiceRuntime, "client" | "connection">;
+}
+
+const createSyncStatusContextController = (
+  _pi: Pick<ExtensionAPI, "appendEntry">,
+  dependencies: CreateSyncStatusContextControllerDependencies = {}
+): SyncStatusContextController => {
+  const runtime = dependencies.runtime ?? getDefaultToduTaskServiceRuntime();
+
+  let activeContext: ExtensionContext | null = null;
+  let syncStatus: SyncStatusValue = "unknown";
+  let syncEventSubscription: ToduDaemonSubscription | null = null;
+  let connectionStateSubscription: ToduDaemonSubscription | null = null;
+  let subscribePromise: Promise<ToduDaemonSubscription> | null = null;
+
+  const updateAmbientUi = (ctx: ExtensionContext): void => {
+    if (!ctx.hasUI) {
+      return;
+    }
+
+    ctx.ui.setStatus(SYNC_STATUS_KEY, formatSyncStatus(syncStatus));
+  };
+
+  const updateSyncStatus = (nextSyncStatus: SyncStatusValue): void => {
+    syncStatus = nextSyncStatus;
+    if (activeContext) {
+      updateAmbientUi(activeContext);
+    }
+  };
+
+  const ensureConnectionStateSubscription = (): void => {
+    if (connectionStateSubscription) {
+      return;
+    }
+
+    connectionStateSubscription = runtime.connection.subscribe((state) => {
+      handleConnectionStateChange(state, updateSyncStatus);
+    });
+  };
+
+  const ensureSyncEventSubscription = async (): Promise<void> => {
+    if (syncEventSubscription) {
+      return;
+    }
+
+    if (subscribePromise) {
+      await subscribePromise;
+      return;
+    }
+
+    subscribePromise = runtime.client
+      .on("sync.statusChanged", (event) => {
+        updateSyncStatus(normalizeSyncStatus(event));
+      })
+      .then((subscription) => {
+        syncEventSubscription = subscription;
+        return subscription;
+      })
+      .finally(() => {
+        subscribePromise = null;
+      });
+
+    await subscribePromise;
+  };
+
+  return {
+    getState: (): SyncStatusContextState => ({ syncStatus }),
+
+    async attach(ctx: ExtensionContext): Promise<void> {
+      activeContext = ctx;
+      ensureConnectionStateSubscription();
+      await ensureSyncEventSubscription();
+      updateAmbientUi(ctx);
+      void runtime.connection.connect().catch(() => {
+        updateSyncStatus("unknown");
+      });
+    },
+
+    async dispose(): Promise<void> {
+      syncEventSubscription?.unsubscribe();
+      syncEventSubscription = null;
+      connectionStateSubscription?.unsubscribe();
+      connectionStateSubscription = null;
+      subscribePromise = null;
+      activeContext = null;
+      syncStatus = "unknown";
+    },
+  };
+};
+
+const handleConnectionStateChange = (
+  state: ToduDaemonConnectionState,
+  setSyncStatus: (status: SyncStatusValue) => void
+): void => {
+  if (state.status !== "connected") {
+    setSyncStatus("unknown");
+  }
+};
+
+const normalizeSyncStatus = (event: Pick<ToduDaemonEvent, "payload">): SyncStatusValue => {
+  const rawStatus = extractSyncStatus(event.payload);
+  if (!rawStatus) {
+    return "unknown";
+  }
+
+  const normalizedStatus = rawStatus.trim().toLowerCase();
+  if (normalizedStatus.length === 0) {
+    return "unknown";
+  }
+
+  if (isKnownSyncStatus(normalizedStatus)) {
+    return normalizedStatus;
+  }
+
+  return `custom:${normalizedStatus}`;
+};
+
+const extractSyncStatus = (payload: unknown): string | null => {
+  if (typeof payload === "string") {
+    return payload;
+  }
+
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const candidate =
+    readString(payload, "status") ??
+    readString(payload, "state") ??
+    readNestedString(payload, "binding", "state") ??
+    readNestedString(payload, "sync", "status") ??
+    readNestedString(payload, "sync", "state");
+
+  return candidate ?? null;
+};
+
+const formatSyncStatus = (status: SyncStatusValue): string => {
+  if (status === "unknown") {
+    return "sync: unknown";
+  }
+
+  if (status.startsWith("custom:")) {
+    return `sync: ${status.slice("custom:".length)}`;
+  }
+
+  return `sync: ${status}`;
+};
+
+const isKnownSyncStatus = (value: string): value is KnownSyncStatus =>
+  KNOWN_SYNC_STATUSES.includes(value as KnownSyncStatus);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const readString = (value: Record<string, unknown>, key: string): string | null => {
+  const candidate = value[key];
+  return typeof candidate === "string" ? candidate : null;
+};
+
+const readNestedString = (
+  value: Record<string, unknown>,
+  outerKey: string,
+  innerKey: string
+): string | null => {
+  const nestedValue = value[outerKey];
+  if (!isRecord(nestedValue)) {
+    return null;
+  }
+
+  return readString(nestedValue, innerKey);
+};
+
+let defaultSyncStatusContextController: SyncStatusContextController | null = null;
+
+const getDefaultSyncStatusContextController = (
+  pi?: Pick<ExtensionAPI, "appendEntry">
+): SyncStatusContextController => {
+  if (!defaultSyncStatusContextController) {
+    if (!pi) {
+      throw new Error("Sync status context controller has not been initialized");
+    }
+
+    defaultSyncStatusContextController = createSyncStatusContextController(pi);
+  }
+
+  return defaultSyncStatusContextController;
+};
+
+const resetDefaultSyncStatusContextController = async (): Promise<void> => {
+  if (!defaultSyncStatusContextController) {
+    return;
+  }
+
+  await defaultSyncStatusContextController.dispose();
+  defaultSyncStatusContextController = null;
+};
+
+export {
+  createSyncStatusContextController,
+  extractSyncStatus,
+  formatSyncStatus,
+  getDefaultSyncStatusContextController,
+  handleConnectionStateChange,
+  normalizeSyncStatus,
+  resetDefaultSyncStatusContextController,
+  SYNC_STATUS_KEY,
+};


### PR DESCRIPTION
## Summary
- add a sync status context controller that subscribes to sync.statusChanged and writes a separate footer status
- initialize and attach the sync status controller through the extension UI/session lifecycle
- add focused tests for sync status normalization and controller behavior

## Verification
- ./scripts/pre-pr.sh

Task: #task-f4f6d1b3