### PR TITLE
feat: add pickup action to task detail

### DIFF
--- a/src/__tests__/task-detail-view.test.ts
+++ b/src/__tests__/task-detail-view.test.ts
@@ -6,7 +6,7 @@ import {
   createTaskDetailViewModel,
 } from "@/ui/components/task-detail";
 
-const createTaskDetail = (): TaskDetail => ({
+const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
   id: "task-123",
   title: "Implement task detail view",
   status: "active",
@@ -31,6 +31,7 @@ const createTaskDetail = (): TaskDetail => ({
       createdAt: "2026-03-19T01:00:00.000Z",
     },
   ],
+  ...overrides,
 });
 
 describe("task detail view model", () => {
@@ -53,6 +54,11 @@ describe("task detail view model", () => {
   it("creates quick action items for the detail hub", () => {
     expect(createTaskDetailActionItems(createTaskDetail())).toEqual([
       {
+        value: "pickup",
+        label: "Pick up task",
+        description: "Prepare the pickup workflow for task-123 and set it as current",
+      },
+      {
         value: "set-current",
         label: "Set as current task",
         description: "Use task-123 as the active coding context",
@@ -61,6 +67,31 @@ describe("task detail view model", () => {
         value: "update-status",
         label: "Update status",
         description: "Change status from Active",
+      },
+      {
+        value: "update-priority",
+        label: "Update priority",
+        description: "Change priority from High",
+      },
+      {
+        value: "comment",
+        label: "Add comment",
+        description: "Open the editor to add a progress note or comment",
+      },
+    ]);
+  });
+
+  it("only shows the pick up action for active tasks", () => {
+    expect(createTaskDetailActionItems(createTaskDetail({ status: "inprogress" }))).toEqual([
+      {
+        value: "set-current",
+        label: "Set as current task",
+        description: "Use task-123 as the active coding context",
+      },
+      {
+        value: "update-status",
+        label: "Update status",
+        description: "Change status from In Progress",
       },
       {
         value: "update-priority",

--- a/src/__tests__/tasks-command.test.ts
+++ b/src/__tests__/tasks-command.test.ts
@@ -829,6 +829,30 @@ describe("openTaskDetailHub", () => {
     });
     expect(context.ui.notify).toHaveBeenCalledWith(`Added comment to ${task.title}`, "info");
   });
+
+  it("prepares the pickup workflow and sets the current task from the detail hub", async () => {
+    const context = createCommandContext();
+    const task = createTaskDetail({ status: "active" });
+    const setCurrentTask = vi.fn().mockResolvedValue(undefined);
+    const taskService = {
+      getTask: vi.fn().mockResolvedValue(task),
+      updateTask: vi.fn(),
+      addTaskComment: vi.fn(),
+    } as unknown as TaskService;
+
+    await openTaskDetailHub(context as never, taskService, task.id, {
+      setCurrentTask,
+      showTaskDetailView: vi.fn().mockResolvedValueOnce("pickup"),
+    });
+
+    expect(setCurrentTask).toHaveBeenCalledWith(context, task);
+    expect(context.ui.setEditorText).toHaveBeenCalledWith(`pickup task ${task.id}`);
+    expect(context.ui.notify).toHaveBeenCalledWith(
+      `Prepared pickup workflow for ${task.title}`,
+      "info"
+    );
+    expect(taskService.updateTask).not.toHaveBeenCalled();
+  });
 });
 
 describe("resolveRequestedTaskId", () => {

--- a/src/extension/register-commands.ts
+++ b/src/extension/register-commands.ts
@@ -1072,6 +1072,13 @@ const openTaskDetailHub = async (
       return;
     }
 
+    if (action === "pickup") {
+      await dependencies.setCurrentTask(ctx, task);
+      ctx.ui.setEditorText(`pickup task ${task.id}`);
+      ctx.ui.notify(`Prepared pickup workflow for ${task.title}`, "info");
+      return;
+    }
+
     if (action === "set-current") {
       await dependencies.setCurrentTask(ctx, task);
       ctx.ui.notify(`Current task set to ${task.title}`, "info");

--- a/src/ui/components/task-detail.ts
+++ b/src/ui/components/task-detail.ts
@@ -1,6 +1,11 @@
 import type { TaskDetail, TaskPriority, TaskStatus } from "../../domain/task";
 
-export type TaskDetailActionKind = "set-current" | "update-status" | "update-priority" | "comment";
+export type TaskDetailActionKind =
+  | "pickup"
+  | "set-current"
+  | "update-status"
+  | "update-priority"
+  | "comment";
 
 export interface TaskDetailActionItem {
   value: TaskDetailActionKind;
@@ -25,28 +30,42 @@ const createTaskDetailViewModel = (
   commentCount: task.comments.length,
 });
 
-const createTaskDetailActionItems = (task: TaskDetail): TaskDetailActionItem[] => [
-  {
-    value: "set-current",
-    label: "Set as current task",
-    description: `Use ${task.id} as the active coding context`,
-  },
-  {
-    value: "update-status",
-    label: "Update status",
-    description: `Change status from ${formatTaskStatusLabel(task.status)}`,
-  },
-  {
-    value: "update-priority",
-    label: "Update priority",
-    description: `Change priority from ${formatTaskPriorityLabel(task.priority)}`,
-  },
-  {
-    value: "comment",
-    label: "Add comment",
-    description: "Open the editor to add a progress note or comment",
-  },
-];
+const createTaskDetailActionItems = (task: TaskDetail): TaskDetailActionItem[] => {
+  const items: TaskDetailActionItem[] = [];
+
+  if (task.status === "active") {
+    items.push({
+      value: "pickup",
+      label: "Pick up task",
+      description: `Prepare the pickup workflow for ${task.id} and set it as current`,
+    });
+  }
+
+  items.push(
+    {
+      value: "set-current",
+      label: "Set as current task",
+      description: `Use ${task.id} as the active coding context`,
+    },
+    {
+      value: "update-status",
+      label: "Update status",
+      description: `Change status from ${formatTaskStatusLabel(task.status)}`,
+    },
+    {
+      value: "update-priority",
+      label: "Update priority",
+      description: `Change priority from ${formatTaskPriorityLabel(task.priority)}`,
+    },
+    {
+      value: "comment",
+      label: "Add comment",
+      description: "Open the editor to add a progress note or comment",
+    }
+  );
+
+  return items;
+};
 
 const createTaskDetailBody = (task: TaskDetail, recentCommentLimit: number): string => {
   const lines = [


### PR DESCRIPTION
## Summary
- add a `Pick up task` quick action for active tasks in the task detail menu
- set the selected task as current and insert the pickup workflow command into the editor
- keep the existing task detail actions unchanged
- add focused tests for action visibility and pickup handoff behavior

## Verification
- `./scripts/pre-pr.sh`

## Task
- `task-d07ba330`