### PR TITLE
feat: add native project CRUD tools

### DIFF
--- a/src/__tests__/project-mutation-tools.test.ts
+++ b/src/__tests__/project-mutation-tools.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ProjectSummary } from "@/domain/task";
+import { registerTools } from "@/extension/register-tools";
+import type { ProjectService } from "@/services/project-service";
+import type { TaskService } from "@/services/task-service";
+import { ToduProjectServiceError } from "@/services/todu/todu-project-service";
+import {
+  createProjectCreateToolDefinition,
+  createProjectDeleteToolDefinition,
+  createProjectUpdateToolDefinition,
+  normalizeCreateProjectInput,
+  normalizeUpdateProjectInput,
+} from "@/tools/project-mutation-tools";
+
+const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectSummary => ({
+  id: "proj-1",
+  name: "Todu Pi Extensions",
+  status: "active",
+  priority: "medium",
+  description: "Primary project",
+  ...overrides,
+});
+
+describe("registerTools", () => {
+  it("registers the native project mutation tools", () => {
+    const pi = {
+      registerTool: vi.fn(),
+    };
+
+    registerTools(pi as never, {
+      getTaskService: vi.fn().mockResolvedValue({} as TaskService),
+      getProjectService: vi.fn().mockResolvedValue({} as ProjectService),
+    });
+
+    const registeredToolNames = pi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(registeredToolNames).toEqual(
+      expect.arrayContaining(["project_create", "project_update", "project_delete"])
+    );
+  });
+});
+
+describe("normalizeCreateProjectInput", () => {
+  it("trims required text fields and normalizes blank descriptions to null", () => {
+    expect(
+      normalizeCreateProjectInput({
+        name: "  Todu Pi Extensions  ",
+        description: "   ",
+        priority: "high",
+      })
+    ).toEqual({
+      name: "Todu Pi Extensions",
+      description: null,
+      priority: "high",
+    });
+  });
+
+  it("rejects blank names", () => {
+    expect(() => normalizeCreateProjectInput({ name: "   " })).toThrow("name is required");
+  });
+});
+
+describe("normalizeUpdateProjectInput", () => {
+  it("requires at least one supported mutation field", () => {
+    expect(() => normalizeUpdateProjectInput({ projectId: "proj-1" })).toThrow(
+      "project_update requires at least one supported field: name, description, status, or priority"
+    );
+  });
+
+  it("trims replacement names and clears blank descriptions", () => {
+    expect(
+      normalizeUpdateProjectInput({
+        projectId: " proj-1 ",
+        name: "  Updated Project  ",
+        description: "   ",
+        priority: "low",
+      })
+    ).toEqual({
+      projectId: "proj-1",
+      name: "Updated Project",
+      status: undefined,
+      priority: "low",
+      description: null,
+    });
+  });
+});
+
+describe("createProjectCreateToolDefinition", () => {
+  it("creates a project and returns structured details", async () => {
+    const project = createProjectSummary({ name: "Created Project", priority: "high" });
+    const projectService = {
+      createProject: vi.fn().mockResolvedValue(project),
+    } as unknown as ProjectService;
+    const tool = createProjectCreateToolDefinition({
+      getProjectService: vi.fn().mockResolvedValue(projectService),
+    });
+
+    const result = await tool.execute("tool-call-1", {
+      name: "  Created Project  ",
+      description: "  Created from tool  ",
+      priority: "high",
+    });
+
+    expect(projectService.createProject).toHaveBeenCalledWith({
+      name: "Created Project",
+      description: "Created from tool",
+      priority: "high",
+    });
+    expect(result.content[0]?.text).toContain(`Created project ${project.id}: ${project.name}`);
+    expect(result.details).toEqual({
+      kind: "project_create",
+      input: {
+        name: "Created Project",
+        description: "Created from tool",
+        priority: "high",
+      },
+      project,
+    });
+  });
+
+  it("surfaces validation failures with tool-specific context", async () => {
+    const tool = createProjectCreateToolDefinition({
+      getProjectService: vi.fn().mockResolvedValue({} as ProjectService),
+    });
+
+    await expect(tool.execute("tool-call-1", { name: "   " })).rejects.toThrow(
+      "project_create failed: name is required"
+    );
+  });
+
+  it("surfaces service failures with tool-specific context", async () => {
+    const tool = createProjectCreateToolDefinition({
+      getProjectService: vi.fn().mockResolvedValue({
+        createProject: vi.fn().mockRejectedValue(new Error("duplicate project name")),
+      } as unknown as ProjectService),
+    });
+
+    await expect(tool.execute("tool-call-1", { name: "Created Project" })).rejects.toThrow(
+      "project_create failed: duplicate project name"
+    );
+  });
+});
+
+describe("createProjectUpdateToolDefinition", () => {
+  it("updates supported fields and returns structured details", async () => {
+    const project = createProjectSummary({
+      name: "Updated Project",
+      status: "done",
+      priority: "high",
+      description: null,
+    });
+    const projectService = {
+      updateProject: vi.fn().mockResolvedValue(project),
+    } as unknown as ProjectService;
+    const tool = createProjectUpdateToolDefinition({
+      getProjectService: vi.fn().mockResolvedValue(projectService),
+    });
+
+    const result = await tool.execute("tool-call-1", {
+      projectId: " proj-1 ",
+      name: "  Updated Project  ",
+      status: "done",
+      priority: "high",
+      description: "   ",
+    });
+
+    expect(projectService.updateProject).toHaveBeenCalledWith({
+      projectId: "proj-1",
+      name: "Updated Project",
+      status: "done",
+      priority: "high",
+      description: null,
+    });
+    expect(result.content[0]?.text).toContain(`Updated project ${project.id}: ${project.name}`);
+    expect(result.content[0]?.text).toContain(
+      'Changes: name="Updated Project", status=done, priority=high, description=cleared'
+    );
+    expect(result.details).toEqual({
+      kind: "project_update",
+      input: {
+        projectId: "proj-1",
+        name: "Updated Project",
+        status: "done",
+        priority: "high",
+        description: null,
+      },
+      project,
+    });
+  });
+
+  it("fails fast when no supported fields are provided", async () => {
+    const tool = createProjectUpdateToolDefinition({
+      getProjectService: vi.fn().mockResolvedValue({} as ProjectService),
+    });
+
+    await expect(tool.execute("tool-call-1", { projectId: "proj-1" })).rejects.toThrow(
+      "project_update failed: project_update requires at least one supported field: name, description, status, or priority"
+    );
+  });
+
+  it("surfaces service failures with tool-specific context", async () => {
+    const tool = createProjectUpdateToolDefinition({
+      getProjectService: vi.fn().mockResolvedValue({
+        updateProject: vi.fn().mockRejectedValue(new Error("project not found")),
+      } as unknown as ProjectService),
+    });
+
+    await expect(
+      tool.execute("tool-call-1", { projectId: "proj-1", priority: "low" })
+    ).rejects.toThrow("project_update failed: project not found");
+  });
+});
+
+describe("createProjectDeleteToolDefinition", () => {
+  it("deletes a project and returns structured details", async () => {
+    const projectService = {
+      deleteProject: vi.fn().mockResolvedValue({ projectId: "proj-1", deleted: true }),
+    } as unknown as ProjectService;
+    const tool = createProjectDeleteToolDefinition({
+      getProjectService: vi.fn().mockResolvedValue(projectService),
+    });
+
+    const result = await tool.execute("tool-call-1", { projectId: " proj-1 " });
+
+    expect(projectService.deleteProject).toHaveBeenCalledWith("proj-1");
+    expect(result.content[0]?.text).toBe("Deleted project proj-1.");
+    expect(result.details).toEqual({
+      kind: "project_delete",
+      projectId: "proj-1",
+      found: true,
+      deleted: true,
+      project: { projectId: "proj-1", deleted: true },
+    });
+  });
+
+  it("returns an explicit not-found result when the project is missing", async () => {
+    const tool = createProjectDeleteToolDefinition({
+      getProjectService: vi.fn().mockResolvedValue({
+        deleteProject: vi.fn().mockRejectedValue(
+          new ToduProjectServiceError({
+            operation: "deleteProject",
+            causeCode: "not-found",
+            message: "deleteProject failed: project.delete failed (NOT_FOUND): project not found",
+          })
+        ),
+      } as unknown as ProjectService),
+    });
+
+    const result = await tool.execute("tool-call-1", { projectId: "proj-missing" });
+
+    expect(result.content[0]?.text).toBe("Project not found: proj-missing");
+    expect(result.details).toEqual({
+      kind: "project_delete",
+      projectId: "proj-missing",
+      found: false,
+      deleted: false,
+    });
+  });
+
+  it("surfaces backend failures with tool-specific context", async () => {
+    const tool = createProjectDeleteToolDefinition({
+      getProjectService: vi.fn().mockResolvedValue({
+        deleteProject: vi.fn().mockRejectedValue(new Error("backend refusal")),
+      } as unknown as ProjectService),
+    });
+
+    await expect(tool.execute("tool-call-1", { projectId: "proj-1" })).rejects.toThrow(
+      "project_delete failed: backend refusal"
+    );
+  });
+});

--- a/src/__tests__/project-read-tools.test.ts
+++ b/src/__tests__/project-read-tools.test.ts
@@ -41,6 +41,9 @@ describe("registerTools", () => {
         "task_comment_create",
         "project_list",
         "project_show",
+        "project_create",
+        "project_update",
+        "project_delete",
       ])
     );
   });

--- a/src/extension/register-tools.ts
+++ b/src/extension/register-tools.ts
@@ -6,6 +6,7 @@ import {
 } from "../services/project-service";
 import type { TaskService } from "../services/task-service";
 import { getDefaultToduTaskServiceRuntime } from "../services/todu/default-task-service";
+import { registerProjectMutationTools } from "../tools/project-mutation-tools";
 import { registerProjectReadTools } from "../tools/project-read-tools";
 import { registerTaskMutationTools } from "../tools/task-mutation-tools";
 import { registerTaskReadTools } from "../tools/task-read-tools";
@@ -26,6 +27,7 @@ const registerTools = (pi: ExtensionAPI, dependencies: RegisterToolDependencies 
 
   registerTaskReadTools(pi, { getTaskService });
   registerProjectReadTools(pi, { getProjectService });
+  registerProjectMutationTools(pi, { getProjectService });
   registerTaskMutationTools(pi, { getTaskService });
 };
 

--- a/src/tools/project-mutation-tools.ts
+++ b/src/tools/project-mutation-tools.ts
@@ -1,0 +1,328 @@
+import { StringEnum } from "@mariozechner/pi-ai";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+
+import type { ProjectSummary, TaskPriority } from "../domain/task";
+import type {
+  CreateProjectInput,
+  DeleteProjectResult,
+  ProjectService,
+  UpdateProjectInput,
+} from "../services/project-service";
+import { ToduProjectServiceError } from "../services/todu/todu-project-service";
+
+const PROJECT_STATUS_VALUES = ["active", "done", "cancelled"] as const;
+const PROJECT_PRIORITY_VALUES = ["low", "medium", "high"] as const;
+
+const ProjectCreateParams = Type.Object({
+  name: Type.String({ description: "Project name" }),
+  description: Type.Optional(Type.String({ description: "Optional project description" })),
+  priority: Type.Optional(
+    StringEnum(PROJECT_PRIORITY_VALUES, { description: "Optional project priority" })
+  ),
+});
+
+const ProjectUpdateParams = Type.Object({
+  projectId: Type.String({ description: "Project ID" }),
+  name: Type.Optional(Type.String({ description: "Optional replacement project name" })),
+  description: Type.Optional(
+    Type.String({
+      description: "Optional replacement description. Use an empty string to clear it.",
+    })
+  ),
+  status: Type.Optional(
+    StringEnum(PROJECT_STATUS_VALUES, { description: "Optional next project status" })
+  ),
+  priority: Type.Optional(
+    StringEnum(PROJECT_PRIORITY_VALUES, { description: "Optional next project priority" })
+  ),
+});
+
+const ProjectDeleteParams = Type.Object({
+  projectId: Type.String({ description: "Project ID" }),
+});
+
+interface ProjectCreateToolParams {
+  name: string;
+  description?: string;
+  priority?: TaskPriority;
+}
+
+interface ProjectUpdateToolParams {
+  projectId: string;
+  name?: string;
+  description?: string;
+  status?: ProjectSummary["status"];
+  priority?: TaskPriority;
+}
+
+interface ProjectDeleteToolParams {
+  projectId: string;
+}
+
+interface ProjectCreateToolDetails {
+  kind: "project_create";
+  input: CreateProjectInput;
+  project: ProjectSummary;
+}
+
+interface ProjectUpdateToolDetails {
+  kind: "project_update";
+  input: UpdateProjectInput;
+  project: ProjectSummary;
+}
+
+interface ProjectDeleteToolDetails {
+  kind: "project_delete";
+  projectId: string;
+  found: boolean;
+  deleted: boolean;
+  project?: DeleteProjectResult;
+}
+
+interface ProjectMutationToolDependencies {
+  getProjectService: () => Promise<ProjectService>;
+}
+
+const createProjectCreateToolDefinition = ({
+  getProjectService,
+}: ProjectMutationToolDependencies) => ({
+  name: "project_create",
+  label: "Project Create",
+  description: "Create a plain project record.",
+  promptSnippet: "Create a plain project record through the native project service.",
+  promptGuidelines: [
+    "Use this tool for plain project record creation in normal chat.",
+    "Do not use it for repository registration or integration-binding behavior.",
+  ],
+  parameters: ProjectCreateParams,
+  async execute(_toolCallId: string, params: ProjectCreateToolParams) {
+    try {
+      const input = normalizeCreateProjectInput(params);
+      const projectService = await getProjectService();
+      const project = await projectService.createProject(input);
+      const details: ProjectCreateToolDetails = {
+        kind: "project_create",
+        input,
+        project,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: formatProjectCreateContent(project) }],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "project_create failed"), { cause: error });
+    }
+  },
+});
+
+const createProjectUpdateToolDefinition = ({
+  getProjectService,
+}: ProjectMutationToolDependencies) => ({
+  name: "project_update",
+  label: "Project Update",
+  description: "Update a plain project's name, description, status, or priority.",
+  promptSnippet: "Update a plain project record by explicit project ID.",
+  promptGuidelines: [
+    "Use this tool for plain project-record updates in normal chat.",
+    "Supported fields are name, description, status, and priority.",
+    "Do not use it for repo inspection or integration-binding changes.",
+  ],
+  parameters: ProjectUpdateParams,
+  async execute(_toolCallId: string, params: ProjectUpdateToolParams) {
+    try {
+      const input = normalizeUpdateProjectInput(params);
+      const projectService = await getProjectService();
+      const project = await projectService.updateProject(input);
+      const details: ProjectUpdateToolDetails = {
+        kind: "project_update",
+        input,
+        project,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: formatProjectUpdateContent(project, input) }],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "project_update failed"), { cause: error });
+    }
+  },
+});
+
+const createProjectDeleteToolDefinition = ({
+  getProjectService,
+}: ProjectMutationToolDependencies) => ({
+  name: "project_delete",
+  label: "Project Delete",
+  description: "Delete a plain project record by explicit project ID.",
+  promptSnippet: "Delete a plain project record by explicit project ID.",
+  promptGuidelines: [
+    "Use this tool for plain project deletion in normal chat.",
+    "Do not use it for repository unregister or integration-binding changes.",
+  ],
+  parameters: ProjectDeleteParams,
+  async execute(_toolCallId: string, params: ProjectDeleteToolParams) {
+    const projectId = normalizeRequiredText(params.projectId, "projectId");
+
+    try {
+      const projectService = await getProjectService();
+      const project = await projectService.deleteProject(projectId);
+      const details: ProjectDeleteToolDetails = {
+        kind: "project_delete",
+        projectId,
+        found: true,
+        deleted: true,
+        project,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: formatProjectDeleteContent(details) }],
+        details,
+      };
+    } catch (error) {
+      if (isProjectNotFoundError(error)) {
+        const details: ProjectDeleteToolDetails = {
+          kind: "project_delete",
+          projectId,
+          found: false,
+          deleted: false,
+        };
+
+        return {
+          content: [{ type: "text" as const, text: formatProjectDeleteContent(details) }],
+          details,
+        };
+      }
+
+      throw new Error(formatToolError(error, "project_delete failed"), { cause: error });
+    }
+  },
+});
+
+const registerProjectMutationTools = (
+  pi: Pick<ExtensionAPI, "registerTool">,
+  dependencies: ProjectMutationToolDependencies
+): void => {
+  pi.registerTool(createProjectCreateToolDefinition(dependencies));
+  pi.registerTool(createProjectUpdateToolDefinition(dependencies));
+  pi.registerTool(createProjectDeleteToolDefinition(dependencies));
+};
+
+const normalizeCreateProjectInput = (params: ProjectCreateToolParams): CreateProjectInput => ({
+  name: normalizeRequiredText(params.name, "name"),
+  description: normalizeOptionalDescription(params, "description"),
+  priority: params.priority,
+});
+
+const normalizeUpdateProjectInput = (params: ProjectUpdateToolParams): UpdateProjectInput => {
+  const input: UpdateProjectInput = {
+    projectId: normalizeRequiredText(params.projectId, "projectId"),
+    status: params.status,
+    priority: params.priority,
+  };
+
+  if (hasOwn(params, "name")) {
+    input.name = normalizeRequiredText(params.name ?? "", "name");
+  }
+
+  if (hasOwn(params, "description")) {
+    input.description = normalizeNullableText(params.description);
+  }
+
+  if (
+    input.name === undefined &&
+    input.status === undefined &&
+    input.priority === undefined &&
+    !hasOwn(input, "description")
+  ) {
+    throw new Error(
+      "project_update requires at least one supported field: name, description, status, or priority"
+    );
+  }
+
+  return input;
+};
+
+const normalizeOptionalDescription = <TValue extends { description?: string }>(
+  params: TValue,
+  fieldName: "description"
+): string | null | undefined => {
+  if (!hasOwn(params, fieldName)) {
+    return undefined;
+  }
+
+  return normalizeNullableText(params[fieldName]);
+};
+
+const normalizeRequiredText = (value: string, fieldName: string): string => {
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) {
+    throw new Error(`${fieldName} is required`);
+  }
+
+  return trimmedValue;
+};
+
+const normalizeNullableText = (value: string | null | undefined): string | null => {
+  const trimmedValue = value?.trim() ?? "";
+  return trimmedValue.length > 0 ? trimmedValue : null;
+};
+
+const hasOwn = <TObject extends object>(value: TObject, property: keyof TObject): boolean =>
+  Object.prototype.hasOwnProperty.call(value, property);
+
+const isProjectNotFoundError = (error: unknown): error is ToduProjectServiceError =>
+  error instanceof ToduProjectServiceError && error.causeCode === "not-found";
+
+const formatProjectCreateContent = (project: ProjectSummary): string =>
+  [
+    `Created project ${project.id}: ${project.name}`,
+    `Status: ${project.status}`,
+    `Priority: ${project.priority}`,
+  ].join("\n");
+
+const formatProjectUpdateContent = (project: ProjectSummary, input: UpdateProjectInput): string => {
+  const changedFields = [
+    input.name !== undefined ? `name=${JSON.stringify(input.name)}` : null,
+    input.status !== undefined ? `status=${input.status}` : null,
+    input.priority !== undefined ? `priority=${input.priority}` : null,
+    hasOwn(input, "description")
+      ? `description=${input.description === null ? "cleared" : "updated"}`
+      : null,
+  ].filter((value): value is string => value !== null);
+
+  return [
+    `Updated project ${project.id}: ${project.name}`,
+    `Changes: ${changedFields.join(", ")}`,
+  ].join("\n");
+};
+
+const formatProjectDeleteContent = (details: ProjectDeleteToolDetails): string =>
+  details.found
+    ? `Deleted project ${details.projectId}.`
+    : `Project not found: ${details.projectId}`;
+
+const formatToolError = (error: unknown, prefix: string): string => {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return `${prefix}: ${error.message}`;
+  }
+
+  return prefix;
+};
+
+export type {
+  ProjectCreateToolDetails,
+  ProjectMutationToolDependencies,
+  ProjectUpdateToolDetails,
+  ProjectDeleteToolDetails,
+};
+export {
+  createProjectCreateToolDefinition,
+  createProjectDeleteToolDefinition,
+  createProjectUpdateToolDefinition,
+  normalizeCreateProjectInput,
+  normalizeUpdateProjectInput,
+  registerProjectMutationTools,
+};


### PR DESCRIPTION
## Summary
- add native `project_create`, `project_update`, and `project_delete` tools
- route plain project CRUD operations through `ProjectService` with explicit not-found and validation behavior
- add focused tests for registration, normalization, delegation, success, and failure paths

## Verification
- npm run format
- npm run lint
- npm run typecheck
- npm test

Task: #task-1a48b4b8