### PR TITLE
fix: resolve project-name lookup for task creation

### DIFF
--- a/src/__tests__/task-mutation-tools.test.ts
+++ b/src/__tests__/task-mutation-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { TaskComment, TaskDetail } from "@/domain/task";
+import type { ProjectSummary, TaskComment, TaskDetail } from "@/domain/task";
 import { registerTools } from "@/extension/register-tools";
 import type { TaskService } from "@/services/task-service";
 import {
@@ -10,6 +10,8 @@ import {
   normalizeCreateTaskInput,
   normalizeTaskCommentInput,
   normalizeUpdateTaskInput,
+  resolveCreateTaskInput,
+  resolveProjectForTaskCreate,
 } from "@/tools/task-mutation-tools";
 
 const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
@@ -31,6 +33,15 @@ const createTaskComment = (overrides: Partial<TaskComment> = {}): TaskComment =>
   author: "user",
   createdAt: "2026-03-19T00:00:00.000Z",
   content: "Looks good",
+  ...overrides,
+});
+
+const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectSummary => ({
+  id: "proj-1",
+  name: "Todu Pi Extensions",
+  status: "active",
+  priority: "medium",
+  description: "Primary project",
   ...overrides,
 });
 
@@ -133,11 +144,85 @@ describe("normalizeTaskCommentInput", () => {
   });
 });
 
+describe("resolveProjectForTaskCreate", () => {
+  it("returns a direct project match by ID first", async () => {
+    const project = createProjectSummary();
+    const taskService = {
+      getProject: vi.fn().mockResolvedValue(project),
+      listProjects: vi.fn(),
+    } as unknown as TaskService;
+
+    await expect(resolveProjectForTaskCreate(taskService, project.id)).resolves.toEqual(project);
+    expect(taskService.getProject).toHaveBeenCalledWith(project.id);
+    expect(taskService.listProjects).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a unique project-name match", async () => {
+    const project = createProjectSummary();
+    const taskService = {
+      getProject: vi.fn().mockResolvedValue(null),
+      listProjects: vi.fn().mockResolvedValue([project]),
+    } as unknown as TaskService;
+
+    await expect(resolveProjectForTaskCreate(taskService, project.name)).resolves.toEqual(project);
+    expect(taskService.getProject).toHaveBeenCalledWith(project.name);
+    expect(taskService.listProjects).toHaveBeenCalledWith();
+  });
+
+  it("fails clearly when the project name does not match anything", async () => {
+    const taskService = {
+      getProject: vi.fn().mockResolvedValue(null),
+      listProjects: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskService;
+
+    await expect(resolveProjectForTaskCreate(taskService, "missing-project")).rejects.toThrow(
+      "project not found: missing-project"
+    );
+  });
+
+  it("fails clearly when the project-name match is ambiguous", async () => {
+    const taskService = {
+      getProject: vi.fn().mockResolvedValue(null),
+      listProjects: vi
+        .fn()
+        .mockResolvedValue([createProjectSummary(), createProjectSummary({ id: "proj-2" })]),
+    } as unknown as TaskService;
+
+    await expect(
+      resolveProjectForTaskCreate(taskService, "Todu Pi Extensions")
+    ).rejects.toThrow("multiple projects matched: Todu Pi Extensions");
+  });
+});
+
+describe("resolveCreateTaskInput", () => {
+  it("replaces a unique project name with the resolved project ID", async () => {
+    const project = createProjectSummary();
+    const taskService = {
+      getProject: vi.fn().mockResolvedValue(null),
+      listProjects: vi.fn().mockResolvedValue([project]),
+    } as unknown as TaskService;
+
+    await expect(
+      resolveCreateTaskInput(taskService, {
+        title: "Implement mutation tools",
+        projectId: project.name,
+        description: "Add create, update, and comment tools.",
+      })
+    ).resolves.toEqual({
+      title: "Implement mutation tools",
+      projectId: project.id,
+      description: "Add create, update, and comment tools.",
+    });
+  });
+});
+
 describe("createTaskCreateToolDefinition", () => {
   it("creates a task and returns structured details", async () => {
     const task = createTaskDetail();
     const taskService = {
       createTask: vi.fn().mockResolvedValue(task),
+      getProject: vi.fn().mockResolvedValue(createProjectSummary()),
+      listProjects: vi.fn(),
     } as unknown as TaskService;
     const tool = createTaskCreateToolDefinition({
       getTaskService: vi.fn().mockResolvedValue(taskService),
@@ -179,9 +264,68 @@ describe("createTaskCreateToolDefinition", () => {
     ).rejects.toThrow("task_create failed: title is required");
   });
 
+  it("resolves a unique project name before creating the task", async () => {
+    const project = createProjectSummary();
+    const task = createTaskDetail({ projectId: project.id, projectName: project.name });
+    const taskService = {
+      createTask: vi.fn().mockResolvedValue(task),
+      getProject: vi.fn().mockResolvedValue(null),
+      listProjects: vi.fn().mockResolvedValue([project]),
+    } as unknown as TaskService;
+    const tool = createTaskCreateToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    await tool.execute("tool-call-1", {
+      title: "Implement mutation tools",
+      projectId: project.name,
+    });
+
+    expect(taskService.createTask).toHaveBeenCalledWith({
+      title: "Implement mutation tools",
+      projectId: project.id,
+      description: undefined,
+    });
+  });
+
+  it("fails clearly when the project name is missing", async () => {
+    const tool = createTaskCreateToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue({
+        getProject: vi.fn().mockResolvedValue(null),
+        listProjects: vi.fn().mockResolvedValue([]),
+      } as unknown as TaskService),
+    });
+
+    await expect(
+      tool.execute("tool-call-1", {
+        title: "Implement mutation tools",
+        projectId: "missing-project",
+      })
+    ).rejects.toThrow("task_create failed: project not found: missing-project");
+  });
+
+  it("fails clearly when the project name is ambiguous", async () => {
+    const tool = createTaskCreateToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue({
+        getProject: vi.fn().mockResolvedValue(null),
+        listProjects: vi
+          .fn()
+          .mockResolvedValue([createProjectSummary(), createProjectSummary({ id: "proj-2" })]),
+      } as unknown as TaskService),
+    });
+
+    await expect(
+      tool.execute("tool-call-1", {
+        title: "Implement mutation tools",
+        projectId: "Todu Pi Extensions",
+      })
+    ).rejects.toThrow("task_create failed: multiple projects matched: Todu Pi Extensions");
+  });
+
   it("surfaces service failures with tool-specific context", async () => {
     const tool = createTaskCreateToolDefinition({
       getTaskService: vi.fn().mockResolvedValue({
+        getProject: vi.fn().mockResolvedValue(createProjectSummary()),
         createTask: vi.fn().mockRejectedValue(new Error("daemon unavailable")),
       } as unknown as TaskService),
     });

--- a/src/tools/task-mutation-tools.ts
+++ b/src/tools/task-mutation-tools.ts
@@ -2,7 +2,14 @@ import { StringEnum } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
-import type { TaskComment, TaskDetail, TaskId, TaskPriority, TaskStatus } from "../domain/task";
+import type {
+  ProjectSummary,
+  TaskComment,
+  TaskDetail,
+  TaskId,
+  TaskPriority,
+  TaskStatus,
+} from "../domain/task";
 import { commentOnTask } from "../flows/comment-on-task";
 import { createTask } from "../flows/create-task";
 import { updateTask } from "../flows/update-task";
@@ -18,7 +25,7 @@ const TASK_PRIORITY_VALUES = ["low", "medium", "high"] as const;
 
 const TaskCreateParams = Type.Object({
   title: Type.String({ description: "Task title" }),
-  projectId: Type.String({ description: "Project ID for the new task" }),
+  projectId: Type.String({ description: "Project ID or unique project name for the new task" }),
   description: Type.Optional(Type.String({ description: "Optional task description" })),
 });
 
@@ -87,17 +94,19 @@ interface TaskMutationToolDependencies {
 const createTaskCreateToolDefinition = ({ getTaskService }: TaskMutationToolDependencies) => ({
   name: "task_create",
   label: "Task Create",
-  description: "Create a task with a title, project ID, and optional description.",
-  promptSnippet: "Create a task when the title and explicit projectId are known.",
+  description: "Create a task with a title, project reference, and optional description.",
+  promptSnippet: "Create a task when the title and project reference are known.",
   promptGuidelines: [
     "Use this tool for backend task creation in normal chat instead of interactive slash-command flows.",
-    "Provide an explicit projectId and do not guess it.",
+    "Provide an explicit project ID when known.",
+    "If only a project name is available, pass the exact unique project name so the tool can resolve it.",
+    "Do not guess project identity.",
   ],
   parameters: TaskCreateParams,
   async execute(_toolCallId: string, params: TaskCreateToolParams) {
     try {
-      const input = normalizeCreateTaskInput(params);
       const taskService = await getTaskService();
+      const input = await resolveCreateTaskInput(taskService, params);
       const task = await createTask({ taskService }, input);
       const details: TaskCreateToolDetails = {
         kind: "task_create",
@@ -193,6 +202,49 @@ const normalizeCreateTaskInput = (params: TaskCreateToolParams): CreateTaskInput
   projectId: normalizeRequiredText(params.projectId, "projectId"),
   description: normalizeOptionalDescription(params, "description"),
 });
+
+const resolveCreateTaskInput = async (
+  taskService: TaskService,
+  params: TaskCreateToolParams
+): Promise<CreateTaskInput> => {
+  const input = normalizeCreateTaskInput(params);
+  const project = await resolveProjectForTaskCreate(
+    taskService,
+    normalizeRequiredText(input.projectId ?? "", "projectId")
+  );
+
+  return {
+    ...input,
+    projectId: project.id,
+  };
+};
+
+const resolveProjectForTaskCreate = async (
+  taskService: TaskService,
+  projectRef: string
+): Promise<ProjectSummary> => {
+  const project = await taskService.getProject(projectRef);
+  if (project) {
+    return project;
+  }
+
+  const projects = await taskService.listProjects();
+  const nameMatches = projects.filter((candidate) => candidate.name === projectRef);
+  if (nameMatches.length === 0) {
+    throw new Error(`project not found: ${projectRef}`);
+  }
+
+  if (nameMatches.length > 1) {
+    throw new Error(`multiple projects matched: ${projectRef}`);
+  }
+
+  const matchedProject = nameMatches[0];
+  if (!matchedProject) {
+    throw new Error(`project not found: ${projectRef}`);
+  }
+
+  return matchedProject;
+};
 
 const normalizeUpdateTaskInput = (params: TaskUpdateToolParams): UpdateTaskInput => {
   const input: UpdateTaskInput = {
@@ -304,4 +356,6 @@ export {
   normalizeTaskCommentInput,
   normalizeUpdateTaskInput,
   registerTaskMutationTools,
+  resolveCreateTaskInput,
+  resolveProjectForTaskCreate,
 };


### PR DESCRIPTION
## Summary
- resolve `task_create` project references by ID first, then exact unique project name
- fail clearly when the project ref is missing or ambiguous instead of passing the raw name as `projectId`
- add focused tests for project resolution and task creation behavior

## Verification
- npm test -- --run src/__tests__/task-mutation-tools.test.ts src/__tests__/project-read-tools.test.ts
- npm run lint
- npm run typecheck

Task: #task-de661ad0