### PR TITLE
feat: clear current task on terminal status

### DIFF
--- a/src/__tests__/current-task-context.test.ts
+++ b/src/__tests__/current-task-context.test.ts
@@ -144,4 +144,60 @@ describe("createCurrentTaskContextController", () => {
       "active • medium • Todu Pi Extensions",
     ]);
   });
+
+  it("clears the current task when a focused task becomes done", async () => {
+    const initialTask = createTaskDetail();
+    const doneTask = createTaskDetail({ status: "done" });
+    const getTask = vi.fn().mockResolvedValue(doneTask);
+    const appendEntry = vi.fn();
+    const ctx = createContext();
+    const controller = createCurrentTaskContextController(
+      { appendEntry },
+      {
+        runtime: {
+          ensureConnected: vi.fn().mockResolvedValue({ getTask }),
+          client: { on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }) },
+        } as never,
+      }
+    );
+
+    await controller.setCurrentTask(ctx as never, initialTask);
+    await controller.handleDataChanged();
+
+    expect(getTask).toHaveBeenCalledWith(initialTask.id);
+    expect(controller.getState()).toEqual({ currentTaskId: null, currentTask: null });
+    expect(appendEntry).toHaveBeenLastCalledWith(TASK_SESSION_ENTRY_TYPE, {
+      currentTaskId: null,
+    });
+    expect(ctx.ui.setStatus).toHaveBeenLastCalledWith(CURRENT_TASK_STATUS_KEY, undefined);
+    expect(ctx.ui.setWidget).toHaveBeenLastCalledWith(CURRENT_TASK_WIDGET_KEY, undefined);
+  });
+
+  it("clears the current task when a focused task becomes cancelled", async () => {
+    const initialTask = createTaskDetail();
+    const cancelledTask = createTaskDetail({ status: "cancelled" });
+    const getTask = vi.fn().mockResolvedValue(cancelledTask);
+    const appendEntry = vi.fn();
+    const ctx = createContext();
+    const controller = createCurrentTaskContextController(
+      { appendEntry },
+      {
+        runtime: {
+          ensureConnected: vi.fn().mockResolvedValue({ getTask }),
+          client: { on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }) },
+        } as never,
+      }
+    );
+
+    await controller.setCurrentTask(ctx as never, initialTask);
+    await controller.handleDataChanged();
+
+    expect(getTask).toHaveBeenCalledWith(initialTask.id);
+    expect(controller.getState()).toEqual({ currentTaskId: null, currentTask: null });
+    expect(appendEntry).toHaveBeenLastCalledWith(TASK_SESSION_ENTRY_TYPE, {
+      currentTaskId: null,
+    });
+    expect(ctx.ui.setStatus).toHaveBeenLastCalledWith(CURRENT_TASK_STATUS_KEY, undefined);
+    expect(ctx.ui.setWidget).toHaveBeenLastCalledWith(CURRENT_TASK_WIDGET_KEY, undefined);
+  });
 });

--- a/src/extension/current-task-context.ts
+++ b/src/extension/current-task-context.ts
@@ -107,7 +107,7 @@ const createCurrentTaskContextController = (
     try {
       const taskService = await runtime.ensureConnected();
       const task = await taskService.getTask(currentTaskId);
-      if (!task) {
+      if (!task || isTerminalCurrentTaskStatus(task.status)) {
         currentTask = null;
         taskSessionStore.clearCurrentTask();
         persistTaskSessionState(pi.appendEntry, taskSessionStore.getState());
@@ -194,6 +194,9 @@ const getDefaultCurrentTaskContextController = (
 
   return defaultCurrentTaskContextController;
 };
+
+const isTerminalCurrentTaskStatus = (status: TaskDetail["status"]): boolean =>
+  status === "done" || status === "cancelled";
 
 const resetDefaultCurrentTaskContextController = async (): Promise<void> => {
   if (!defaultCurrentTaskContextController) {


### PR DESCRIPTION
## Summary

Clear the current task automatically when the focused task becomes terminal through the existing daemon-driven refresh flow.

## Task

- `task-de49c2cb`

## Changes

- detect terminal current-task statuses during `data.changed` refreshes
- clear the current task when the focused task becomes `done`
- clear the current task when the focused task becomes `cancelled`
- preserve normal ambient status/widget updates for non-terminal task refreshes
- add tests for automatic clearing on terminal statuses

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [ ] Documentation updated (if needed)
- [x] No unrelated changes included
