### PR TITLE
feat: add task-clear command

### DIFF
--- a/src/__tests__/tasks-command.test.ts
+++ b/src/__tests__/tasks-command.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { TaskDetail, TaskSummary } from "@/domain/task";
 import {
+  createTaskClearCommandHandler,
   createTaskCommandHandler,
   createTasksCommandHandler,
   DEFAULT_BROWSE_TASKS_FILTER,
@@ -40,7 +41,7 @@ const createCommandContext = () => ({
 });
 
 describe("registerCommands", () => {
-  it("registers the /tasks and /task commands", () => {
+  it("registers the /tasks, /task, and /task-clear commands", () => {
     const pi = {
       appendEntry: vi.fn(),
       registerCommand: vi.fn(),
@@ -59,6 +60,13 @@ describe("registerCommands", () => {
       "task",
       expect.objectContaining({
         description: "Show the current task or a specific task by ID",
+        handler: expect.any(Function),
+      })
+    );
+    expect(pi.registerCommand).toHaveBeenCalledWith(
+      "task-clear",
+      expect.objectContaining({
+        description: "Clear the current task context",
         handler: expect.any(Function),
       })
     );
@@ -201,6 +209,54 @@ describe("createTaskCommandHandler", () => {
       "No task selected. Run /tasks or pass a task ID.",
       "warning"
     );
+  });
+});
+
+describe("createTaskClearCommandHandler", () => {
+  it("clears the current task in interactive mode", async () => {
+    const context = createCommandContext();
+    const clearCurrentTask = vi.fn().mockResolvedValue(undefined);
+    const handler = createTaskClearCommandHandler({
+      getCurrentTaskId: vi.fn().mockReturnValue("task-current"),
+      clearCurrentTask,
+    });
+
+    await handler("", context as never);
+
+    expect(clearCurrentTask).toHaveBeenCalledWith(context);
+    expect(context.ui.notify).toHaveBeenCalledWith("Cleared current task", "info");
+  });
+
+  it("reports when there is no current task in interactive mode", async () => {
+    const context = createCommandContext();
+    const clearCurrentTask = vi.fn().mockResolvedValue(undefined);
+    const handler = createTaskClearCommandHandler({
+      getCurrentTaskId: vi.fn().mockReturnValue(null),
+      clearCurrentTask,
+    });
+
+    await handler("", context as never);
+
+    expect(clearCurrentTask).not.toHaveBeenCalled();
+    expect(context.ui.notify).toHaveBeenCalledWith("No current task to clear", "info");
+  });
+
+  it("prints a success message in non-interactive mode", async () => {
+    const context = createCommandContext();
+    context.hasUI = false;
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const clearCurrentTask = vi.fn().mockResolvedValue(undefined);
+    const handler = createTaskClearCommandHandler({
+      getCurrentTaskId: vi.fn().mockReturnValue("task-current"),
+      clearCurrentTask,
+    });
+
+    await handler("", context as never);
+
+    expect(clearCurrentTask).toHaveBeenCalledWith(context);
+    expect(stdoutWrite).toHaveBeenCalledWith("Cleared current task\n");
+
+    stdoutWrite.mockRestore();
   });
 });
 

--- a/src/extension/register-commands.ts
+++ b/src/extension/register-commands.ts
@@ -55,6 +55,7 @@ type TaskBrowseLoadResult = LoadedTasksResult | CancelledTasksResult | ErrorTask
 export interface RegisterCommandDependencies {
   getTaskService?: () => Promise<TaskService>;
   getCurrentTaskId?: () => TaskId | null;
+  clearCurrentTask?: (ctx: ExtensionCommandContext) => Promise<void>;
   loadTasks?: (
     ctx: ExtensionCommandContext,
     taskService: TaskService
@@ -184,6 +185,48 @@ const createTaskCommandHandler = (
   };
 };
 
+const createTaskClearCommandHandler = (
+  dependencies: RegisterCommandDependencies = {}
+): ((args: string, ctx: ExtensionCommandContext) => Promise<void>) => {
+  const getCurrentTaskId =
+    dependencies.getCurrentTaskId ??
+    (() => getDefaultCurrentTaskContextController().getState().currentTaskId);
+  const clearCurrentTask =
+    dependencies.clearCurrentTask ??
+    ((ctx: ExtensionCommandContext) =>
+      getDefaultCurrentTaskContextController().clearCurrentTask(ctx));
+
+  return async (_args: string, ctx: ExtensionCommandContext): Promise<void> => {
+    const currentTaskId = getCurrentTaskId();
+    if (!currentTaskId) {
+      if (ctx.hasUI) {
+        ctx.ui.notify("No current task to clear", "info");
+        return;
+      }
+
+      process.stdout.write("No current task to clear\n");
+      return;
+    }
+
+    try {
+      await clearCurrentTask(ctx);
+      if (ctx.hasUI) {
+        ctx.ui.notify("Cleared current task", "info");
+        return;
+      }
+
+      process.stdout.write("Cleared current task\n");
+    } catch (error) {
+      if (ctx.hasUI) {
+        ctx.ui.notify(formatTasksCommandError(error, "Failed to clear current task"), "error");
+        return;
+      }
+
+      process.stderr.write(`${formatTasksCommandError(error, "Failed to clear current task")}\n`);
+    }
+  };
+};
+
 const registerCommands = (
   pi: ExtensionAPI,
   dependencies: RegisterCommandDependencies = {}
@@ -198,6 +241,11 @@ const registerCommands = (
   pi.registerCommand("task", {
     description: "Show the current task or a specific task by ID",
     handler: createTaskCommandHandler(dependencies),
+  });
+
+  pi.registerCommand("task-clear", {
+    description: "Clear the current task context",
+    handler: createTaskClearCommandHandler(dependencies),
   });
 };
 
@@ -581,6 +629,7 @@ const formatTasksCommandError = (error: unknown, prefix: string): string => {
 };
 
 export {
+  createTaskClearCommandHandler,
   createTaskCommandHandler,
   createTasksCommandHandler,
   DEFAULT_BROWSE_TASKS_FILTER,


### PR DESCRIPTION
## Summary
- add a /task-clear command that clears the current task context
- support both interactive and non-interactive success paths
- add focused tests for clear, no-current-task, and non-interactive behavior

## Verification
- ./scripts/pre-pr.sh

Task: #task-754de684