### PR TITLE
feat: add project_show tool

### DIFF
--- a/docs/plans/project-agent-tools.md
+++ b/docs/plans/project-agent-tools.md
@@ -111,7 +111,7 @@ Planned native project tool areas:
 ### Error, empty, and cancel states
 
 - `project_list` should treat an empty result as a successful non-error outcome.
-- `project_show` should return an explicit not-found result instead of throwing for missing project IDs.
+- `project_show` should return an explicit not-found result instead of throwing for missing project references.
 - `project_create` and `project_update` should fail fast on invalid inputs instead of guessing field values.
 - `project_delete` should report explicit success or explicit not-found behavior and surface backend refusal clearly if tasks or related data block deletion.
 - `project_check` should report ambiguous or missing repo context clearly.
@@ -375,19 +375,21 @@ Behavior:
 
 Purpose:
 
-- show one project by explicit project ID
+- show one project by explicit project reference
 
 Parameters:
 
-- `projectId: string`
+- `projectRef: string` — project ID or unique project name
 
 Result shape:
 
-- `details: { kind: "project_show", projectId, found, project? }`
+- `details: { kind: "project_show", projectRef, found, project? }`
 
 Behavior:
 
+- resolve by project ID first, then fall back to unique name matching
 - missing project returns `found: false` instead of throwing
+- ambiguous name matches fail clearly instead of guessing
 - service failures throw normal tool errors
 - response should stay focused on project metadata, not embed a full task browser
 

--- a/src/__tests__/project-read-tools.test.ts
+++ b/src/__tests__/project-read-tools.test.ts
@@ -5,7 +5,10 @@ import { registerTools } from "@/extension/register-tools";
 import type { TaskService } from "@/services/task-service";
 import {
   createProjectListToolDefinition,
+  createProjectShowToolDefinition,
   formatProjectListContent,
+  formatProjectShowContent,
+  resolveProjectByRef,
 } from "@/tools/project-read-tools";
 
 const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectSummary => ({
@@ -36,6 +39,7 @@ describe("registerTools", () => {
         "task_update",
         "task_comment_create",
         "project_list",
+        "project_show",
       ])
     );
   });
@@ -51,6 +55,62 @@ describe("formatProjectListContent", () => {
         empty: false,
       })
     ).toContain("proj-1 • Todu Pi Extensions • active • medium");
+  });
+});
+
+describe("formatProjectShowContent", () => {
+  it("formats concise project detail output", () => {
+    expect(formatProjectShowContent(createProjectSummary())).toContain(
+      "Project proj-1: Todu Pi Extensions"
+    );
+  });
+});
+
+describe("resolveProjectByRef", () => {
+  it("returns a direct project match by ID first", async () => {
+    const project = createProjectSummary();
+    const taskService = {
+      getProject: vi.fn().mockResolvedValue(project),
+      listProjects: vi.fn(),
+    } as unknown as TaskService;
+
+    await expect(resolveProjectByRef(taskService, project.id)).resolves.toEqual(project);
+    expect(taskService.getProject).toHaveBeenCalledWith(project.id);
+    expect(taskService.listProjects).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a unique project-name match", async () => {
+    const project = createProjectSummary();
+    const taskService = {
+      getProject: vi.fn().mockResolvedValue(null),
+      listProjects: vi.fn().mockResolvedValue([project]),
+    } as unknown as TaskService;
+
+    await expect(resolveProjectByRef(taskService, project.name)).resolves.toEqual(project);
+    expect(taskService.getProject).toHaveBeenCalledWith(project.name);
+    expect(taskService.listProjects).toHaveBeenCalledWith();
+  });
+
+  it("returns null when no project matches the ref", async () => {
+    const taskService = {
+      getProject: vi.fn().mockResolvedValue(null),
+      listProjects: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskService;
+
+    await expect(resolveProjectByRef(taskService, "missing-project")).resolves.toBeNull();
+  });
+
+  it("fails clearly when name matching is ambiguous", async () => {
+    const taskService = {
+      getProject: vi.fn().mockResolvedValue(null),
+      listProjects: vi
+        .fn()
+        .mockResolvedValue([createProjectSummary(), createProjectSummary({ id: "proj-2" })]),
+    } as unknown as TaskService;
+
+    await expect(resolveProjectByRef(taskService, "Todu Pi Extensions")).rejects.toThrow(
+      "project_show found multiple projects named: Todu Pi Extensions"
+    );
   });
 });
 
@@ -106,6 +166,100 @@ describe("createProjectListToolDefinition", () => {
 
     await expect(tool.execute("tool-call-1", {})).rejects.toThrow(
       "project_list failed: daemon unavailable"
+    );
+  });
+});
+
+describe("createProjectShowToolDefinition", () => {
+  it("returns project detail with a structured found result for ID lookups", async () => {
+    const project = createProjectSummary();
+    const taskService = {
+      getProject: vi.fn().mockResolvedValue(project),
+      listProjects: vi.fn(),
+    } as unknown as TaskService;
+    const tool = createProjectShowToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    const result = await tool.execute("tool-call-1", { projectRef: project.id });
+
+    expect(taskService.getProject).toHaveBeenCalledWith(project.id);
+    expect(taskService.listProjects).not.toHaveBeenCalled();
+    expect(result.content[0]?.text).toContain(`Project ${project.id}: ${project.name}`);
+    expect(result.details).toEqual({
+      kind: "project_show",
+      projectRef: project.id,
+      found: true,
+      project,
+    });
+  });
+
+  it("returns project detail with a structured found result for unique name lookups", async () => {
+    const project = createProjectSummary();
+    const taskService = {
+      getProject: vi.fn().mockResolvedValue(null),
+      listProjects: vi.fn().mockResolvedValue([project]),
+    } as unknown as TaskService;
+    const tool = createProjectShowToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    const result = await tool.execute("tool-call-1", { projectRef: project.name });
+
+    expect(taskService.getProject).toHaveBeenCalledWith(project.name);
+    expect(taskService.listProjects).toHaveBeenCalledWith();
+    expect(result.content[0]?.text).toContain(`Project ${project.id}: ${project.name}`);
+    expect(result.details).toEqual({
+      kind: "project_show",
+      projectRef: project.name,
+      found: true,
+      project,
+    });
+  });
+
+  it("returns a non-error not-found result when the project is missing", async () => {
+    const taskService = {
+      getProject: vi.fn().mockResolvedValue(null),
+      listProjects: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskService;
+    const tool = createProjectShowToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    const result = await tool.execute("tool-call-1", { projectRef: "missing-project" });
+
+    expect(result.content[0]?.text).toBe("Project not found: missing-project");
+    expect(result.details).toEqual({
+      kind: "project_show",
+      projectRef: "missing-project",
+      found: false,
+    });
+  });
+
+  it("surfaces ambiguous project-name matches clearly", async () => {
+    const tool = createProjectShowToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue({
+        getProject: vi.fn().mockResolvedValue(null),
+        listProjects: vi
+          .fn()
+          .mockResolvedValue([createProjectSummary(), createProjectSummary({ id: "proj-2" })]),
+      } as unknown as TaskService),
+    });
+
+    await expect(tool.execute("tool-call-1", { projectRef: "Todu Pi Extensions" })).rejects.toThrow(
+      "project_show failed: project_show found multiple projects named: Todu Pi Extensions"
+    );
+  });
+
+  it("surfaces service failures with tool-specific context", async () => {
+    const tool = createProjectShowToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue({
+        getProject: vi.fn().mockRejectedValue(new Error("daemon unavailable")),
+      } as unknown as TaskService),
+    });
+
+    await expect(tool.execute("tool-call-1", { projectRef: "proj-1" })).rejects.toThrow(
+      "project_show failed: daemon unavailable"
     );
   });
 });

--- a/src/tools/project-read-tools.ts
+++ b/src/tools/project-read-tools.ts
@@ -5,6 +5,9 @@ import type { ProjectSummary } from "../domain/task";
 import type { TaskService } from "../services/task-service";
 
 const ProjectListParams = Type.Object({});
+const ProjectShowParams = Type.Object({
+  projectRef: Type.String({ description: "Project ID or unique project name" }),
+});
 const MAX_PROJECT_LIST_PREVIEW_COUNT = 25;
 
 interface ProjectListToolDetails {
@@ -12,6 +15,17 @@ interface ProjectListToolDetails {
   projects: ProjectSummary[];
   total: number;
   empty: boolean;
+}
+
+interface ProjectShowToolDetails {
+  kind: "project_show";
+  projectRef: string;
+  found: boolean;
+  project?: ProjectSummary;
+}
+
+interface ProjectShowToolParams {
+  projectRef: string;
 }
 
 interface ProjectReadToolDependencies {
@@ -49,11 +63,81 @@ const createProjectListToolDefinition = ({ getTaskService }: ProjectReadToolDepe
   },
 });
 
+const createProjectShowToolDefinition = ({ getTaskService }: ProjectReadToolDependencies) => ({
+  name: "project_show",
+  label: "Project Show",
+  description: "Show project details by ID or unique name.",
+  promptSnippet: "Show details for a project by explicit ID or unique name.",
+  promptGuidelines: [
+    "Use this tool when the user asks for details about a known project.",
+    "Resolve by project ID first, then by unique name when needed.",
+    "If the project is missing or ambiguous, report that explicitly instead of guessing.",
+  ],
+  parameters: ProjectShowParams,
+  async execute(_toolCallId: string, params: ProjectShowToolParams) {
+    const projectRef = normalizeRequiredText(params.projectRef, "projectRef");
+
+    try {
+      const taskService = await getTaskService();
+      const project = await resolveProjectByRef(taskService, projectRef);
+      if (!project) {
+        const details: ProjectShowToolDetails = {
+          kind: "project_show",
+          projectRef,
+          found: false,
+        };
+
+        return {
+          content: [{ type: "text" as const, text: `Project not found: ${projectRef}` }],
+          details,
+        };
+      }
+
+      const details: ProjectShowToolDetails = {
+        kind: "project_show",
+        projectRef,
+        found: true,
+        project,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: formatProjectShowContent(project) }],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "project_show failed"), { cause: error });
+    }
+  },
+});
+
 const registerProjectReadTools = (
   pi: Pick<ExtensionAPI, "registerTool">,
   dependencies: ProjectReadToolDependencies
 ): void => {
   pi.registerTool(createProjectListToolDefinition(dependencies));
+  pi.registerTool(createProjectShowToolDefinition(dependencies));
+};
+
+const resolveProjectByRef = async (
+  taskService: TaskService,
+  projectRef: string
+): Promise<ProjectSummary | null> => {
+  const project = await taskService.getProject(projectRef);
+  if (project) {
+    return project;
+  }
+
+  const projects = await taskService.listProjects();
+  const nameMatches = projects.filter((candidate) => candidate.name === projectRef);
+  if (nameMatches.length === 0) {
+    return null;
+  }
+
+  if (nameMatches.length > 1) {
+    throw new Error(`project_show found multiple projects named: ${projectRef}`);
+  }
+
+  return nameMatches[0] ?? null;
 };
 
 const formatProjectListContent = (details: ProjectListToolDetails): string => {
@@ -76,8 +160,28 @@ const formatProjectListContent = (details: ProjectListToolDetails): string => {
   return lines.join("\n");
 };
 
+const formatProjectShowContent = (project: ProjectSummary): string =>
+  [
+    `Project ${project.id}: ${project.name}`,
+    "",
+    `Status: ${project.status}`,
+    `Priority: ${project.priority}`,
+    "",
+    "Description:",
+    project.description?.trim().length ? project.description : "(none)",
+  ].join("\n");
+
 const formatProjectSummaryLine = (project: ProjectSummary): string =>
   `${project.id} • ${project.name} • ${project.status} • ${project.priority}`;
+
+const normalizeRequiredText = (value: string, fieldName: string): string => {
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) {
+    throw new Error(`${fieldName} is required`);
+  }
+
+  return trimmedValue;
+};
 
 const formatToolError = (error: unknown, prefix: string): string => {
   if (error instanceof Error && error.message.trim().length > 0) {
@@ -87,5 +191,12 @@ const formatToolError = (error: unknown, prefix: string): string => {
   return prefix;
 };
 
-export type { ProjectListToolDetails, ProjectReadToolDependencies };
-export { createProjectListToolDefinition, formatProjectListContent, registerProjectReadTools };
+export type { ProjectListToolDetails, ProjectReadToolDependencies, ProjectShowToolDetails };
+export {
+  createProjectListToolDefinition,
+  createProjectShowToolDefinition,
+  formatProjectListContent,
+  formatProjectShowContent,
+  registerProjectReadTools,
+  resolveProjectByRef,
+};


### PR DESCRIPTION
## Summary
- add native `project_show` to the project read tools
- support project lookup by ID first and unique name as a fallback
- add focused tests and align the project-tools plan contract with project reference lookup

## Verification
- ./scripts/pre-pr.sh

Task: #task-a9b94cfe