### PR TITLE
feat: add project_list tool

### DIFF
--- a/src/__tests__/project-read-tools.test.ts
+++ b/src/__tests__/project-read-tools.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ProjectSummary } from "@/domain/task";
+import { registerTools } from "@/extension/register-tools";
+import type { TaskService } from "@/services/task-service";
+import {
+  createProjectListToolDefinition,
+  formatProjectListContent,
+} from "@/tools/project-read-tools";
+
+const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectSummary => ({
+  id: "proj-1",
+  name: "Todu Pi Extensions",
+  status: "active",
+  priority: "medium",
+  description: "Primary project",
+  ...overrides,
+});
+
+describe("registerTools", () => {
+  it("registers the complete V1 first-wave tool set", () => {
+    const pi = {
+      registerTool: vi.fn(),
+    };
+
+    registerTools(pi as never, {
+      getTaskService: vi.fn().mockResolvedValue({} as TaskService),
+    });
+
+    const registeredToolNames = pi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(registeredToolNames).toEqual(
+      expect.arrayContaining([
+        "task_list",
+        "task_show",
+        "task_create",
+        "task_update",
+        "task_comment_create",
+        "project_list",
+      ])
+    );
+  });
+});
+
+describe("formatProjectListContent", () => {
+  it("formats concise project summary lines", () => {
+    expect(
+      formatProjectListContent({
+        kind: "project_list",
+        projects: [createProjectSummary()],
+        total: 1,
+        empty: false,
+      })
+    ).toContain("proj-1 • Todu Pi Extensions • active • medium");
+  });
+});
+
+describe("createProjectListToolDefinition", () => {
+  it("lists projects and returns structured details", async () => {
+    const projects = [createProjectSummary()];
+    const taskService = {
+      listProjects: vi.fn().mockResolvedValue(projects),
+    } as unknown as TaskService;
+    const tool = createProjectListToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    const result = await tool.execute("tool-call-1", {});
+
+    expect(taskService.listProjects).toHaveBeenCalledWith();
+    expect(result.content[0]?.type).toBe("text");
+    expect(result.content[0]?.text).toContain("Projects (1):");
+    expect(result.content[0]?.text).toContain("proj-1");
+    expect(result.details).toEqual({
+      kind: "project_list",
+      projects,
+      total: 1,
+      empty: false,
+    });
+  });
+
+  it("returns a non-error empty result when no projects exist", async () => {
+    const taskService = {
+      listProjects: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskService;
+    const tool = createProjectListToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    const result = await tool.execute("tool-call-1", {});
+
+    expect(result.content[0]?.text).toBe("No projects found.");
+    expect(result.details).toEqual({
+      kind: "project_list",
+      projects: [],
+      total: 0,
+      empty: true,
+    });
+  });
+
+  it("surfaces service failures with tool-specific context", async () => {
+    const tool = createProjectListToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue({
+        listProjects: vi.fn().mockRejectedValue(new Error("daemon unavailable")),
+      } as unknown as TaskService),
+    });
+
+    await expect(tool.execute("tool-call-1", {})).rejects.toThrow(
+      "project_list failed: daemon unavailable"
+    );
+  });
+});

--- a/src/extension/register-tools.ts
+++ b/src/extension/register-tools.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 import type { TaskService } from "../services/task-service";
 import { getDefaultToduTaskServiceRuntime } from "../services/todu/default-task-service";
+import { registerProjectReadTools } from "../tools/project-read-tools";
 import { registerTaskMutationTools } from "../tools/task-mutation-tools";
 import { registerTaskReadTools } from "../tools/task-read-tools";
 
@@ -14,6 +15,7 @@ const registerTools = (pi: ExtensionAPI, dependencies: RegisterToolDependencies 
     dependencies.getTaskService ?? (() => getDefaultToduTaskServiceRuntime().ensureConnected());
 
   registerTaskReadTools(pi, { getTaskService });
+  registerProjectReadTools(pi, { getTaskService });
   registerTaskMutationTools(pi, { getTaskService });
 };
 

--- a/src/tools/project-read-tools.ts
+++ b/src/tools/project-read-tools.ts
@@ -1,0 +1,91 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+
+import type { ProjectSummary } from "../domain/task";
+import type { TaskService } from "../services/task-service";
+
+const ProjectListParams = Type.Object({});
+const MAX_PROJECT_LIST_PREVIEW_COUNT = 25;
+
+interface ProjectListToolDetails {
+  kind: "project_list";
+  projects: ProjectSummary[];
+  total: number;
+  empty: boolean;
+}
+
+interface ProjectReadToolDependencies {
+  getTaskService: () => Promise<TaskService>;
+}
+
+const createProjectListToolDefinition = ({ getTaskService }: ProjectReadToolDependencies) => ({
+  name: "project_list",
+  label: "Project List",
+  description: "List projects.",
+  promptSnippet: "List projects using the native backend tool.",
+  promptGuidelines: [
+    "Use this tool when the user asks to list projects in normal chat.",
+    "Keep project_list unfiltered in V1.",
+  ],
+  parameters: ProjectListParams,
+  async execute(_toolCallId: string, _params: Record<string, never>) {
+    try {
+      const taskService = await getTaskService();
+      const projects = await taskService.listProjects();
+      const details: ProjectListToolDetails = {
+        kind: "project_list",
+        projects,
+        total: projects.length,
+        empty: projects.length === 0,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: formatProjectListContent(details) }],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "project_list failed"), { cause: error });
+    }
+  },
+});
+
+const registerProjectReadTools = (
+  pi: Pick<ExtensionAPI, "registerTool">,
+  dependencies: ProjectReadToolDependencies
+): void => {
+  pi.registerTool(createProjectListToolDefinition(dependencies));
+};
+
+const formatProjectListContent = (details: ProjectListToolDetails): string => {
+  if (details.empty) {
+    return "No projects found.";
+  }
+
+  const previewProjects = details.projects.slice(0, MAX_PROJECT_LIST_PREVIEW_COUNT);
+  const lines = [`Projects (${details.total}):`];
+
+  for (const project of previewProjects) {
+    lines.push(`- ${formatProjectSummaryLine(project)}`);
+  }
+
+  const remainingCount = details.total - previewProjects.length;
+  if (remainingCount > 0) {
+    lines.push(`- ... ${remainingCount} more project(s)`);
+  }
+
+  return lines.join("\n");
+};
+
+const formatProjectSummaryLine = (project: ProjectSummary): string =>
+  `${project.id} • ${project.name} • ${project.status} • ${project.priority}`;
+
+const formatToolError = (error: unknown, prefix: string): string => {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return `${prefix}: ${error.message}`;
+  }
+
+  return prefix;
+};
+
+export type { ProjectListToolDetails, ProjectReadToolDependencies };
+export { createProjectListToolDefinition, formatProjectListContent, registerProjectReadTools };


### PR DESCRIPTION
## Summary
- add a dedicated project read tool module with native `project_list`
- register `project_list` alongside the existing V1 task tools
- add focused tests for registration, success, empty results, and failures

## Verification
- ./scripts/pre-pr.sh

Task: #task-2bec9ed4