### PR TITLE
Add repo context and project integration services

### DIFF
--- a/src/__tests__/daemon-client.test.ts
+++ b/src/__tests__/daemon-client.test.ts
@@ -434,6 +434,163 @@ describe("createToduDaemonClient", () => {
     );
   });
 
+  it("lists integration bindings through integration.list", async () => {
+    const connection = createConnectionMock();
+    connection.request.mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          id: "ibind-1",
+          provider: "github",
+          projectId: "proj-1",
+          targetKind: "repository",
+          targetRef: "evcraddock/todu-pi-extensions",
+          strategy: "bidirectional",
+          enabled: true,
+          createdAt: "2026-03-19T00:00:00.000Z",
+          updatedAt: "2026-03-19T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await expect(client.listIntegrationBindings({ provider: "github" })).resolves.toEqual([
+      {
+        id: "ibind-1",
+        provider: "github",
+        projectId: "proj-1",
+        targetKind: "repository",
+        targetRef: "evcraddock/todu-pi-extensions",
+        strategy: "bidirectional",
+        enabled: true,
+        options: undefined,
+        createdAt: "2026-03-19T00:00:00.000Z",
+        updatedAt: "2026-03-19T00:00:00.000Z",
+      },
+    ]);
+    expect(connection.request).toHaveBeenCalledWith("integration.list", {
+      filter: {
+        provider: "github",
+        projectId: undefined,
+        enabled: undefined,
+      },
+    });
+  });
+
+  it("creates integration bindings through integration.create", async () => {
+    const connection = createConnectionMock();
+    connection.request.mockResolvedValue({
+      ok: true,
+      value: {
+        id: "ibind-1",
+        provider: "github",
+        projectId: "proj-1",
+        targetKind: "repository",
+        targetRef: "evcraddock/todu-pi-extensions",
+        strategy: "bidirectional",
+        enabled: true,
+        createdAt: "2026-03-19T00:00:00.000Z",
+        updatedAt: "2026-03-19T00:00:00.000Z",
+      },
+    });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await expect(
+      client.createIntegrationBinding({
+        provider: "github",
+        projectId: "proj-1",
+        targetKind: "repository",
+        targetRef: "evcraddock/todu-pi-extensions",
+      })
+    ).resolves.toEqual({
+      id: "ibind-1",
+      provider: "github",
+      projectId: "proj-1",
+      targetKind: "repository",
+      targetRef: "evcraddock/todu-pi-extensions",
+      strategy: "bidirectional",
+      enabled: true,
+      options: undefined,
+      createdAt: "2026-03-19T00:00:00.000Z",
+      updatedAt: "2026-03-19T00:00:00.000Z",
+    });
+    expect(connection.request).toHaveBeenCalledWith("integration.create", {
+      input: {
+        provider: "github",
+        projectId: "proj-1",
+        targetKind: "repository",
+        targetRef: "evcraddock/todu-pi-extensions",
+        strategy: undefined,
+        enabled: undefined,
+        options: undefined,
+      },
+    });
+  });
+
+  it("maps integration failures into client errors", async () => {
+    const connection = createConnectionMock();
+    connection.request
+      .mockResolvedValueOnce({
+        ok: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "invalid integration filter",
+          details: { field: "provider" },
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: {
+          code: "CONFLICT",
+          message: "project already has an integration binding",
+          details: { projectId: "proj-1" },
+        },
+      });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await expect(client.listIntegrationBindings()).rejects.toEqual(
+      expect.objectContaining({
+        name: "ToduDaemonClientError",
+        code: "validation",
+        method: "integration.list",
+        message: "integration.list failed (VALIDATION_ERROR): invalid integration filter",
+      })
+    );
+    await expect(
+      client.createIntegrationBinding({
+        provider: "github",
+        projectId: "proj-1",
+        targetKind: "repository",
+        targetRef: "evcraddock/todu-pi-extensions",
+      })
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: "ToduDaemonClientError",
+        code: "conflict",
+        method: "integration.create",
+        message: "integration.create failed (CONFLICT): project already has an integration binding",
+      })
+    );
+  });
+
   it("adapts event subscriptions through the connection manager", async () => {
     const connection = createConnectionMock();
     const subscription = { unsubscribe: vi.fn() };

--- a/src/__tests__/project-integration-service.test.ts
+++ b/src/__tests__/project-integration-service.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ProjectSummary } from "@/domain/task";
+import {
+  createProjectIntegrationService,
+  type IntegrationBinding,
+} from "@/services/project-integration-service";
+import type { ProjectService } from "@/services/project-service";
+import type { RepoContextService } from "@/services/repo-context";
+import {
+  createToduProjectIntegrationService,
+  ToduProjectIntegrationServiceError,
+} from "@/services/todu/todu-project-integration-service";
+import { ToduDaemonClientError } from "@/services/todu/daemon-client";
+
+const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectSummary => ({
+  id: "proj-1",
+  name: "Todu Pi Extensions",
+  status: "active",
+  priority: "medium",
+  description: "Primary project",
+  ...overrides,
+});
+
+const createBinding = (overrides: Partial<IntegrationBinding> = {}): IntegrationBinding => ({
+  id: "ibind-1",
+  provider: "github",
+  projectId: "proj-1",
+  targetKind: "repository",
+  targetRef: "evcraddock/todu-pi-extensions",
+  strategy: "bidirectional",
+  enabled: true,
+  createdAt: "2026-03-19T00:00:00.000Z",
+  updatedAt: "2026-03-19T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("createProjectIntegrationService", () => {
+  it("returns registered when one matching binding exists", async () => {
+    const project = createProjectSummary();
+    const service = createProjectIntegrationService({
+      projectService: {
+        getProject: vi.fn().mockResolvedValue(project),
+      } as unknown as ProjectService,
+      repoContextService: {
+        resolveRepository: vi.fn().mockResolvedValue({
+          kind: "resolved",
+          repository: {
+            repositoryPath: "/tmp/repo",
+            remoteName: "origin",
+            remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+            provider: "github",
+            targetRef: "evcraddock/todu-pi-extensions",
+          },
+        }),
+      } as unknown as RepoContextService,
+      gateway: {
+        listIntegrationBindings: vi.fn().mockResolvedValue([createBinding()]),
+        createIntegrationBinding: vi.fn(),
+      },
+    });
+
+    await expect(service.checkRepositoryBinding()).resolves.toEqual({
+      kind: "registered",
+      repository: {
+        repositoryPath: "/tmp/repo",
+        remoteName: "origin",
+        remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+        provider: "github",
+        targetRef: "evcraddock/todu-pi-extensions",
+      },
+      binding: createBinding(),
+      project,
+    });
+  });
+
+  it("returns explicit ambiguity when multiple bindings match", async () => {
+    const service = createProjectIntegrationService({
+      projectService: {} as ProjectService,
+      repoContextService: {
+        resolveRepository: vi.fn().mockResolvedValue({
+          kind: "resolved",
+          repository: {
+            repositoryPath: "/tmp/repo",
+            remoteName: "origin",
+            remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+            provider: "github",
+            targetRef: "evcraddock/todu-pi-extensions",
+          },
+        }),
+      } as unknown as RepoContextService,
+      gateway: {
+        listIntegrationBindings: vi
+          .fn()
+          .mockResolvedValue([createBinding(), createBinding({ id: "ibind-2" })]),
+        createIntegrationBinding: vi.fn(),
+      },
+    });
+
+    await expect(service.checkRepositoryBinding()).resolves.toEqual({
+      kind: "ambiguous",
+      reason: "multiple-matching-bindings",
+      repository: {
+        repositoryPath: "/tmp/repo",
+        remoteName: "origin",
+        remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+        provider: "github",
+        targetRef: "evcraddock/todu-pi-extensions",
+      },
+      bindings: [createBinding(), createBinding({ id: "ibind-2" })],
+    });
+  });
+
+  it("returns not-registered when no binding matches", async () => {
+    const service = createProjectIntegrationService({
+      projectService: {} as ProjectService,
+      repoContextService: {
+        resolveRepository: vi.fn().mockResolvedValue({
+          kind: "resolved",
+          repository: {
+            repositoryPath: "/tmp/repo",
+            remoteName: "origin",
+            remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+            provider: "github",
+            targetRef: "evcraddock/todu-pi-extensions",
+          },
+        }),
+      } as unknown as RepoContextService,
+      gateway: {
+        listIntegrationBindings: vi.fn().mockResolvedValue([]),
+        createIntegrationBinding: vi.fn(),
+      },
+    });
+
+    await expect(service.checkRepositoryBinding()).resolves.toEqual({
+      kind: "not-registered",
+      repository: {
+        repositoryPath: "/tmp/repo",
+        remoteName: "origin",
+        remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+        provider: "github",
+        targetRef: "evcraddock/todu-pi-extensions",
+      },
+    });
+  });
+
+  it("registers a repository project through project creation plus binding creation", async () => {
+    const project = createProjectSummary({ name: "todu-pi-extensions" });
+    const createIntegrationBinding = vi.fn().mockResolvedValue(createBinding());
+    const service = createProjectIntegrationService({
+      projectService: {
+        createProject: vi.fn().mockResolvedValue(project),
+      } as unknown as ProjectService,
+      repoContextService: {
+        resolveRepository: vi.fn().mockResolvedValue({
+          kind: "resolved",
+          repository: {
+            repositoryPath: "/tmp/repo",
+            remoteName: "origin",
+            remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+            provider: "github",
+            targetRef: "evcraddock/todu-pi-extensions",
+          },
+        }),
+      } as unknown as RepoContextService,
+      gateway: {
+        listIntegrationBindings: vi.fn().mockResolvedValue([]),
+        createIntegrationBinding,
+      },
+    });
+
+    await expect(service.registerRepositoryProject({})).resolves.toEqual({
+      kind: "registered",
+      repository: {
+        repositoryPath: "/tmp/repo",
+        remoteName: "origin",
+        remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+        provider: "github",
+        targetRef: "evcraddock/todu-pi-extensions",
+      },
+      project,
+      binding: createBinding(),
+      createdProject: true,
+      createdBinding: true,
+    });
+    expect(createIntegrationBinding).toHaveBeenCalledWith({
+      provider: "github",
+      projectId: "proj-1",
+      targetKind: "repository",
+      targetRef: "evcraddock/todu-pi-extensions",
+      strategy: undefined,
+      enabled: undefined,
+    });
+  });
+
+  it("treats explicit provider and targetRef as higher priority than repo detection", async () => {
+    const project = createProjectSummary({ name: "custom" });
+    const service = createProjectIntegrationService({
+      projectService: {
+        createProject: vi.fn().mockResolvedValue(project),
+      } as unknown as ProjectService,
+      repoContextService: {
+        resolveRepository: vi.fn().mockResolvedValue({
+          kind: "resolved",
+          repository: {
+            repositoryPath: "/tmp/repo",
+            remoteName: "origin",
+            remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+            provider: "github",
+            targetRef: "evcraddock/todu-pi-extensions",
+          },
+        }),
+      } as unknown as RepoContextService,
+      gateway: {
+        listIntegrationBindings: vi.fn().mockResolvedValue([]),
+        createIntegrationBinding: vi
+          .fn()
+          .mockResolvedValue(createBinding({ provider: "forgejo", targetRef: "team/custom" })),
+      },
+    });
+
+    const result = await service.registerRepositoryProject({
+      provider: "forgejo",
+      targetRef: "team/custom",
+      projectName: "custom",
+    });
+
+    expect(result).toEqual({
+      kind: "registered",
+      repository: {
+        repositoryPath: "/tmp/repo",
+        remoteName: "origin",
+        remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+        provider: "forgejo",
+        targetRef: "team/custom",
+      },
+      project,
+      binding: createBinding({ provider: "forgejo", targetRef: "team/custom" }),
+      createdProject: true,
+      createdBinding: true,
+    });
+  });
+});
+
+describe("createToduProjectIntegrationService", () => {
+  it("wraps daemon gateway failures in an integration-service error", async () => {
+    const service = createToduProjectIntegrationService({
+      client: {
+        listIntegrationBindings: vi.fn().mockRejectedValue(
+          new ToduDaemonClientError({
+            code: "unavailable",
+            method: "integration.list",
+            message: "integration.list failed (DAEMON_UNAVAILABLE): daemon unavailable",
+            details: { socketPath: "/tmp/daemon.sock" },
+          })
+        ),
+      } as never,
+      projectService: {} as ProjectService,
+      repoContextService: {
+        resolveRepository: vi.fn().mockResolvedValue({
+          kind: "resolved",
+          repository: {
+            repositoryPath: "/tmp/repo",
+            remoteName: "origin",
+            remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+            provider: "github",
+            targetRef: "evcraddock/todu-pi-extensions",
+          },
+        }),
+      } as unknown as RepoContextService,
+    });
+
+    await expect(service.checkRepositoryBinding()).rejects.toEqual(
+      expect.objectContaining<ToduProjectIntegrationServiceError>({
+        name: "ToduProjectIntegrationServiceError",
+        operation: "checkRepositoryBinding",
+        causeCode: "unavailable",
+        message:
+          "checkRepositoryBinding failed: integration.list failed (DAEMON_UNAVAILABLE): daemon unavailable",
+      })
+    );
+  });
+});

--- a/src/__tests__/repo-context.test.ts
+++ b/src/__tests__/repo-context.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createRepoContextService,
+  normalizeGitRemoteUrl,
+  parseGitRemoteOutput,
+  selectGitRemote,
+} from "@/services/repo-context";
+
+describe("parseGitRemoteOutput", () => {
+  it("parses fetch and push remotes deterministically", () => {
+    expect(
+      parseGitRemoteOutput(
+        [
+          "origin\tgit@github.com:evcraddock/todu-pi-extensions.git (fetch)",
+          "origin\tgit@github.com:evcraddock/todu-pi-extensions.git (push)",
+        ].join("\n")
+      )
+    ).toEqual([
+      {
+        name: "origin",
+        fetchUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+        pushUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+      },
+    ]);
+  });
+});
+
+describe("selectGitRemote", () => {
+  it("prefers origin when present", () => {
+    expect(
+      selectGitRemote(
+        [
+          { name: "upstream", fetchUrl: "https://git.example.com/org/repo.git", pushUrl: null },
+          {
+            name: "origin",
+            fetchUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+            pushUrl: null,
+          },
+        ],
+        undefined
+      )
+    ).toEqual({
+      name: "origin",
+      fetchUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+      pushUrl: null,
+    });
+  });
+
+  it("returns null when multiple remotes exist without origin", () => {
+    expect(
+      selectGitRemote(
+        [
+          { name: "fork", fetchUrl: "https://git.example.com/org/repo.git", pushUrl: null },
+          { name: "upstream", fetchUrl: "https://git.example.com/team/repo.git", pushUrl: null },
+        ],
+        undefined
+      )
+    ).toBeNull();
+  });
+});
+
+describe("normalizeGitRemoteUrl", () => {
+  it("normalizes github ssh remotes", () => {
+    expect(normalizeGitRemoteUrl("git@github.com:evcraddock/todu-pi-extensions.git")).toEqual({
+      provider: "github",
+      targetRef: "evcraddock/todu-pi-extensions",
+    });
+  });
+
+  it("normalizes forgejo https remotes", () => {
+    expect(normalizeGitRemoteUrl("https://git.example.com/owner/repo.git")).toEqual({
+      provider: "forgejo",
+      targetRef: "owner/repo",
+    });
+  });
+
+  it("returns null for unsupported formats", () => {
+    expect(normalizeGitRemoteUrl("file:///tmp/repo")).toBeNull();
+  });
+});
+
+describe("createRepoContextService", () => {
+  it("resolves repository context from git commands", async () => {
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({ stdout: "/tmp/repo\n", stderr: "" })
+        .mockResolvedValueOnce({
+          stdout: "origin\tgit@github.com:evcraddock/todu-pi-extensions.git (fetch)\n",
+          stderr: "",
+        }),
+    };
+
+    const service = createRepoContextService(runner);
+
+    await expect(service.resolveRepository({ repositoryPath: "/tmp/repo" })).resolves.toEqual({
+      kind: "resolved",
+      repository: {
+        repositoryPath: "/tmp/repo",
+        remoteName: "origin",
+        remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+        provider: "github",
+        targetRef: "evcraddock/todu-pi-extensions",
+      },
+    });
+  });
+
+  it("returns explicit missing context for non-git directories", async () => {
+    const service = createRepoContextService({
+      run: vi.fn().mockRejectedValue(new Error("not a git repository")),
+    });
+
+    await expect(service.resolveRepository({ repositoryPath: "/tmp/nope" })).resolves.toEqual({
+      kind: "missing-context",
+      reason: "not-a-git-repository",
+      repositoryPath: "/tmp/nope",
+    });
+  });
+
+  it("returns explicit ambiguity for multiple remotes without origin", async () => {
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({ stdout: "/tmp/repo\n", stderr: "" })
+        .mockResolvedValueOnce({
+          stdout: [
+            "fork\thttps://git.example.com/org/repo.git (fetch)",
+            "upstream\thttps://git.example.com/team/repo.git (fetch)",
+          ].join("\n"),
+          stderr: "",
+        }),
+    };
+
+    const service = createRepoContextService(runner);
+
+    await expect(service.resolveRepository({ repositoryPath: "/tmp/repo" })).resolves.toEqual({
+      kind: "ambiguous",
+      reason: "multiple-remotes",
+      repositoryPath: "/tmp/repo",
+      remotes: ["fork", "upstream"],
+    });
+  });
+
+  it("returns explicit unsupported format results", async () => {
+    const runner = {
+      run: vi
+        .fn()
+        .mockResolvedValueOnce({ stdout: "/tmp/repo\n", stderr: "" })
+        .mockResolvedValueOnce({
+          stdout: "origin\tfile:///tmp/repo (fetch)\n",
+          stderr: "",
+        }),
+    };
+
+    const service = createRepoContextService(runner);
+
+    await expect(service.resolveRepository({ repositoryPath: "/tmp/repo" })).resolves.toEqual({
+      kind: "unsupported",
+      reason: "unsupported-remote-format",
+      repositoryPath: "/tmp/repo",
+      remoteName: "origin",
+      remoteUrl: "file:///tmp/repo",
+    });
+  });
+});

--- a/src/__tests__/task-mutation-tools.test.ts
+++ b/src/__tests__/task-mutation-tools.test.ts
@@ -188,9 +188,9 @@ describe("resolveProjectForTaskCreate", () => {
         .mockResolvedValue([createProjectSummary(), createProjectSummary({ id: "proj-2" })]),
     } as unknown as TaskService;
 
-    await expect(
-      resolveProjectForTaskCreate(taskService, "Todu Pi Extensions")
-    ).rejects.toThrow("multiple projects matched: Todu Pi Extensions");
+    await expect(resolveProjectForTaskCreate(taskService, "Todu Pi Extensions")).rejects.toThrow(
+      "multiple projects matched: Todu Pi Extensions"
+    );
   });
 });
 

--- a/src/__tests__/todu-task-service.test.ts
+++ b/src/__tests__/todu-task-service.test.ts
@@ -36,6 +36,8 @@ describe("createToduTaskService", () => {
       createProject: vi.fn(),
       updateProject: vi.fn(),
       deleteProject: vi.fn(),
+      listIntegrationBindings: vi.fn(),
+      createIntegrationBinding: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -81,6 +83,8 @@ describe("createToduTaskService", () => {
       createProject: vi.fn(),
       updateProject: vi.fn(),
       deleteProject: vi.fn(),
+      listIntegrationBindings: vi.fn(),
+      createIntegrationBinding: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -129,6 +133,8 @@ describe("createToduTaskService", () => {
       createProject: vi.fn(),
       updateProject: vi.fn(),
       deleteProject: vi.fn(),
+      listIntegrationBindings: vi.fn(),
+      createIntegrationBinding: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -182,6 +188,8 @@ describe("createToduTaskService", () => {
       createProject: vi.fn(),
       updateProject: vi.fn(),
       deleteProject: vi.fn(),
+      listIntegrationBindings: vi.fn(),
+      createIntegrationBinding: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -246,6 +254,8 @@ describe("createToduTaskService", () => {
       createProject: vi.fn(),
       updateProject: vi.fn(),
       deleteProject: vi.fn(),
+      listIntegrationBindings: vi.fn(),
+      createIntegrationBinding: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };

--- a/src/services/project-integration-service.ts
+++ b/src/services/project-integration-service.ts
@@ -1,0 +1,276 @@
+import type { ProjectSummary, TaskPriority } from "../domain/task";
+import type { ProjectService } from "./project-service";
+import type { RepoContextService, ResolvedRepositoryContext } from "./repo-context";
+
+export type IntegrationSyncStrategy = "bidirectional" | "pull" | "push" | "none";
+
+export interface IntegrationBinding {
+  id: string;
+  provider: string;
+  projectId: string;
+  targetKind: string;
+  targetRef: string;
+  strategy: IntegrationSyncStrategy;
+  enabled: boolean;
+  options?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateIntegrationBindingInput {
+  provider: string;
+  projectId: string;
+  targetKind: string;
+  targetRef: string;
+  strategy?: IntegrationSyncStrategy;
+  enabled?: boolean;
+  options?: Record<string, unknown>;
+}
+
+export interface IntegrationBindingFilter {
+  provider?: string;
+  projectId?: string;
+  enabled?: boolean;
+}
+
+export type RepositoryBindingCheckResult =
+  | {
+      kind: "registered";
+      repository: ResolvedRepositoryContext;
+      binding: IntegrationBinding;
+      project: ProjectSummary | null;
+    }
+  | {
+      kind: "not-registered";
+      repository: ResolvedRepositoryContext;
+    }
+  | {
+      kind: "ambiguous";
+      reason: "multiple-remotes" | "multiple-matching-bindings";
+      repositoryPath?: string;
+      repository?: ResolvedRepositoryContext;
+      remotes?: string[];
+      bindings?: IntegrationBinding[];
+    }
+  | {
+      kind: "missing-context";
+      reason: "not-a-git-repository" | "no-remotes";
+      repositoryPath?: string;
+    }
+  | {
+      kind: "unsupported";
+      reason: "unsupported-remote-format";
+      repositoryPath?: string;
+      remoteName: string;
+      remoteUrl: string;
+    };
+
+export type RepositoryProjectRegistrationResult =
+  | {
+      kind: "registered";
+      repository: ResolvedRepositoryContext;
+      project: ProjectSummary;
+      binding: IntegrationBinding;
+      createdProject: boolean;
+      createdBinding: boolean;
+    }
+  | {
+      kind: "already-registered";
+      repository: ResolvedRepositoryContext;
+      binding: IntegrationBinding;
+      project: ProjectSummary | null;
+    }
+  | RepositoryBindingCheckResult;
+
+export interface RegisterRepositoryProjectInput {
+  projectName?: string;
+  repositoryPath?: string;
+  provider?: string;
+  targetRef?: string;
+  description?: string | null;
+  priority?: TaskPriority;
+  strategy?: IntegrationSyncStrategy;
+  enabled?: boolean;
+}
+
+export interface ProjectIntegrationService {
+  listIntegrationBindings(filter?: IntegrationBindingFilter): Promise<IntegrationBinding[]>;
+  checkRepositoryBinding(input?: {
+    repositoryPath?: string;
+    provider?: string;
+    targetRef?: string;
+  }): Promise<RepositoryBindingCheckResult>;
+  registerRepositoryProject(
+    input: RegisterRepositoryProjectInput
+  ): Promise<RepositoryProjectRegistrationResult>;
+}
+
+export interface ProjectIntegrationGateway {
+  listIntegrationBindings(filter?: IntegrationBindingFilter): Promise<IntegrationBinding[]>;
+  createIntegrationBinding(input: CreateIntegrationBindingInput): Promise<IntegrationBinding>;
+}
+
+export interface ProjectIntegrationServiceDependencies {
+  projectService: ProjectService;
+  repoContextService: RepoContextService;
+  gateway: ProjectIntegrationGateway;
+}
+
+const createProjectIntegrationService = ({
+  projectService,
+  repoContextService,
+  gateway,
+}: ProjectIntegrationServiceDependencies): ProjectIntegrationService => ({
+  listIntegrationBindings: (filter) => gateway.listIntegrationBindings(filter),
+  checkRepositoryBinding: async (input = {}) => {
+    const repositoryResolution = await resolveRepositoryInput(repoContextService, input);
+    if (repositoryResolution.kind !== "resolved") {
+      return repositoryResolution;
+    }
+
+    const matches = await findMatchingBindings(gateway, repositoryResolution.repository);
+    if (matches.length === 0) {
+      return {
+        kind: "not-registered",
+        repository: repositoryResolution.repository,
+      };
+    }
+
+    if (matches.length > 1) {
+      return {
+        kind: "ambiguous",
+        reason: "multiple-matching-bindings",
+        repository: repositoryResolution.repository,
+        bindings: matches,
+      };
+    }
+
+    const binding = matches[0];
+    return {
+      kind: "registered",
+      repository: repositoryResolution.repository,
+      binding,
+      project: binding ? await projectService.getProject(binding.projectId) : null,
+    };
+  },
+  registerRepositoryProject: async (input) => {
+    const repositoryResolution = await resolveRepositoryInput(repoContextService, input);
+    if (repositoryResolution.kind !== "resolved") {
+      return repositoryResolution;
+    }
+
+    const checkResult = await createProjectIntegrationService({
+      projectService,
+      repoContextService,
+      gateway,
+    }).checkRepositoryBinding({
+      repositoryPath: repositoryResolution.repository.repositoryPath,
+      provider: repositoryResolution.repository.provider,
+      targetRef: repositoryResolution.repository.targetRef,
+    });
+
+    if (checkResult.kind === "registered") {
+      return {
+        kind: "already-registered",
+        repository: checkResult.repository,
+        binding: checkResult.binding,
+        project: checkResult.project,
+      };
+    }
+
+    if (checkResult.kind !== "not-registered") {
+      return checkResult;
+    }
+
+    const project = await projectService.createProject({
+      name: normalizeProjectName(input.projectName, checkResult.repository.targetRef),
+      description: input.description,
+      priority: input.priority,
+    });
+    const binding = await gateway.createIntegrationBinding({
+      provider: checkResult.repository.provider,
+      projectId: project.id,
+      targetKind: "repository",
+      targetRef: checkResult.repository.targetRef,
+      strategy: input.strategy,
+      enabled: input.enabled,
+    });
+
+    return {
+      kind: "registered",
+      repository: checkResult.repository,
+      project,
+      binding,
+      createdProject: true,
+      createdBinding: true,
+    };
+  },
+});
+
+const resolveRepositoryInput = async (
+  repoContextService: RepoContextService,
+  input: { repositoryPath?: string; provider?: string; targetRef?: string }
+): Promise<
+  RepositoryBindingCheckResult | { kind: "resolved"; repository: ResolvedRepositoryContext }
+> => {
+  const repoResult = await repoContextService.resolveRepository({
+    repositoryPath: input.repositoryPath,
+  });
+  if (repoResult.kind === "resolved") {
+    return {
+      kind: "resolved",
+      repository: {
+        ...repoResult.repository,
+        provider:
+          (input.provider as ResolvedRepositoryContext["provider"] | undefined) ??
+          repoResult.repository.provider,
+        targetRef: input.targetRef ?? repoResult.repository.targetRef,
+      },
+    };
+  }
+
+  if (input.provider && input.targetRef) {
+    return {
+      kind: "resolved",
+      repository: {
+        repositoryPath: input.repositoryPath ?? process.cwd(),
+        remoteName: "explicit",
+        remoteUrl: "explicit",
+        provider: input.provider as ResolvedRepositoryContext["provider"],
+        targetRef: input.targetRef,
+      },
+    };
+  }
+
+  return repoResult;
+};
+
+const findMatchingBindings = async (
+  gateway: ProjectIntegrationGateway,
+  repository: ResolvedRepositoryContext
+): Promise<IntegrationBinding[]> => {
+  const bindings = await gateway.listIntegrationBindings({ provider: repository.provider });
+  return bindings.filter(
+    (binding) =>
+      binding.provider === repository.provider &&
+      binding.targetKind === "repository" &&
+      binding.targetRef === repository.targetRef
+  );
+};
+
+const normalizeProjectName = (projectName: string | undefined, targetRef: string): string => {
+  const trimmedName = projectName?.trim();
+  if (trimmedName && trimmedName.length > 0) {
+    return trimmedName;
+  }
+
+  const segments = targetRef.split("/");
+  return segments[segments.length - 1] ?? targetRef;
+};
+
+export {
+  createProjectIntegrationService,
+  findMatchingBindings,
+  normalizeProjectName,
+  resolveRepositoryInput,
+};

--- a/src/services/repo-context.ts
+++ b/src/services/repo-context.ts
@@ -1,0 +1,231 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type RepoProvider = "github" | "forgejo";
+
+export interface GitRemote {
+  name: string;
+  fetchUrl: string | null;
+  pushUrl: string | null;
+}
+
+export interface ResolvedRepositoryContext {
+  repositoryPath: string;
+  remoteName: string;
+  remoteUrl: string;
+  provider: RepoProvider;
+  targetRef: string;
+}
+
+export type RepoContextResult =
+  | {
+      kind: "resolved";
+      repository: ResolvedRepositoryContext;
+    }
+  | {
+      kind: "missing-context";
+      reason: "not-a-git-repository" | "no-remotes";
+      repositoryPath?: string;
+    }
+  | {
+      kind: "ambiguous";
+      reason: "multiple-remotes";
+      repositoryPath?: string;
+      remotes: string[];
+    }
+  | {
+      kind: "unsupported";
+      reason: "unsupported-remote-format";
+      repositoryPath?: string;
+      remoteName: string;
+      remoteUrl: string;
+    };
+
+export interface ResolveRepoContextInput {
+  repositoryPath?: string;
+  remoteName?: string;
+}
+
+export interface RepoCommandRunner {
+  run(cwd: string | undefined, args: string[]): Promise<{ stdout: string; stderr: string }>;
+}
+
+export interface RepoContextService {
+  resolveRepository(input?: ResolveRepoContextInput): Promise<RepoContextResult>;
+}
+
+const createRepoContextService = (
+  runner: RepoCommandRunner = createDefaultRepoCommandRunner()
+): RepoContextService => ({
+  async resolveRepository(input: ResolveRepoContextInput = {}): Promise<RepoContextResult> {
+    const resolvedRoot = await resolveGitRoot(runner, input.repositoryPath);
+    if (!resolvedRoot) {
+      return {
+        kind: "missing-context",
+        reason: "not-a-git-repository",
+        repositoryPath: input.repositoryPath,
+      };
+    }
+
+    const remotes = await listGitRemotes(runner, resolvedRoot);
+    if (remotes.length === 0) {
+      return {
+        kind: "missing-context",
+        reason: "no-remotes",
+        repositoryPath: resolvedRoot,
+      };
+    }
+
+    const selectedRemote = selectGitRemote(remotes, input.remoteName);
+    if (!selectedRemote) {
+      return {
+        kind: "ambiguous",
+        reason: "multiple-remotes",
+        repositoryPath: resolvedRoot,
+        remotes: remotes.map((remote) => remote.name),
+      };
+    }
+
+    const normalizedRemote = normalizeGitRemoteUrl(
+      selectedRemote.fetchUrl ?? selectedRemote.pushUrl ?? ""
+    );
+    if (!normalizedRemote) {
+      return {
+        kind: "unsupported",
+        reason: "unsupported-remote-format",
+        repositoryPath: resolvedRoot,
+        remoteName: selectedRemote.name,
+        remoteUrl: selectedRemote.fetchUrl ?? selectedRemote.pushUrl ?? "",
+      };
+    }
+
+    return {
+      kind: "resolved",
+      repository: {
+        repositoryPath: resolvedRoot,
+        remoteName: selectedRemote.name,
+        remoteUrl: selectedRemote.fetchUrl ?? selectedRemote.pushUrl ?? "",
+        provider: normalizedRemote.provider,
+        targetRef: normalizedRemote.targetRef,
+      },
+    };
+  },
+});
+
+const resolveGitRoot = async (
+  runner: RepoCommandRunner,
+  repositoryPath?: string
+): Promise<string | null> => {
+  try {
+    const result = await runner.run(repositoryPath, ["rev-parse", "--show-toplevel"]);
+    const root = result.stdout.trim();
+    return root.length > 0 ? root : null;
+  } catch {
+    return null;
+  }
+};
+
+const listGitRemotes = async (
+  runner: RepoCommandRunner,
+  repositoryPath: string
+): Promise<GitRemote[]> => {
+  const result = await runner.run(repositoryPath, ["remote", "-v"]);
+  return parseGitRemoteOutput(result.stdout);
+};
+
+const parseGitRemoteOutput = (stdout: string): GitRemote[] => {
+  const remotes = new Map<string, GitRemote>();
+  const lines = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  for (const line of lines) {
+    const match = line.match(/^(\S+)\s+(\S+)\s+\((fetch|push)\)$/);
+    if (!match) {
+      continue;
+    }
+
+    const [, name, url, kind] = match;
+    const remote = remotes.get(name) ?? { name, fetchUrl: null, pushUrl: null };
+    if (kind === "fetch") {
+      remote.fetchUrl = url;
+    } else {
+      remote.pushUrl = url;
+    }
+    remotes.set(name, remote);
+  }
+
+  return [...remotes.values()].filter((remote) => remote.fetchUrl || remote.pushUrl);
+};
+
+const selectGitRemote = (remotes: GitRemote[], requestedRemoteName?: string): GitRemote | null => {
+  if (requestedRemoteName) {
+    return remotes.find((remote) => remote.name === requestedRemoteName) ?? null;
+  }
+
+  const originRemote = remotes.find((remote) => remote.name === "origin");
+  if (originRemote) {
+    return originRemote;
+  }
+
+  return remotes.length === 1 ? (remotes[0] ?? null) : null;
+};
+
+const normalizeGitRemoteUrl = (
+  remoteUrl: string
+): { provider: RepoProvider; targetRef: string } | null => {
+  const sshMatch = remoteUrl.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
+  if (sshMatch) {
+    return normalizeRemoteParts(sshMatch[1], sshMatch[2]);
+  }
+
+  const sshProtocolMatch = remoteUrl.match(/^ssh:\/\/git@([^/]+)\/(.+?)(?:\.git)?$/);
+  if (sshProtocolMatch) {
+    return normalizeRemoteParts(sshProtocolMatch[1], sshProtocolMatch[2]);
+  }
+
+  const httpMatch = remoteUrl.match(/^https?:\/\/([^/]+)\/(.+?)(?:\.git)?\/?$/);
+  if (httpMatch) {
+    return normalizeRemoteParts(httpMatch[1], httpMatch[2]);
+  }
+
+  return null;
+};
+
+const normalizeRemoteParts = (
+  host: string | undefined,
+  rawTargetRef: string | undefined
+): { provider: RepoProvider; targetRef: string } | null => {
+  const normalizedHost = host?.trim().toLowerCase();
+  const normalizedTargetRef = rawTargetRef?.trim().replace(/^\/+|\/+$/g, "") ?? "";
+  if (!normalizedHost || normalizedTargetRef.length === 0 || !normalizedTargetRef.includes("/")) {
+    return null;
+  }
+
+  return {
+    provider: normalizedHost === "github.com" ? "github" : "forgejo",
+    targetRef: normalizedTargetRef,
+  };
+};
+
+const createDefaultRepoCommandRunner = (): RepoCommandRunner => ({
+  async run(cwd: string | undefined, args: string[]) {
+    const result = await execFileAsync("git", args, { cwd });
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  },
+});
+
+export {
+  createDefaultRepoCommandRunner,
+  createRepoContextService,
+  listGitRemotes,
+  normalizeGitRemoteUrl,
+  parseGitRemoteOutput,
+  selectGitRemote,
+};

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -1,4 +1,6 @@
 import type {
+  IntegrationBinding as ToduIntegrationBinding,
+  IntegrationBindingFilter as ToduIntegrationBindingFilter,
   Note as ToduNote,
   Project as ToduProject,
   Task as ToduTask,
@@ -17,6 +19,11 @@ import type {
   TaskStatus,
   TaskSummary,
 } from "../../domain/task";
+import type {
+  CreateIntegrationBindingInput,
+  IntegrationBinding,
+  IntegrationBindingFilter,
+} from "../project-integration-service";
 import type {
   CreateProjectInput,
   DeleteProjectResult,
@@ -78,6 +85,8 @@ export interface ToduDaemonClient {
   createProject(input: CreateProjectInput): Promise<ToduProjectSummary>;
   updateProject(input: UpdateLocalProjectInput): Promise<ToduProjectSummary>;
   deleteProject(projectId: string): Promise<DeleteProjectResult>;
+  listIntegrationBindings(filter?: IntegrationBindingFilter): Promise<IntegrationBinding[]>;
+  createIntegrationBinding(input: CreateIntegrationBindingInput): Promise<IntegrationBinding>;
   listTaskComments(taskId: TaskId): Promise<TaskComment[]>;
   on(
     eventName: ToduDaemonEventName,
@@ -207,6 +216,32 @@ const createToduDaemonClient = ({
     };
   },
 
+  async listIntegrationBindings(
+    filter: IntegrationBindingFilter = {}
+  ): Promise<IntegrationBinding[]> {
+    const result = await connection.request<ToduIntegrationBinding[]>("integration.list", {
+      filter: mapIntegrationBindingFilter(filter),
+    });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("integration.list", result.error);
+    }
+
+    return result.value.map(mapIntegrationBinding);
+  },
+
+  async createIntegrationBinding(
+    input: CreateIntegrationBindingInput
+  ): Promise<IntegrationBinding> {
+    const result = await connection.request<ToduIntegrationBinding>("integration.create", {
+      input: mapCreateIntegrationBindingInput(input),
+    });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("integration.create", result.error);
+    }
+
+    return mapIntegrationBinding(result.value);
+  },
+
   async listTaskComments(taskId: TaskId): Promise<TaskComment[]> {
     return fetchTaskComments(connection, taskId);
   },
@@ -297,6 +332,19 @@ const mapProjectSummary = (project: ToduProject): ToduProjectSummary => ({
   description: project.description ?? null,
 });
 
+const mapIntegrationBinding = (binding: ToduIntegrationBinding): IntegrationBinding => ({
+  id: binding.id,
+  provider: binding.provider,
+  projectId: binding.projectId,
+  targetKind: binding.targetKind,
+  targetRef: binding.targetRef,
+  strategy: binding.strategy,
+  enabled: binding.enabled,
+  options: binding.options,
+  createdAt: binding.createdAt,
+  updatedAt: binding.updatedAt,
+});
+
 const mapCreateProjectInput = (input: CreateProjectInput): Record<string, unknown> => ({
   name: input.name,
   description: input.description ?? undefined,
@@ -308,6 +356,26 @@ const mapUpdateProjectInput = (input: UpdateLocalProjectInput): Record<string, u
   description: input.description ?? undefined,
   status: input.status ? toRemoteProjectStatus(input.status) : undefined,
   priority: input.priority ?? undefined,
+});
+
+const mapIntegrationBindingFilter = (
+  filter: IntegrationBindingFilter
+): ToduIntegrationBindingFilter => ({
+  provider: filter.provider,
+  projectId: filter.projectId as ToduIntegrationBindingFilter["projectId"],
+  enabled: filter.enabled,
+});
+
+const mapCreateIntegrationBindingInput = (
+  input: CreateIntegrationBindingInput
+): Record<string, unknown> => ({
+  provider: input.provider,
+  projectId: input.projectId,
+  targetKind: input.targetKind,
+  targetRef: input.targetRef,
+  strategy: input.strategy,
+  enabled: input.enabled,
+  options: input.options,
 });
 
 const mapTaskFilter = (filter: TaskFilter): Record<string, unknown> => {
@@ -423,8 +491,10 @@ const toRemoteProjectStatus = (status: ProjectSummary["status"]): string =>
 
 export {
   createToduDaemonClient,
+  mapCreateIntegrationBindingInput,
   mapCreateProjectInput,
   mapDaemonErrorToClientError,
+  mapIntegrationBindingFilter,
   mapUpdateProjectInput,
   toLocalTaskStatus,
   toRemoteProjectStatus,

--- a/src/services/todu/default-task-service.ts
+++ b/src/services/todu/default-task-service.ts
@@ -1,4 +1,6 @@
+import type { ProjectIntegrationService } from "../project-integration-service";
 import type { ProjectService } from "../project-service";
+import { createRepoContextService } from "../repo-context";
 import type { TaskService } from "../task-service";
 import { createToduDaemonClient, type ToduDaemonClient } from "./daemon-client";
 import {
@@ -6,6 +8,7 @@ import {
   type CreateToduDaemonConnectionOptions,
   type ToduDaemonConnection,
 } from "./daemon-connection";
+import { createToduProjectIntegrationService } from "./todu-project-integration-service";
 import { createToduProjectService } from "./todu-project-service";
 import { createToduTaskService } from "./todu-task-service";
 
@@ -16,8 +19,10 @@ export interface ToduTaskServiceRuntime {
   client: ToduDaemonClient;
   taskService: TaskService;
   projectService: ProjectService;
+  projectIntegrationService: ProjectIntegrationService;
   ensureConnected(): Promise<TaskService>;
   ensureProjectServiceConnected(): Promise<ProjectService>;
+  ensureProjectIntegrationServiceConnected(): Promise<ProjectIntegrationService>;
   disconnect(): Promise<void>;
 }
 
@@ -32,6 +37,11 @@ const createToduTaskServiceRuntime = (
   const client = createToduDaemonClient({ connection });
   const taskService = createToduTaskService({ client });
   const projectService = createToduProjectService({ client });
+  const projectIntegrationService = createToduProjectIntegrationService({
+    client,
+    projectService,
+    repoContextService: createRepoContextService(),
+  });
   const initialConnectTimeoutMs = normalizeTimeout(
     options.initialConnectTimeoutMs,
     DEFAULT_TODU_INITIAL_CONNECT_TIMEOUT_MS
@@ -42,6 +52,7 @@ const createToduTaskServiceRuntime = (
     client,
     taskService,
     projectService,
+    projectIntegrationService,
     ensureConnected: async () => {
       if (connection.getState().status !== "connected") {
         await connectWithinTimeout(connection, initialConnectTimeoutMs);
@@ -55,6 +66,13 @@ const createToduTaskServiceRuntime = (
       }
 
       return projectService;
+    },
+    ensureProjectIntegrationServiceConnected: async () => {
+      if (connection.getState().status !== "connected") {
+        await connectWithinTimeout(connection, initialConnectTimeoutMs);
+      }
+
+      return projectIntegrationService;
     },
     disconnect: () => connection.disconnect(),
   };

--- a/src/services/todu/todu-project-integration-service.ts
+++ b/src/services/todu/todu-project-integration-service.ts
@@ -1,0 +1,104 @@
+import type {
+  CreateIntegrationBindingInput,
+  IntegrationBinding,
+  IntegrationBindingFilter,
+  ProjectIntegrationGateway,
+  ProjectIntegrationService,
+  RegisterRepositoryProjectInput,
+  RepositoryBindingCheckResult,
+  RepositoryProjectRegistrationResult,
+} from "../project-integration-service";
+import { createProjectIntegrationService } from "../project-integration-service";
+import type { ProjectService } from "../project-service";
+import type { RepoContextService } from "../repo-context";
+import { ToduDaemonClientError, type ToduDaemonClient } from "./daemon-client";
+
+export class ToduProjectIntegrationServiceError extends Error {
+  readonly operation: string;
+  readonly causeCode: string;
+  readonly details?: Record<string, unknown>;
+
+  constructor(options: {
+    operation: string;
+    causeCode: string;
+    message: string;
+    details?: Record<string, unknown>;
+    cause?: unknown;
+  }) {
+    super(options.message, options.cause ? { cause: options.cause } : undefined);
+    this.name = "ToduProjectIntegrationServiceError";
+    this.operation = options.operation;
+    this.causeCode = options.causeCode;
+    this.details = options.details;
+  }
+}
+
+export interface ToduProjectIntegrationGatewayDependencies {
+  client: ToduDaemonClient;
+}
+
+const createToduProjectIntegrationGateway = ({
+  client,
+}: ToduProjectIntegrationGatewayDependencies): ProjectIntegrationGateway => ({
+  listIntegrationBindings: (filter?: IntegrationBindingFilter): Promise<IntegrationBinding[]> =>
+    client.listIntegrationBindings(filter),
+  createIntegrationBinding: (input: CreateIntegrationBindingInput): Promise<IntegrationBinding> =>
+    client.createIntegrationBinding(input),
+});
+
+const createToduProjectIntegrationService = ({
+  client,
+  projectService,
+  repoContextService,
+}: {
+  client: ToduDaemonClient;
+  projectService: ProjectService;
+  repoContextService: RepoContextService;
+}): ProjectIntegrationService => {
+  const gateway = createToduProjectIntegrationGateway({ client });
+  const service = createProjectIntegrationService({ projectService, repoContextService, gateway });
+
+  return {
+    listIntegrationBindings: (filter) =>
+      runProjectIntegrationServiceOperation("listIntegrationBindings", () =>
+        service.listIntegrationBindings(filter)
+      ),
+    checkRepositoryBinding: (input): Promise<RepositoryBindingCheckResult> =>
+      runProjectIntegrationServiceOperation("checkRepositoryBinding", () =>
+        service.checkRepositoryBinding(input)
+      ),
+    registerRepositoryProject: (
+      input: RegisterRepositoryProjectInput
+    ): Promise<RepositoryProjectRegistrationResult> =>
+      runProjectIntegrationServiceOperation("registerRepositoryProject", () =>
+        service.registerRepositoryProject(input)
+      ),
+  };
+};
+
+const runProjectIntegrationServiceOperation = async <TResult>(
+  operation: string,
+  action: () => Promise<TResult>
+): Promise<TResult> => {
+  try {
+    return await action();
+  } catch (error) {
+    if (error instanceof ToduDaemonClientError) {
+      throw new ToduProjectIntegrationServiceError({
+        operation,
+        causeCode: error.code,
+        message: `${operation} failed: ${error.message}`,
+        details: error.details,
+        cause: error,
+      });
+    }
+
+    throw error;
+  }
+};
+
+export {
+  createToduProjectIntegrationGateway,
+  createToduProjectIntegrationService,
+  runProjectIntegrationServiceOperation,
+};


### PR DESCRIPTION
## Summary
- add a repo-context helper that resolves git remotes into explicit repository integration context
- add a dedicated project integration service plus Todu-backed gateway/error mapping
- extend the daemon client/runtime and add focused tests for integration flows and ambiguity handling

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm test

Refs: task-10d149c0