### PR TITLE
feat: add dedicated project service boundary

### DIFF
--- a/src/__tests__/project-read-tools.test.ts
+++ b/src/__tests__/project-read-tools.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { ProjectSummary } from "@/domain/task";
 import { registerTools } from "@/extension/register-tools";
+import type { ProjectService } from "@/services/project-service";
 import type { TaskService } from "@/services/task-service";
 import {
   createProjectListToolDefinition,
@@ -69,46 +70,46 @@ describe("formatProjectShowContent", () => {
 describe("resolveProjectByRef", () => {
   it("returns a direct project match by ID first", async () => {
     const project = createProjectSummary();
-    const taskService = {
+    const projectService = {
       getProject: vi.fn().mockResolvedValue(project),
       listProjects: vi.fn(),
-    } as unknown as TaskService;
+    } as unknown as ProjectService;
 
-    await expect(resolveProjectByRef(taskService, project.id)).resolves.toEqual(project);
-    expect(taskService.getProject).toHaveBeenCalledWith(project.id);
-    expect(taskService.listProjects).not.toHaveBeenCalled();
+    await expect(resolveProjectByRef(projectService, project.id)).resolves.toEqual(project);
+    expect(projectService.getProject).toHaveBeenCalledWith(project.id);
+    expect(projectService.listProjects).not.toHaveBeenCalled();
   });
 
   it("falls back to a unique project-name match", async () => {
     const project = createProjectSummary();
-    const taskService = {
+    const projectService = {
       getProject: vi.fn().mockResolvedValue(null),
       listProjects: vi.fn().mockResolvedValue([project]),
-    } as unknown as TaskService;
+    } as unknown as ProjectService;
 
-    await expect(resolveProjectByRef(taskService, project.name)).resolves.toEqual(project);
-    expect(taskService.getProject).toHaveBeenCalledWith(project.name);
-    expect(taskService.listProjects).toHaveBeenCalledWith();
+    await expect(resolveProjectByRef(projectService, project.name)).resolves.toEqual(project);
+    expect(projectService.getProject).toHaveBeenCalledWith(project.name);
+    expect(projectService.listProjects).toHaveBeenCalledWith();
   });
 
   it("returns null when no project matches the ref", async () => {
-    const taskService = {
+    const projectService = {
       getProject: vi.fn().mockResolvedValue(null),
       listProjects: vi.fn().mockResolvedValue([]),
-    } as unknown as TaskService;
+    } as unknown as ProjectService;
 
-    await expect(resolveProjectByRef(taskService, "missing-project")).resolves.toBeNull();
+    await expect(resolveProjectByRef(projectService, "missing-project")).resolves.toBeNull();
   });
 
   it("fails clearly when name matching is ambiguous", async () => {
-    const taskService = {
+    const projectService = {
       getProject: vi.fn().mockResolvedValue(null),
       listProjects: vi
         .fn()
         .mockResolvedValue([createProjectSummary(), createProjectSummary({ id: "proj-2" })]),
-    } as unknown as TaskService;
+    } as unknown as ProjectService;
 
-    await expect(resolveProjectByRef(taskService, "Todu Pi Extensions")).rejects.toThrow(
+    await expect(resolveProjectByRef(projectService, "Todu Pi Extensions")).rejects.toThrow(
       "project_show found multiple projects named: Todu Pi Extensions"
     );
   });
@@ -117,16 +118,16 @@ describe("resolveProjectByRef", () => {
 describe("createProjectListToolDefinition", () => {
   it("lists projects and returns structured details", async () => {
     const projects = [createProjectSummary()];
-    const taskService = {
+    const projectService = {
       listProjects: vi.fn().mockResolvedValue(projects),
-    } as unknown as TaskService;
+    } as unknown as ProjectService;
     const tool = createProjectListToolDefinition({
-      getTaskService: vi.fn().mockResolvedValue(taskService),
+      getProjectService: vi.fn().mockResolvedValue(projectService),
     });
 
     const result = await tool.execute("tool-call-1", {});
 
-    expect(taskService.listProjects).toHaveBeenCalledWith();
+    expect(projectService.listProjects).toHaveBeenCalledWith();
     expect(result.content[0]?.type).toBe("text");
     expect(result.content[0]?.text).toContain("Projects (1):");
     expect(result.content[0]?.text).toContain("proj-1");
@@ -139,11 +140,11 @@ describe("createProjectListToolDefinition", () => {
   });
 
   it("returns a non-error empty result when no projects exist", async () => {
-    const taskService = {
+    const projectService = {
       listProjects: vi.fn().mockResolvedValue([]),
-    } as unknown as TaskService;
+    } as unknown as ProjectService;
     const tool = createProjectListToolDefinition({
-      getTaskService: vi.fn().mockResolvedValue(taskService),
+      getProjectService: vi.fn().mockResolvedValue(projectService),
     });
 
     const result = await tool.execute("tool-call-1", {});
@@ -159,9 +160,9 @@ describe("createProjectListToolDefinition", () => {
 
   it("surfaces service failures with tool-specific context", async () => {
     const tool = createProjectListToolDefinition({
-      getTaskService: vi.fn().mockResolvedValue({
+      getProjectService: vi.fn().mockResolvedValue({
         listProjects: vi.fn().mockRejectedValue(new Error("daemon unavailable")),
-      } as unknown as TaskService),
+      } as unknown as ProjectService),
     });
 
     await expect(tool.execute("tool-call-1", {})).rejects.toThrow(
@@ -173,18 +174,18 @@ describe("createProjectListToolDefinition", () => {
 describe("createProjectShowToolDefinition", () => {
   it("returns project detail with a structured found result for ID lookups", async () => {
     const project = createProjectSummary();
-    const taskService = {
+    const projectService = {
       getProject: vi.fn().mockResolvedValue(project),
       listProjects: vi.fn(),
-    } as unknown as TaskService;
+    } as unknown as ProjectService;
     const tool = createProjectShowToolDefinition({
-      getTaskService: vi.fn().mockResolvedValue(taskService),
+      getProjectService: vi.fn().mockResolvedValue(projectService),
     });
 
     const result = await tool.execute("tool-call-1", { projectRef: project.id });
 
-    expect(taskService.getProject).toHaveBeenCalledWith(project.id);
-    expect(taskService.listProjects).not.toHaveBeenCalled();
+    expect(projectService.getProject).toHaveBeenCalledWith(project.id);
+    expect(projectService.listProjects).not.toHaveBeenCalled();
     expect(result.content[0]?.text).toContain(`Project ${project.id}: ${project.name}`);
     expect(result.details).toEqual({
       kind: "project_show",
@@ -196,18 +197,18 @@ describe("createProjectShowToolDefinition", () => {
 
   it("returns project detail with a structured found result for unique name lookups", async () => {
     const project = createProjectSummary();
-    const taskService = {
+    const projectService = {
       getProject: vi.fn().mockResolvedValue(null),
       listProjects: vi.fn().mockResolvedValue([project]),
-    } as unknown as TaskService;
+    } as unknown as ProjectService;
     const tool = createProjectShowToolDefinition({
-      getTaskService: vi.fn().mockResolvedValue(taskService),
+      getProjectService: vi.fn().mockResolvedValue(projectService),
     });
 
     const result = await tool.execute("tool-call-1", { projectRef: project.name });
 
-    expect(taskService.getProject).toHaveBeenCalledWith(project.name);
-    expect(taskService.listProjects).toHaveBeenCalledWith();
+    expect(projectService.getProject).toHaveBeenCalledWith(project.name);
+    expect(projectService.listProjects).toHaveBeenCalledWith();
     expect(result.content[0]?.text).toContain(`Project ${project.id}: ${project.name}`);
     expect(result.details).toEqual({
       kind: "project_show",
@@ -218,12 +219,12 @@ describe("createProjectShowToolDefinition", () => {
   });
 
   it("returns a non-error not-found result when the project is missing", async () => {
-    const taskService = {
+    const projectService = {
       getProject: vi.fn().mockResolvedValue(null),
       listProjects: vi.fn().mockResolvedValue([]),
-    } as unknown as TaskService;
+    } as unknown as ProjectService;
     const tool = createProjectShowToolDefinition({
-      getTaskService: vi.fn().mockResolvedValue(taskService),
+      getProjectService: vi.fn().mockResolvedValue(projectService),
     });
 
     const result = await tool.execute("tool-call-1", { projectRef: "missing-project" });
@@ -238,12 +239,12 @@ describe("createProjectShowToolDefinition", () => {
 
   it("surfaces ambiguous project-name matches clearly", async () => {
     const tool = createProjectShowToolDefinition({
-      getTaskService: vi.fn().mockResolvedValue({
+      getProjectService: vi.fn().mockResolvedValue({
         getProject: vi.fn().mockResolvedValue(null),
         listProjects: vi
           .fn()
           .mockResolvedValue([createProjectSummary(), createProjectSummary({ id: "proj-2" })]),
-      } as unknown as TaskService),
+      } as unknown as ProjectService),
     });
 
     await expect(tool.execute("tool-call-1", { projectRef: "Todu Pi Extensions" })).rejects.toThrow(
@@ -253,9 +254,9 @@ describe("createProjectShowToolDefinition", () => {
 
   it("surfaces service failures with tool-specific context", async () => {
     const tool = createProjectShowToolDefinition({
-      getTaskService: vi.fn().mockResolvedValue({
+      getProjectService: vi.fn().mockResolvedValue({
         getProject: vi.fn().mockRejectedValue(new Error("daemon unavailable")),
-      } as unknown as TaskService),
+      } as unknown as ProjectService),
     });
 
     await expect(tool.execute("tool-call-1", { projectRef: "proj-1" })).rejects.toThrow(

--- a/src/__tests__/project-service.test.ts
+++ b/src/__tests__/project-service.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ProjectSummary } from "@/domain/task";
+import {
+  createProjectServiceFromTaskService,
+  type ProjectService,
+} from "@/services/project-service";
+import type { TaskService } from "@/services/task-service";
+import {
+  createToduProjectService,
+  ToduProjectServiceError,
+} from "@/services/todu/todu-project-service";
+import { ToduDaemonClientError } from "@/services/todu/daemon-client";
+
+const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectSummary => ({
+  id: "proj-1",
+  name: "Todu Pi Extensions",
+  status: "active",
+  priority: "medium",
+  description: "Primary project",
+  ...overrides,
+});
+
+describe("createProjectServiceFromTaskService", () => {
+  it("delegates project reads through the existing task service surface", async () => {
+    const projects = [createProjectSummary()];
+    const taskService = {
+      listProjects: vi.fn().mockResolvedValue(projects),
+      getProject: vi.fn().mockResolvedValue(projects[0]),
+    } as unknown as TaskService;
+
+    const projectService = createProjectServiceFromTaskService(taskService);
+
+    await expect(projectService.listProjects()).resolves.toEqual(projects);
+    await expect(projectService.getProject("proj-1")).resolves.toEqual(projects[0]);
+    expect(taskService.listProjects).toHaveBeenCalledWith();
+    expect(taskService.getProject).toHaveBeenCalledWith("proj-1");
+  });
+});
+
+describe("createToduProjectService", () => {
+  it("delegates project reads to the daemon client", async () => {
+    const projects = [createProjectSummary()];
+    const client = {
+      listProjects: vi.fn().mockResolvedValue(projects),
+      getProject: vi.fn().mockResolvedValue(projects[0]),
+    } as unknown as {
+      listProjects: ProjectService["listProjects"];
+      getProject: ProjectService["getProject"];
+    };
+
+    const projectService = createToduProjectService({ client: client as never });
+
+    await expect(projectService.listProjects()).resolves.toEqual(projects);
+    await expect(projectService.getProject("proj-1")).resolves.toEqual(projects[0]);
+    expect(client.listProjects).toHaveBeenCalledWith();
+    expect(client.getProject).toHaveBeenCalledWith("proj-1");
+  });
+
+  it("wraps daemon client failures in a project-service error", async () => {
+    const client = {
+      listProjects: vi.fn().mockRejectedValue(
+        new ToduDaemonClientError({
+          code: "unavailable",
+          method: "project.list",
+          message: "project.list failed (DAEMON_UNAVAILABLE): daemon unavailable",
+          details: { socketPath: "/tmp/daemon.sock" },
+        })
+      ),
+      getProject: vi.fn(),
+    } as unknown as {
+      listProjects: ProjectService["listProjects"];
+      getProject: ProjectService["getProject"];
+    };
+
+    const projectService = createToduProjectService({ client: client as never });
+
+    await expect(projectService.listProjects()).rejects.toEqual(
+      expect.objectContaining<ToduProjectServiceError>({
+        name: "ToduProjectServiceError",
+        operation: "listProjects",
+        causeCode: "unavailable",
+        message:
+          "listProjects failed: project.list failed (DAEMON_UNAVAILABLE): daemon unavailable",
+      })
+    );
+  });
+});

--- a/src/extension/register-tools.ts
+++ b/src/extension/register-tools.ts
@@ -1,5 +1,9 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
+import {
+  createProjectServiceFromTaskService,
+  type ProjectService,
+} from "../services/project-service";
 import type { TaskService } from "../services/task-service";
 import { getDefaultToduTaskServiceRuntime } from "../services/todu/default-task-service";
 import { registerProjectReadTools } from "../tools/project-read-tools";
@@ -8,14 +12,20 @@ import { registerTaskReadTools } from "../tools/task-read-tools";
 
 export interface RegisterToolDependencies {
   getTaskService?: () => Promise<TaskService>;
+  getProjectService?: () => Promise<ProjectService>;
 }
 
 const registerTools = (pi: ExtensionAPI, dependencies: RegisterToolDependencies = {}): void => {
-  const getTaskService =
-    dependencies.getTaskService ?? (() => getDefaultToduTaskServiceRuntime().ensureConnected());
+  const runtime = getDefaultToduTaskServiceRuntime();
+  const getTaskService = dependencies.getTaskService ?? (() => runtime.ensureConnected());
+  const getProjectService =
+    dependencies.getProjectService ??
+    (dependencies.getTaskService
+      ? async () => createProjectServiceFromTaskService(await getTaskService())
+      : () => runtime.ensureProjectServiceConnected());
 
   registerTaskReadTools(pi, { getTaskService });
-  registerProjectReadTools(pi, { getTaskService });
+  registerProjectReadTools(pi, { getProjectService });
   registerTaskMutationTools(pi, { getTaskService });
 };
 

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -1,0 +1,14 @@
+import type { ProjectSummary } from "../domain/task";
+import type { TaskService } from "./task-service";
+
+export interface ProjectService {
+  listProjects(): Promise<ProjectSummary[]>;
+  getProject(projectId: string): Promise<ProjectSummary | null>;
+}
+
+const createProjectServiceFromTaskService = (taskService: TaskService): ProjectService => ({
+  listProjects: () => taskService.listProjects(),
+  getProject: (projectId) => taskService.getProject(projectId),
+});
+
+export { createProjectServiceFromTaskService };

--- a/src/services/task-service.ts
+++ b/src/services/task-service.ts
@@ -35,6 +35,8 @@ export interface TaskService {
   createTask(input: CreateTaskInput): Promise<TaskDetail>;
   updateTask(input: UpdateTaskInput): Promise<TaskDetail>;
   addTaskComment(input: AddTaskCommentInput): Promise<TaskComment>;
+  // Project reads remain here as compatibility support for existing task flows.
+  // Future project-specific work should prefer ProjectService.
   listProjects(): Promise<ProjectSummary[]>;
   getProject(projectId: string): Promise<ProjectSummary | null>;
   listTaskComments(taskId: TaskId): Promise<TaskComment[]>;

--- a/src/services/todu/default-task-service.ts
+++ b/src/services/todu/default-task-service.ts
@@ -1,3 +1,4 @@
+import type { ProjectService } from "../project-service";
 import type { TaskService } from "../task-service";
 import { createToduDaemonClient, type ToduDaemonClient } from "./daemon-client";
 import {
@@ -5,6 +6,7 @@ import {
   type CreateToduDaemonConnectionOptions,
   type ToduDaemonConnection,
 } from "./daemon-connection";
+import { createToduProjectService } from "./todu-project-service";
 import { createToduTaskService } from "./todu-task-service";
 
 export const DEFAULT_TODU_INITIAL_CONNECT_TIMEOUT_MS = 2_000;
@@ -13,7 +15,9 @@ export interface ToduTaskServiceRuntime {
   connection: ToduDaemonConnection;
   client: ToduDaemonClient;
   taskService: TaskService;
+  projectService: ProjectService;
   ensureConnected(): Promise<TaskService>;
+  ensureProjectServiceConnected(): Promise<ProjectService>;
   disconnect(): Promise<void>;
 }
 
@@ -27,6 +31,7 @@ const createToduTaskServiceRuntime = (
   const connection = createToduDaemonConnection(options);
   const client = createToduDaemonClient({ connection });
   const taskService = createToduTaskService({ client });
+  const projectService = createToduProjectService({ client });
   const initialConnectTimeoutMs = normalizeTimeout(
     options.initialConnectTimeoutMs,
     DEFAULT_TODU_INITIAL_CONNECT_TIMEOUT_MS
@@ -36,12 +41,20 @@ const createToduTaskServiceRuntime = (
     connection,
     client,
     taskService,
+    projectService,
     ensureConnected: async () => {
       if (connection.getState().status !== "connected") {
         await connectWithinTimeout(connection, initialConnectTimeoutMs);
       }
 
       return taskService;
+    },
+    ensureProjectServiceConnected: async () => {
+      if (connection.getState().status !== "connected") {
+        await connectWithinTimeout(connection, initialConnectTimeoutMs);
+      }
+
+      return projectService;
     },
     disconnect: () => connection.disconnect(),
   };

--- a/src/services/todu/todu-project-service.ts
+++ b/src/services/todu/todu-project-service.ts
@@ -1,0 +1,59 @@
+import type { ProjectSummary } from "../../domain/task";
+import type { ProjectService } from "../project-service";
+import { ToduDaemonClientError, type ToduDaemonClient } from "./daemon-client";
+
+export class ToduProjectServiceError extends Error {
+  readonly operation: string;
+  readonly causeCode: string;
+  readonly details?: Record<string, unknown>;
+
+  constructor(options: {
+    operation: string;
+    causeCode: string;
+    message: string;
+    details?: Record<string, unknown>;
+    cause?: unknown;
+  }) {
+    super(options.message, options.cause ? { cause: options.cause } : undefined);
+    this.name = "ToduProjectServiceError";
+    this.operation = options.operation;
+    this.causeCode = options.causeCode;
+    this.details = options.details;
+  }
+}
+
+export interface ToduProjectServiceDependencies {
+  client: ToduDaemonClient;
+}
+
+const createToduProjectService = ({ client }: ToduProjectServiceDependencies): ProjectService => ({
+  listProjects: () => runProjectServiceOperation("listProjects", () => client.listProjects()),
+  getProject: (projectId) =>
+    runProjectServiceOperation("getProject", () => client.getProject(projectId)),
+});
+
+const runProjectServiceOperation = async <TProjectResult>(
+  operation: string,
+  action: () => Promise<TProjectResult>
+): Promise<TProjectResult> => {
+  try {
+    return await action();
+  } catch (error) {
+    if (error instanceof ToduDaemonClientError) {
+      throw new ToduProjectServiceError({
+        operation,
+        causeCode: error.code,
+        message: `${operation} failed: ${error.message}`,
+        details: error.details,
+        cause: error,
+      });
+    }
+
+    throw error;
+  }
+};
+
+const listProjects = async (projectService: ProjectService): Promise<ProjectSummary[]> =>
+  projectService.listProjects();
+
+export { createToduProjectService, listProjects, runProjectServiceOperation };

--- a/src/tools/project-read-tools.ts
+++ b/src/tools/project-read-tools.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
 import type { ProjectSummary } from "../domain/task";
-import type { TaskService } from "../services/task-service";
+import type { ProjectService } from "../services/project-service";
 
 const ProjectListParams = Type.Object({});
 const ProjectShowParams = Type.Object({
@@ -29,10 +29,10 @@ interface ProjectShowToolParams {
 }
 
 interface ProjectReadToolDependencies {
-  getTaskService: () => Promise<TaskService>;
+  getProjectService: () => Promise<ProjectService>;
 }
 
-const createProjectListToolDefinition = ({ getTaskService }: ProjectReadToolDependencies) => ({
+const createProjectListToolDefinition = ({ getProjectService }: ProjectReadToolDependencies) => ({
   name: "project_list",
   label: "Project List",
   description: "List projects.",
@@ -44,8 +44,8 @@ const createProjectListToolDefinition = ({ getTaskService }: ProjectReadToolDepe
   parameters: ProjectListParams,
   async execute(_toolCallId: string, _params: Record<string, never>) {
     try {
-      const taskService = await getTaskService();
-      const projects = await taskService.listProjects();
+      const projectService = await getProjectService();
+      const projects = await projectService.listProjects();
       const details: ProjectListToolDetails = {
         kind: "project_list",
         projects,
@@ -63,7 +63,7 @@ const createProjectListToolDefinition = ({ getTaskService }: ProjectReadToolDepe
   },
 });
 
-const createProjectShowToolDefinition = ({ getTaskService }: ProjectReadToolDependencies) => ({
+const createProjectShowToolDefinition = ({ getProjectService }: ProjectReadToolDependencies) => ({
   name: "project_show",
   label: "Project Show",
   description: "Show project details by ID or unique name.",
@@ -78,8 +78,8 @@ const createProjectShowToolDefinition = ({ getTaskService }: ProjectReadToolDepe
     const projectRef = normalizeRequiredText(params.projectRef, "projectRef");
 
     try {
-      const taskService = await getTaskService();
-      const project = await resolveProjectByRef(taskService, projectRef);
+      const projectService = await getProjectService();
+      const project = await resolveProjectByRef(projectService, projectRef);
       if (!project) {
         const details: ProjectShowToolDetails = {
           kind: "project_show",
@@ -119,15 +119,15 @@ const registerProjectReadTools = (
 };
 
 const resolveProjectByRef = async (
-  taskService: TaskService,
+  projectService: ProjectService,
   projectRef: string
 ): Promise<ProjectSummary | null> => {
-  const project = await taskService.getProject(projectRef);
+  const project = await projectService.getProject(projectRef);
   if (project) {
     return project;
   }
 
-  const projects = await taskService.listProjects();
+  const projects = await projectService.listProjects();
   const nameMatches = projects.filter((candidate) => candidate.name === projectRef);
   if (nameMatches.length === 0) {
     return null;


### PR DESCRIPTION
## Summary
- add a dedicated `ProjectService` interface and daemon-backed implementation for project reads
- wire the default runtime and project read tools through `ProjectService` while preserving current task flows
- add focused tests for the new project-service adapters and wiring

## Verification
- npm run format
- npm run lint
- npm run typecheck
- npm test

Task: #task-b201d6fc