### PR TITLE
feat: support title updates in task_update

### DIFF
--- a/docs/plans/agent-tools-v1.md
+++ b/docs/plans/agent-tools-v1.md
@@ -108,6 +108,7 @@ Planned V1 parameters:
   - `description?: string`
 - `task_update`
   - `taskId: TaskId`
+  - `title?: string`
   - `status?: TaskStatus`
   - `priority?: TaskPriority`
   - `description?: string`
@@ -120,7 +121,7 @@ Planned V1 parameters:
 Deferred from V1 even if other clients support them:
 
 - task labels on `task_create`
-- title changes, due dates, scheduled dates, and label updates on `task_update`
+- due dates, scheduled dates, and label updates on `task_update`
 - all delete, move, integration, habit, and recurring operations
 
 #### Result and `details` contract
@@ -169,7 +170,7 @@ The initial guideline set should reinforce that:
 
 - tools are for backend operations, not interactive browsing flows
 - slash commands remain the right choice for rich TUI navigation and editing
-- `task_update` supports only status, priority, and description in V1
+- `task_update` supports only title, status, priority, and description in V1
 - `task_create` requires explicit `projectId`
 
 #### UI-neutrality contract
@@ -201,7 +202,7 @@ Current service capabilities already available:
 - list tasks
 - get task detail
 - create task
-- update task status, priority, and description
+- update task title, status, priority, and description
 - add task comment
 - list projects
 - get project summary
@@ -227,7 +228,7 @@ Recommended V1 behavior per tool:
   - accepts title, required project ID, and optional description
   - defers labels for V1 even if the backend can support them
 - `task_update`
-  - supports only the currently implemented update surface: status, priority, and description
+  - supports only the currently implemented update surface: title, status, priority, and description
   - explicitly defer unsupported task fields rather than widening the contract implicitly
 - `task_comment_create`
   - accepts task ID and comment content

--- a/src/__tests__/daemon-client.test.ts
+++ b/src/__tests__/daemon-client.test.ts
@@ -166,6 +166,58 @@ describe("createToduDaemonClient", () => {
     );
   });
 
+  it("updates tasks through task.update with title changes", async () => {
+    const connection = createConnectionMock();
+    connection.request
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          id: "task-1",
+          title: "Renamed task",
+          status: "active",
+          priority: "medium",
+          projectId: "proj-1",
+          labels: ["daemon"],
+          assignees: [],
+          description: "Implement the typed client wrapper",
+          createdAt: "2026-03-19T00:00:00.000Z",
+          updatedAt: "2026-03-19T00:00:00.000Z",
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: [],
+      });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await expect(
+      client.updateTask({
+        taskId: "task-1",
+        title: "Renamed task",
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        id: "task-1",
+        title: "Renamed task",
+      })
+    );
+    expect(connection.request).toHaveBeenNthCalledWith(1, "task.update", {
+      id: "task-1",
+      input: {
+        title: "Renamed task",
+        status: undefined,
+        priority: undefined,
+        description: undefined,
+      },
+    });
+  });
+
   it("creates task comments through note.create", async () => {
     const connection = createConnectionMock();
     connection.request.mockResolvedValue({

--- a/src/__tests__/task-mutation-tools.test.ts
+++ b/src/__tests__/task-mutation-tools.test.ts
@@ -79,8 +79,22 @@ describe("normalizeCreateTaskInput", () => {
 describe("normalizeUpdateTaskInput", () => {
   it("requires at least one supported mutation field", () => {
     expect(() => normalizeUpdateTaskInput({ taskId: "task-123" })).toThrow(
-      "task_update requires at least one supported field: status, priority, or description"
+      "task_update requires at least one supported field: title, status, priority, or description"
     );
+  });
+
+  it("trims replacement titles", () => {
+    expect(
+      normalizeUpdateTaskInput({
+        taskId: " task-123 ",
+        title: "  Updated title  ",
+      })
+    ).toEqual({
+      taskId: "task-123",
+      title: "Updated title",
+      status: undefined,
+      priority: undefined,
+    });
   });
 
   it("treats blank descriptions as an explicit clear", () => {
@@ -183,7 +197,12 @@ describe("createTaskCreateToolDefinition", () => {
 
 describe("createTaskUpdateToolDefinition", () => {
   it("updates supported fields and returns structured details", async () => {
-    const task = createTaskDetail({ status: "inprogress", priority: "medium", description: null });
+    const task = createTaskDetail({
+      title: "Updated task title",
+      status: "inprogress",
+      priority: "medium",
+      description: null,
+    });
     const taskService = {
       updateTask: vi.fn().mockResolvedValue(task),
     } as unknown as TaskService;
@@ -193,6 +212,7 @@ describe("createTaskUpdateToolDefinition", () => {
 
     const result = await tool.execute("tool-call-1", {
       taskId: " task-123 ",
+      title: "  Updated task title  ",
       status: "inprogress",
       priority: "medium",
       description: "   ",
@@ -200,18 +220,20 @@ describe("createTaskUpdateToolDefinition", () => {
 
     expect(taskService.updateTask).toHaveBeenCalledWith({
       taskId: "task-123",
+      title: "Updated task title",
       status: "inprogress",
       priority: "medium",
       description: null,
     });
     expect(result.content[0]?.text).toContain(`Updated task ${task.id}: ${task.title}`);
     expect(result.content[0]?.text).toContain(
-      "Changes: status=inprogress, priority=medium, description=cleared"
+      'Changes: title="Updated task title", status=inprogress, priority=medium, description=cleared'
     );
     expect(result.details).toEqual({
       kind: "task_update",
       input: {
         taskId: "task-123",
+        title: "Updated task title",
         status: "inprogress",
         priority: "medium",
         description: null,
@@ -226,8 +248,21 @@ describe("createTaskUpdateToolDefinition", () => {
     });
 
     await expect(tool.execute("tool-call-1", { taskId: "task-123" })).rejects.toThrow(
-      "task_update failed: task_update requires at least one supported field: status, priority, or description"
+      "task_update failed: task_update requires at least one supported field: title, status, priority, or description"
     );
+  });
+
+  it("surfaces title validation failures with tool-specific context", async () => {
+    const tool = createTaskUpdateToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue({} as TaskService),
+    });
+
+    await expect(
+      tool.execute("tool-call-1", {
+        taskId: "task-123",
+        title: "   ",
+      })
+    ).rejects.toThrow("task_update failed: title is required");
   });
 
   it("surfaces service failures with tool-specific context", async () => {

--- a/src/services/task-service.ts
+++ b/src/services/task-service.ts
@@ -18,6 +18,7 @@ export interface CreateTaskInput {
 
 export interface UpdateTaskInput {
   taskId: TaskId;
+  title?: string;
   status?: TaskStatus;
   priority?: TaskPriority;
   description?: string | null;

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -278,6 +278,7 @@ const mapCreateTaskInput = (input: CreateTaskInput): Record<string, unknown> => 
 });
 
 const mapUpdateTaskInput = (input: UpdateTaskInput): Record<string, unknown> => ({
+  title: input.title ?? undefined,
   status: input.status ? toRemoteTaskStatus(input.status) : undefined,
   priority: input.priority ? toRemoteTaskPriority(input.priority) : undefined,
   description: input.description ?? undefined,

--- a/src/tools/task-mutation-tools.ts
+++ b/src/tools/task-mutation-tools.ts
@@ -24,6 +24,7 @@ const TaskCreateParams = Type.Object({
 
 const TaskUpdateParams = Type.Object({
   taskId: Type.String({ description: "Task ID" }),
+  title: Type.Optional(Type.String({ description: "Optional replacement task title" })),
   status: Type.Optional(
     StringEnum(TASK_STATUS_VALUES, { description: "Optional next task status" })
   ),
@@ -50,6 +51,7 @@ interface TaskCreateToolParams {
 
 interface TaskUpdateToolParams {
   taskId: TaskId;
+  title?: string;
   status?: TaskStatus;
   priority?: TaskPriority;
   description?: string;
@@ -116,11 +118,11 @@ const createTaskCreateToolDefinition = ({ getTaskService }: TaskMutationToolDepe
 const createTaskUpdateToolDefinition = ({ getTaskService }: TaskMutationToolDependencies) => ({
   name: "task_update",
   label: "Task Update",
-  description: "Update a task's status, priority, or description.",
+  description: "Update a task's title, status, priority, or description.",
   promptSnippet: "Update a task's supported metadata fields by task ID.",
   promptGuidelines: [
     "Use this tool for backend task updates in normal chat.",
-    "In V1, only status, priority, and description are supported.",
+    "Supported fields are title, status, priority, and description.",
   ],
   parameters: TaskUpdateParams,
   async execute(_toolCallId: string, params: TaskUpdateToolParams) {
@@ -199,13 +201,22 @@ const normalizeUpdateTaskInput = (params: TaskUpdateToolParams): UpdateTaskInput
     priority: params.priority,
   };
 
+  if (hasOwn(params, "title")) {
+    input.title = normalizeRequiredText(params.title ?? "", "title");
+  }
+
   if (hasOwn(params, "description")) {
     input.description = normalizeNullableText(params.description);
   }
 
-  if (input.status === undefined && input.priority === undefined && !hasOwn(input, "description")) {
+  if (
+    input.title === undefined &&
+    input.status === undefined &&
+    input.priority === undefined &&
+    !hasOwn(input, "description")
+  ) {
     throw new Error(
-      "task_update requires at least one supported field: status, priority, or description"
+      "task_update requires at least one supported field: title, status, priority, or description"
     );
   }
 
@@ -255,6 +266,7 @@ const formatTaskCreateContent = (task: TaskDetail): string =>
 
 const formatTaskUpdateContent = (task: TaskDetail, input: UpdateTaskInput): string => {
   const changedFields = [
+    input.title !== undefined ? `title=${JSON.stringify(input.title)}` : null,
     input.status !== undefined ? `status=${input.status}` : null,
     input.priority !== undefined ? `priority=${input.priority}` : null,
     hasOwn(input, "description")


### PR DESCRIPTION
## Summary
- extend the native `task_update` tool and shared update contract to support title changes
- pass title updates through the daemon-backed task update client mapping
- add focused tests for title update success, validation, and daemon request mapping
- update the V1 agent tool plan to reflect title support in `task_update`

## Verification
- `./scripts/pre-pr.sh`

## Task
- `task-26000def`