### PR TITLE
feat: add daemon-backed project mutations

### DIFF
--- a/src/__tests__/daemon-client.test.ts
+++ b/src/__tests__/daemon-client.test.ts
@@ -258,6 +258,182 @@ describe("createToduDaemonClient", () => {
     });
   });
 
+  it("creates projects through project.create", async () => {
+    const connection = createConnectionMock();
+    connection.request.mockResolvedValue({
+      ok: true,
+      value: {
+        id: "proj-1",
+        name: "Created Project",
+        status: "active",
+        priority: "high",
+        description: "Created from tests",
+        createdAt: "2026-03-19T00:00:00.000Z",
+        updatedAt: "2026-03-19T00:00:00.000Z",
+      },
+    });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await expect(
+      client.createProject({
+        name: "Created Project",
+        description: "Created from tests",
+        priority: "high",
+      })
+    ).resolves.toEqual({
+      id: "proj-1",
+      name: "Created Project",
+      status: "active",
+      priority: "high",
+      description: "Created from tests",
+    });
+    expect(connection.request).toHaveBeenCalledWith("project.create", {
+      input: {
+        name: "Created Project",
+        description: "Created from tests",
+        priority: "high",
+      },
+    });
+  });
+
+  it("updates projects through project.update", async () => {
+    const connection = createConnectionMock();
+    connection.request.mockResolvedValue({
+      ok: true,
+      value: {
+        id: "proj-1",
+        name: "Updated Project",
+        status: "canceled",
+        priority: "low",
+        description: "Updated from tests",
+        createdAt: "2026-03-19T00:00:00.000Z",
+        updatedAt: "2026-03-20T00:00:00.000Z",
+      },
+    });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await expect(
+      client.updateProject({
+        projectId: "proj-1",
+        name: "Updated Project",
+        description: "Updated from tests",
+        status: "cancelled",
+        priority: "low",
+      })
+    ).resolves.toEqual({
+      id: "proj-1",
+      name: "Updated Project",
+      status: "cancelled",
+      priority: "low",
+      description: "Updated from tests",
+    });
+    expect(connection.request).toHaveBeenCalledWith("project.update", {
+      id: "proj-1",
+      input: {
+        name: "Updated Project",
+        description: "Updated from tests",
+        status: "canceled",
+        priority: "low",
+      },
+    });
+  });
+
+  it("deletes projects through project.delete", async () => {
+    const connection = createConnectionMock();
+    connection.request.mockResolvedValue({
+      ok: true,
+      value: null,
+    });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await expect(client.deleteProject("proj-1")).resolves.toEqual({
+      projectId: "proj-1",
+      deleted: true,
+    });
+    expect(connection.request).toHaveBeenCalledWith("project.delete", { id: "proj-1" });
+  });
+
+  it("maps project mutation failures into client errors", async () => {
+    const connection = createConnectionMock();
+    connection.request
+      .mockResolvedValueOnce({
+        ok: false,
+        error: {
+          code: "CONFLICT",
+          message: "duplicate project name",
+          details: { name: "Created Project" },
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: "project not found",
+          details: { id: "proj-missing" },
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "invalid project update",
+          details: { field: "status" },
+        },
+      });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await expect(client.createProject({ name: "Created Project" })).rejects.toEqual(
+      expect.objectContaining({
+        name: "ToduDaemonClientError",
+        code: "conflict",
+        method: "project.create",
+        message: "project.create failed (CONFLICT): duplicate project name",
+      })
+    );
+    await expect(
+      client.updateProject({ projectId: "proj-missing", name: "Updated Project" })
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: "ToduDaemonClientError",
+        code: "not-found",
+        method: "project.update",
+        message: "project.update failed (NOT_FOUND): project not found",
+      })
+    );
+    await expect(client.deleteProject("proj-1")).rejects.toEqual(
+      expect.objectContaining({
+        name: "ToduDaemonClientError",
+        code: "validation",
+        method: "project.delete",
+        message: "project.delete failed (VALIDATION_ERROR): invalid project update",
+      })
+    );
+  });
+
   it("adapts event subscriptions through the connection manager", async () => {
     const connection = createConnectionMock();
     const subscription = { unsubscribe: vi.fn() };

--- a/src/__tests__/project-service.test.ts
+++ b/src/__tests__/project-service.test.ts
@@ -36,41 +36,106 @@ describe("createProjectServiceFromTaskService", () => {
     expect(taskService.listProjects).toHaveBeenCalledWith();
     expect(taskService.getProject).toHaveBeenCalledWith("proj-1");
   });
+
+  it("rejects project mutations through the task-service compatibility adapter", async () => {
+    const projectService = createProjectServiceFromTaskService({} as TaskService);
+
+    await expect(projectService.createProject({ name: "New Project" })).rejects.toThrow(
+      "createProject is not supported by TaskService"
+    );
+    await expect(
+      projectService.updateProject({ projectId: "proj-1", name: "Renamed" })
+    ).rejects.toThrow("updateProject is not supported by TaskService");
+    await expect(projectService.deleteProject("proj-1")).rejects.toThrow(
+      "deleteProject is not supported by TaskService"
+    );
+  });
 });
 
 describe("createToduProjectService", () => {
-  it("delegates project reads to the daemon client", async () => {
+  it("delegates project reads and mutations to the daemon client", async () => {
     const projects = [createProjectSummary()];
+    const createdProject = createProjectSummary({ id: "proj-2", name: "Created Project" });
+    const updatedProject = createProjectSummary({ name: "Updated Project", priority: "high" });
     const client = {
       listProjects: vi.fn().mockResolvedValue(projects),
       getProject: vi.fn().mockResolvedValue(projects[0]),
+      createProject: vi.fn().mockResolvedValue(createdProject),
+      updateProject: vi.fn().mockResolvedValue(updatedProject),
+      deleteProject: vi.fn().mockResolvedValue({ projectId: "proj-1", deleted: true }),
     } as unknown as {
       listProjects: ProjectService["listProjects"];
       getProject: ProjectService["getProject"];
+      createProject: ProjectService["createProject"];
+      updateProject: ProjectService["updateProject"];
+      deleteProject: ProjectService["deleteProject"];
     };
 
     const projectService = createToduProjectService({ client: client as never });
 
     await expect(projectService.listProjects()).resolves.toEqual(projects);
     await expect(projectService.getProject("proj-1")).resolves.toEqual(projects[0]);
+    await expect(projectService.createProject({ name: "Created Project" })).resolves.toEqual(
+      createdProject
+    );
+    await expect(
+      projectService.updateProject({ projectId: "proj-1", name: "Updated Project" })
+    ).resolves.toEqual(updatedProject);
+    await expect(projectService.deleteProject("proj-1")).resolves.toEqual({
+      projectId: "proj-1",
+      deleted: true,
+    });
     expect(client.listProjects).toHaveBeenCalledWith();
     expect(client.getProject).toHaveBeenCalledWith("proj-1");
+    expect(client.createProject).toHaveBeenCalledWith({ name: "Created Project" });
+    expect(client.updateProject).toHaveBeenCalledWith({
+      projectId: "proj-1",
+      name: "Updated Project",
+    });
+    expect(client.deleteProject).toHaveBeenCalledWith("proj-1");
   });
 
   it("wraps daemon client failures in a project-service error", async () => {
     const client = {
       listProjects: vi.fn().mockRejectedValue(
         new ToduDaemonClientError({
-          code: "unavailable",
+          code: "validation",
           method: "project.list",
-          message: "project.list failed (DAEMON_UNAVAILABLE): daemon unavailable",
-          details: { socketPath: "/tmp/daemon.sock" },
+          message: "project.list failed (VALIDATION_ERROR): invalid request",
+          details: { field: "filter" },
         })
       ),
       getProject: vi.fn(),
+      createProject: vi.fn().mockRejectedValue(
+        new ToduDaemonClientError({
+          code: "conflict",
+          method: "project.create",
+          message: "project.create failed (CONFLICT): duplicate project name",
+          details: { name: "Todu Pi Extensions" },
+        })
+      ),
+      updateProject: vi.fn().mockRejectedValue(
+        new ToduDaemonClientError({
+          code: "not-found",
+          method: "project.update",
+          message: "project.update failed (NOT_FOUND): project not found",
+          details: { id: "proj-missing" },
+        })
+      ),
+      deleteProject: vi.fn().mockRejectedValue(
+        new ToduDaemonClientError({
+          code: "unavailable",
+          method: "project.delete",
+          message: "project.delete failed (DAEMON_UNAVAILABLE): daemon unavailable",
+          details: { socketPath: "/tmp/daemon.sock" },
+        })
+      ),
     } as unknown as {
       listProjects: ProjectService["listProjects"];
       getProject: ProjectService["getProject"];
+      createProject: ProjectService["createProject"];
+      updateProject: ProjectService["updateProject"];
+      deleteProject: ProjectService["deleteProject"];
     };
 
     const projectService = createToduProjectService({ client: client as never });
@@ -79,9 +144,35 @@ describe("createToduProjectService", () => {
       expect.objectContaining<ToduProjectServiceError>({
         name: "ToduProjectServiceError",
         operation: "listProjects",
+        causeCode: "validation",
+        message: "listProjects failed: project.list failed (VALIDATION_ERROR): invalid request",
+      })
+    );
+    await expect(projectService.createProject({ name: "Todu Pi Extensions" })).rejects.toEqual(
+      expect.objectContaining<ToduProjectServiceError>({
+        name: "ToduProjectServiceError",
+        operation: "createProject",
+        causeCode: "conflict",
+        message: "createProject failed: project.create failed (CONFLICT): duplicate project name",
+      })
+    );
+    await expect(
+      projectService.updateProject({ projectId: "proj-missing", name: "Renamed" })
+    ).rejects.toEqual(
+      expect.objectContaining<ToduProjectServiceError>({
+        name: "ToduProjectServiceError",
+        operation: "updateProject",
+        causeCode: "not-found",
+        message: "updateProject failed: project.update failed (NOT_FOUND): project not found",
+      })
+    );
+    await expect(projectService.deleteProject("proj-1")).rejects.toEqual(
+      expect.objectContaining<ToduProjectServiceError>({
+        name: "ToduProjectServiceError",
+        operation: "deleteProject",
         causeCode: "unavailable",
         message:
-          "listProjects failed: project.list failed (DAEMON_UNAVAILABLE): daemon unavailable",
+          "deleteProject failed: project.delete failed (DAEMON_UNAVAILABLE): daemon unavailable",
       })
     );
   });

--- a/src/__tests__/todu-task-service.test.ts
+++ b/src/__tests__/todu-task-service.test.ts
@@ -33,6 +33,9 @@ describe("createToduTaskService", () => {
       addTaskComment: vi.fn(),
       listProjects: vi.fn().mockResolvedValue([project]),
       getProject: vi.fn().mockResolvedValue(project),
+      createProject: vi.fn(),
+      updateProject: vi.fn(),
+      deleteProject: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -75,6 +78,9 @@ describe("createToduTaskService", () => {
       addTaskComment: vi.fn(),
       listProjects: vi.fn(),
       getProject: vi.fn().mockResolvedValue(project),
+      createProject: vi.fn(),
+      updateProject: vi.fn(),
+      deleteProject: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -120,6 +126,9 @@ describe("createToduTaskService", () => {
       addTaskComment: vi.fn(),
       listProjects: vi.fn().mockResolvedValue([]),
       getProject: vi.fn().mockResolvedValue(null),
+      createProject: vi.fn(),
+      updateProject: vi.fn(),
+      deleteProject: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -170,6 +179,9 @@ describe("createToduTaskService", () => {
         )
         .mockResolvedValueOnce([project]),
       getProject: vi.fn().mockResolvedValue(project),
+      createProject: vi.fn(),
+      updateProject: vi.fn(),
+      deleteProject: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -231,6 +243,9 @@ describe("createToduTaskService", () => {
           })
         )
         .mockResolvedValueOnce(project),
+      createProject: vi.fn(),
+      updateProject: vi.fn(),
+      deleteProject: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -1,14 +1,39 @@
-import type { ProjectSummary } from "../domain/task";
+import type { ProjectSummary, TaskPriority } from "../domain/task";
 import type { TaskService } from "./task-service";
+
+export interface CreateProjectInput {
+  name: string;
+  description?: string | null;
+  priority?: TaskPriority;
+}
+
+export interface UpdateProjectInput {
+  projectId: string;
+  name?: string;
+  description?: string | null;
+  status?: ProjectSummary["status"];
+  priority?: TaskPriority;
+}
+
+export interface DeleteProjectResult {
+  projectId: string;
+  deleted: true;
+}
 
 export interface ProjectService {
   listProjects(): Promise<ProjectSummary[]>;
   getProject(projectId: string): Promise<ProjectSummary | null>;
+  createProject(input: CreateProjectInput): Promise<ProjectSummary>;
+  updateProject(input: UpdateProjectInput): Promise<ProjectSummary>;
+  deleteProject(projectId: string): Promise<DeleteProjectResult>;
 }
 
 const createProjectServiceFromTaskService = (taskService: TaskService): ProjectService => ({
   listProjects: () => taskService.listProjects(),
   getProject: (projectId) => taskService.getProject(projectId),
+  createProject: () => Promise.reject(new Error("createProject is not supported by TaskService")),
+  updateProject: () => Promise.reject(new Error("updateProject is not supported by TaskService")),
+  deleteProject: () => Promise.reject(new Error("deleteProject is not supported by TaskService")),
 });
 
 export { createProjectServiceFromTaskService };

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -8,6 +8,7 @@ import type {
 } from "@todu/core";
 
 import type {
+  ProjectSummary,
   TaskComment,
   TaskDetail,
   TaskFilter,
@@ -16,6 +17,11 @@ import type {
   TaskStatus,
   TaskSummary,
 } from "../../domain/task";
+import type {
+  CreateProjectInput,
+  DeleteProjectResult,
+  UpdateProjectInput as UpdateLocalProjectInput,
+} from "../project-service";
 import type { AddTaskCommentInput, CreateTaskInput, UpdateTaskInput } from "../task-service";
 import type { ToduDaemonConnection, ToduDaemonConnectionError } from "./daemon-connection";
 import type {
@@ -69,6 +75,9 @@ export interface ToduDaemonClient {
   addTaskComment(input: AddTaskCommentInput): Promise<TaskComment>;
   listProjects(): Promise<ToduProjectSummary[]>;
   getProject(projectId: string): Promise<ToduProjectSummary | null>;
+  createProject(input: CreateProjectInput): Promise<ToduProjectSummary>;
+  updateProject(input: UpdateLocalProjectInput): Promise<ToduProjectSummary>;
+  deleteProject(projectId: string): Promise<DeleteProjectResult>;
   listTaskComments(taskId: TaskId): Promise<TaskComment[]>;
   on(
     eventName: ToduDaemonEventName,
@@ -163,6 +172,41 @@ const createToduDaemonClient = ({
     return mapProjectSummary(result.value);
   },
 
+  async createProject(input: CreateProjectInput): Promise<ToduProjectSummary> {
+    const result = await connection.request<ToduProject>("project.create", {
+      input: mapCreateProjectInput(input),
+    });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("project.create", result.error);
+    }
+
+    return mapProjectSummary(result.value);
+  },
+
+  async updateProject(input: UpdateLocalProjectInput): Promise<ToduProjectSummary> {
+    const result = await connection.request<ToduProject>("project.update", {
+      id: input.projectId,
+      input: mapUpdateProjectInput(input),
+    });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("project.update", result.error);
+    }
+
+    return mapProjectSummary(result.value);
+  },
+
+  async deleteProject(projectId: string): Promise<DeleteProjectResult> {
+    const result = await connection.request<null>("project.delete", { id: projectId });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("project.delete", result.error);
+    }
+
+    return {
+      projectId,
+      deleted: true,
+    };
+  },
+
   async listTaskComments(taskId: TaskId): Promise<TaskComment[]> {
     return fetchTaskComments(connection, taskId);
   },
@@ -251,6 +295,19 @@ const mapProjectSummary = (project: ToduProject): ToduProjectSummary => ({
   status: toLocalProjectStatus(project.status),
   priority: toLocalTaskPriority(project.priority),
   description: project.description ?? null,
+});
+
+const mapCreateProjectInput = (input: CreateProjectInput): Record<string, unknown> => ({
+  name: input.name,
+  description: input.description ?? undefined,
+  priority: input.priority ?? undefined,
+});
+
+const mapUpdateProjectInput = (input: UpdateLocalProjectInput): Record<string, unknown> => ({
+  name: input.name ?? undefined,
+  description: input.description ?? undefined,
+  status: input.status ? toRemoteProjectStatus(input.status) : undefined,
+  priority: input.priority ?? undefined,
 });
 
 const mapTaskFilter = (filter: TaskFilter): Record<string, unknown> => {
@@ -361,9 +418,15 @@ const toLocalTaskPriority = (priority: ToduTaskPriority): TaskPriority => priori
 
 const toRemoteTaskPriority = (priority: TaskPriority): ToduTaskPriority => priority;
 
+const toRemoteProjectStatus = (status: ProjectSummary["status"]): string =>
+  status === "cancelled" ? "canceled" : status;
+
 export {
   createToduDaemonClient,
+  mapCreateProjectInput,
   mapDaemonErrorToClientError,
+  mapUpdateProjectInput,
   toLocalTaskStatus,
+  toRemoteProjectStatus,
   toRemoteTaskStatus,
 };

--- a/src/services/todu/todu-project-service.ts
+++ b/src/services/todu/todu-project-service.ts
@@ -1,5 +1,9 @@
-import type { ProjectSummary } from "../../domain/task";
-import type { ProjectService } from "../project-service";
+import type {
+  CreateProjectInput,
+  DeleteProjectResult,
+  ProjectService,
+  UpdateProjectInput,
+} from "../project-service";
 import { ToduDaemonClientError, type ToduDaemonClient } from "./daemon-client";
 
 export class ToduProjectServiceError extends Error {
@@ -30,6 +34,12 @@ const createToduProjectService = ({ client }: ToduProjectServiceDependencies): P
   listProjects: () => runProjectServiceOperation("listProjects", () => client.listProjects()),
   getProject: (projectId) =>
     runProjectServiceOperation("getProject", () => client.getProject(projectId)),
+  createProject: (input) =>
+    runProjectServiceOperation("createProject", () => client.createProject(input)),
+  updateProject: (input) =>
+    runProjectServiceOperation("updateProject", () => client.updateProject(input)),
+  deleteProject: (projectId) =>
+    runProjectServiceOperation("deleteProject", () => client.deleteProject(projectId)),
 });
 
 const runProjectServiceOperation = async <TProjectResult>(
@@ -53,7 +63,24 @@ const runProjectServiceOperation = async <TProjectResult>(
   }
 };
 
-const listProjects = async (projectService: ProjectService): Promise<ProjectSummary[]> =>
-  projectService.listProjects();
+const listProjects = async (projectService: ProjectService) => projectService.listProjects();
 
-export { createToduProjectService, listProjects, runProjectServiceOperation };
+const createProject = async (projectService: ProjectService, input: CreateProjectInput) =>
+  projectService.createProject(input);
+
+const updateProject = async (projectService: ProjectService, input: UpdateProjectInput) =>
+  projectService.updateProject(input);
+
+const deleteProject = async (
+  projectService: ProjectService,
+  projectId: string
+): Promise<DeleteProjectResult> => projectService.deleteProject(projectId);
+
+export {
+  createProject,
+  createToduProjectService,
+  deleteProject,
+  listProjects,
+  runProjectServiceOperation,
+  updateProject,
+};


### PR DESCRIPTION
## Summary
- add typed daemon-backed project create, update, and delete support
- extend `ProjectService` with matching mutation operations and service-level error wrapping
- add focused tests for project mutation mapping and failure handling

## Verification
- npm run format
- npm run lint
- npm run typecheck
- npm test

Task: #task-1b16a357