### PR TITLE
Add project_check and project_register tools

### DIFF
--- a/src/__tests__/project-integration-tools.test.ts
+++ b/src/__tests__/project-integration-tools.test.ts
@@ -1,0 +1,503 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ProjectSummary } from "@/domain/task";
+import { registerTools } from "@/extension/register-tools";
+import type {
+  IntegrationBinding,
+  ProjectIntegrationService,
+} from "@/services/project-integration-service";
+import type { ProjectService } from "@/services/project-service";
+import type { TaskService } from "@/services/task-service";
+import {
+  createProjectCheckToolDefinition,
+  createProjectRegisterToolDefinition,
+  formatProjectCheckContent,
+  formatProjectRegisterContent,
+} from "@/tools/project-integration-tools";
+
+const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectSummary => ({
+  id: "proj-1",
+  name: "todu-pi-extensions",
+  status: "active",
+  priority: "medium",
+  description: "Primary project",
+  ...overrides,
+});
+
+const createBinding = (overrides: Partial<IntegrationBinding> = {}): IntegrationBinding => ({
+  id: "ibind-1",
+  provider: "github",
+  projectId: "proj-1",
+  targetKind: "repository",
+  targetRef: "evcraddock/todu-pi-extensions",
+  strategy: "bidirectional",
+  enabled: true,
+  createdAt: "2026-03-19T00:00:00.000Z",
+  updatedAt: "2026-03-19T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("registerTools", () => {
+  it("registers the native project integration tools", () => {
+    const pi = {
+      registerTool: vi.fn(),
+    };
+
+    registerTools(pi as never, {
+      getTaskService: vi.fn().mockResolvedValue({} as TaskService),
+      getProjectService: vi.fn().mockResolvedValue({} as ProjectService),
+      getProjectIntegrationService: vi.fn().mockResolvedValue({} as ProjectIntegrationService),
+    });
+
+    const registeredToolNames = pi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(registeredToolNames).toEqual(
+      expect.arrayContaining(["project_check", "project_register"])
+    );
+  });
+});
+
+describe("formatProjectCheckContent", () => {
+  it("formats registered results concisely", () => {
+    expect(
+      formatProjectCheckContent({
+        kind: "project_check",
+        state: "registered",
+        repository: {
+          repositoryPath: "/tmp/repo",
+          remoteName: "origin",
+          remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+          provider: "github",
+          targetRef: "evcraddock/todu-pi-extensions",
+        },
+        project: createProjectSummary(),
+        binding: createBinding(),
+      })
+    ).toContain("Registration: Registered");
+  });
+});
+
+describe("formatProjectRegisterContent", () => {
+  it("formats registration results concisely", () => {
+    expect(
+      formatProjectRegisterContent({
+        kind: "project_register",
+        state: "registered",
+        repository: {
+          repositoryPath: "/tmp/repo",
+          remoteName: "origin",
+          remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+          provider: "github",
+          targetRef: "evcraddock/todu-pi-extensions",
+        },
+        project: createProjectSummary(),
+        binding: createBinding(),
+        createdProject: true,
+        createdBinding: true,
+      })
+    ).toContain("Registered project proj-1: todu-pi-extensions");
+  });
+});
+
+describe("createProjectCheckToolDefinition", () => {
+  it("returns a structured registered result", async () => {
+    const projectIntegrationService = {
+      checkRepositoryBinding: vi.fn().mockResolvedValue({
+        kind: "registered",
+        repository: {
+          repositoryPath: "/tmp/repo",
+          remoteName: "origin",
+          remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+          provider: "github",
+          targetRef: "evcraddock/todu-pi-extensions",
+        },
+        project: createProjectSummary(),
+        binding: createBinding(),
+      }),
+    } as unknown as ProjectIntegrationService;
+    const tool = createProjectCheckToolDefinition({
+      getProjectIntegrationService: vi.fn().mockResolvedValue(projectIntegrationService),
+    });
+
+    const result = await tool.execute("tool-call-1", {});
+
+    expect(projectIntegrationService.checkRepositoryBinding).toHaveBeenCalledWith({
+      repositoryPath: undefined,
+      provider: undefined,
+      targetRef: undefined,
+    });
+    expect(result.details).toEqual({
+      kind: "project_check",
+      state: "registered",
+      repositoryPath: undefined,
+      repository: {
+        repositoryPath: "/tmp/repo",
+        remoteName: "origin",
+        remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+        provider: "github",
+        targetRef: "evcraddock/todu-pi-extensions",
+      },
+      project: createProjectSummary(),
+      binding: createBinding(),
+    });
+  });
+
+  it("returns explicit not-registered results", async () => {
+    const tool = createProjectCheckToolDefinition({
+      getProjectIntegrationService: vi.fn().mockResolvedValue({
+        checkRepositoryBinding: vi.fn().mockResolvedValue({
+          kind: "not-registered",
+          repository: {
+            repositoryPath: "/tmp/repo",
+            remoteName: "origin",
+            remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+            provider: "github",
+            targetRef: "evcraddock/todu-pi-extensions",
+          },
+        }),
+      } as unknown as ProjectIntegrationService),
+    });
+
+    const result = await tool.execute("tool-call-1", {});
+
+    expect(result.content[0]?.text).toContain("Registration: Not Registered");
+    expect(result.details).toEqual({
+      kind: "project_check",
+      state: "not-registered",
+      repositoryPath: undefined,
+      repository: {
+        repositoryPath: "/tmp/repo",
+        remoteName: "origin",
+        remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+        provider: "github",
+        targetRef: "evcraddock/todu-pi-extensions",
+      },
+    });
+  });
+
+  it("returns explicit ambiguity results", async () => {
+    const tool = createProjectCheckToolDefinition({
+      getProjectIntegrationService: vi.fn().mockResolvedValue({
+        checkRepositoryBinding: vi.fn().mockResolvedValue({
+          kind: "ambiguous",
+          reason: "multiple-matching-bindings",
+          repository: {
+            repositoryPath: "/tmp/repo",
+            remoteName: "origin",
+            remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+            provider: "github",
+            targetRef: "evcraddock/todu-pi-extensions",
+          },
+          bindings: [createBinding(), createBinding({ id: "ibind-2" })],
+        }),
+      } as unknown as ProjectIntegrationService),
+    });
+
+    const result = await tool.execute("tool-call-1", {});
+
+    expect(result.content[0]?.text).toContain("Registration: Ambiguous");
+    expect(result.details).toEqual({
+      kind: "project_check",
+      state: "ambiguous",
+      repositoryPath: undefined,
+      repository: {
+        repositoryPath: "/tmp/repo",
+        remoteName: "origin",
+        remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+        provider: "github",
+        targetRef: "evcraddock/todu-pi-extensions",
+      },
+      bindings: [createBinding(), createBinding({ id: "ibind-2" })],
+      remotes: undefined,
+      reason: "multiple-matching-bindings",
+    });
+  });
+
+  it("surfaces backend failures with tool-specific context", async () => {
+    const tool = createProjectCheckToolDefinition({
+      getProjectIntegrationService: vi.fn().mockResolvedValue({
+        checkRepositoryBinding: vi.fn().mockRejectedValue(new Error("daemon unavailable")),
+      } as unknown as ProjectIntegrationService),
+    });
+
+    await expect(tool.execute("tool-call-1", {})).rejects.toThrow(
+      "project_check failed: daemon unavailable"
+    );
+  });
+});
+
+describe("createProjectRegisterToolDefinition", () => {
+  it("registers a repository-backed project successfully", async () => {
+    const project = createProjectSummary();
+    const binding = createBinding();
+    const projectIntegrationService = {
+      checkRepositoryBinding: vi.fn().mockResolvedValue({
+        kind: "not-registered",
+        repository: {
+          repositoryPath: "/tmp/repo",
+          remoteName: "origin",
+          remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+          provider: "github",
+          targetRef: "evcraddock/todu-pi-extensions",
+        },
+      }),
+      registerRepositoryProject: vi.fn().mockResolvedValue({
+        kind: "registered",
+        repository: {
+          repositoryPath: "/tmp/repo",
+          remoteName: "origin",
+          remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+          provider: "github",
+          targetRef: "evcraddock/todu-pi-extensions",
+        },
+        project,
+        binding,
+        createdProject: true,
+        createdBinding: true,
+      }),
+    } as unknown as ProjectIntegrationService;
+    const projectService = {
+      listProjects: vi.fn().mockResolvedValue([]),
+    } as unknown as ProjectService;
+    const tool = createProjectRegisterToolDefinition({
+      getProjectIntegrationService: vi.fn().mockResolvedValue(projectIntegrationService),
+      getProjectService: vi.fn().mockResolvedValue(projectService),
+    });
+
+    const result = await tool.execute("tool-call-1", {});
+
+    expect(projectIntegrationService.checkRepositoryBinding).toHaveBeenCalledWith({
+      projectName: undefined,
+      repositoryPath: undefined,
+      provider: undefined,
+      targetRef: undefined,
+      description: undefined,
+      priority: undefined,
+    });
+    expect(projectService.listProjects).toHaveBeenCalledWith();
+    expect(projectIntegrationService.registerRepositoryProject).toHaveBeenCalledWith({
+      projectName: undefined,
+      repositoryPath: undefined,
+      provider: undefined,
+      targetRef: undefined,
+      description: undefined,
+      priority: undefined,
+    });
+    expect(result.details).toEqual({
+      kind: "project_register",
+      state: "registered",
+      repositoryPath: undefined,
+      repository: {
+        repositoryPath: "/tmp/repo",
+        remoteName: "origin",
+        remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+        provider: "github",
+        targetRef: "evcraddock/todu-pi-extensions",
+      },
+      project,
+      binding,
+      createdProject: true,
+      createdBinding: true,
+    });
+  });
+
+  it("returns explicit already-registered results", async () => {
+    const projectIntegrationService = {
+      checkRepositoryBinding: vi.fn().mockResolvedValue({
+        kind: "registered",
+        repository: {
+          repositoryPath: "/tmp/repo",
+          remoteName: "origin",
+          remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+          provider: "github",
+          targetRef: "evcraddock/todu-pi-extensions",
+        },
+        project: createProjectSummary(),
+        binding: createBinding(),
+      }),
+      registerRepositoryProject: vi.fn().mockResolvedValue({
+        kind: "already-registered",
+        repository: {
+          repositoryPath: "/tmp/repo",
+          remoteName: "origin",
+          remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+          provider: "github",
+          targetRef: "evcraddock/todu-pi-extensions",
+        },
+        project: createProjectSummary(),
+        binding: createBinding(),
+      }),
+    } as unknown as ProjectIntegrationService;
+    const tool = createProjectRegisterToolDefinition({
+      getProjectIntegrationService: vi.fn().mockResolvedValue(projectIntegrationService),
+      getProjectService: vi
+        .fn()
+        .mockResolvedValue({ listProjects: vi.fn() } as unknown as ProjectService),
+    });
+
+    const result = await tool.execute("tool-call-1", {});
+
+    expect(result.content[0]?.text).toContain("Repository is already registered.");
+    expect(result.details).toEqual({
+      kind: "project_register",
+      state: "already-registered",
+      repositoryPath: undefined,
+      repository: {
+        repositoryPath: "/tmp/repo",
+        remoteName: "origin",
+        remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+        provider: "github",
+        targetRef: "evcraddock/todu-pi-extensions",
+      },
+      project: createProjectSummary(),
+      binding: createBinding(),
+    });
+  });
+
+  it("returns explicit name-conflict results", async () => {
+    const tool = createProjectRegisterToolDefinition({
+      getProjectIntegrationService: vi.fn().mockResolvedValue({
+        checkRepositoryBinding: vi.fn().mockResolvedValue({
+          kind: "not-registered",
+          repository: {
+            repositoryPath: "/tmp/repo",
+            remoteName: "origin",
+            remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+            provider: "github",
+            targetRef: "evcraddock/todu-pi-extensions",
+          },
+        }),
+      } as unknown as ProjectIntegrationService),
+      getProjectService: vi.fn().mockResolvedValue({
+        listProjects: vi.fn().mockResolvedValue([createProjectSummary()]),
+      } as unknown as ProjectService),
+    });
+
+    const result = await tool.execute("tool-call-1", {});
+
+    expect(result.content[0]?.text).toContain(
+      "Repository registration blocked by project name conflict."
+    );
+    expect(result.details).toEqual({
+      kind: "project_register",
+      state: "name-conflict",
+      repositoryPath: undefined,
+      repository: {
+        repositoryPath: "/tmp/repo",
+        remoteName: "origin",
+        remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+        provider: "github",
+        targetRef: "evcraddock/todu-pi-extensions",
+      },
+      conflictingProjects: [createProjectSummary()],
+      reason: "project-name-conflict",
+    });
+  });
+
+  it("returns explicit missing-context results", async () => {
+    const tool = createProjectRegisterToolDefinition({
+      getProjectIntegrationService: vi.fn().mockResolvedValue({
+        checkRepositoryBinding: vi.fn().mockResolvedValue({
+          kind: "missing-context",
+          reason: "not-a-git-repository",
+          repositoryPath: "/tmp/nope",
+        }),
+        registerRepositoryProject: vi.fn().mockResolvedValue({
+          kind: "missing-context",
+          reason: "not-a-git-repository",
+          repositoryPath: "/tmp/nope",
+        }),
+      } as unknown as ProjectIntegrationService),
+      getProjectService: vi
+        .fn()
+        .mockResolvedValue({ listProjects: vi.fn() } as unknown as ProjectService),
+    });
+
+    const result = await tool.execute("tool-call-1", { repositoryPath: "/tmp/nope" });
+
+    expect(result.content[0]?.text).toContain(
+      "Repository registration requires repository context."
+    );
+    expect(result.details).toEqual({
+      kind: "project_register",
+      state: "missing-context",
+      repositoryPath: "/tmp/nope",
+      reason: "not-a-git-repository",
+    });
+  });
+
+  it("respects explicit provider and targetRef precedence", async () => {
+    const projectIntegrationService = {
+      checkRepositoryBinding: vi.fn().mockResolvedValue({
+        kind: "not-registered",
+        repository: {
+          repositoryPath: "/tmp/repo",
+          remoteName: "origin",
+          remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+          provider: "forgejo",
+          targetRef: "team/custom",
+        },
+      }),
+      registerRepositoryProject: vi.fn().mockResolvedValue({
+        kind: "registered",
+        repository: {
+          repositoryPath: "/tmp/repo",
+          remoteName: "origin",
+          remoteUrl: "git@github.com:evcraddock/todu-pi-extensions.git",
+          provider: "forgejo",
+          targetRef: "team/custom",
+        },
+        project: createProjectSummary({ name: "custom" }),
+        binding: createBinding({ provider: "forgejo", targetRef: "team/custom" }),
+        createdProject: true,
+        createdBinding: true,
+      }),
+    } as unknown as ProjectIntegrationService;
+    const tool = createProjectRegisterToolDefinition({
+      getProjectIntegrationService: vi.fn().mockResolvedValue(projectIntegrationService),
+      getProjectService: vi
+        .fn()
+        .mockResolvedValue({
+          listProjects: vi.fn().mockResolvedValue([]),
+        } as unknown as ProjectService),
+    });
+
+    await tool.execute("tool-call-1", {
+      provider: " forgejo ",
+      targetRef: " team/custom ",
+      repositoryPath: " /tmp/repo ",
+      projectName: " custom ",
+    });
+
+    expect(projectIntegrationService.checkRepositoryBinding).toHaveBeenCalledWith({
+      projectName: "custom",
+      repositoryPath: "/tmp/repo",
+      provider: "forgejo",
+      targetRef: "team/custom",
+      description: undefined,
+      priority: undefined,
+    });
+    expect(projectIntegrationService.registerRepositoryProject).toHaveBeenCalledWith({
+      projectName: "custom",
+      repositoryPath: "/tmp/repo",
+      provider: "forgejo",
+      targetRef: "team/custom",
+      description: undefined,
+      priority: undefined,
+    });
+  });
+
+  it("surfaces backend failures with tool-specific context", async () => {
+    const tool = createProjectRegisterToolDefinition({
+      getProjectIntegrationService: vi.fn().mockResolvedValue({
+        checkRepositoryBinding: vi.fn().mockRejectedValue(new Error("daemon unavailable")),
+      } as unknown as ProjectIntegrationService),
+      getProjectService: vi
+        .fn()
+        .mockResolvedValue({ listProjects: vi.fn() } as unknown as ProjectService),
+    });
+
+    await expect(tool.execute("tool-call-1", {})).rejects.toThrow(
+      "project_register failed: daemon unavailable"
+    );
+  });
+});

--- a/src/extension/register-tools.ts
+++ b/src/extension/register-tools.ts
@@ -1,11 +1,13 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
+import type { ProjectIntegrationService } from "../services/project-integration-service";
 import {
   createProjectServiceFromTaskService,
   type ProjectService,
 } from "../services/project-service";
 import type { TaskService } from "../services/task-service";
 import { getDefaultToduTaskServiceRuntime } from "../services/todu/default-task-service";
+import { registerProjectIntegrationTools } from "../tools/project-integration-tools";
 import { registerProjectMutationTools } from "../tools/project-mutation-tools";
 import { registerProjectReadTools } from "../tools/project-read-tools";
 import { registerTaskMutationTools } from "../tools/task-mutation-tools";
@@ -14,6 +16,7 @@ import { registerTaskReadTools } from "../tools/task-read-tools";
 export interface RegisterToolDependencies {
   getTaskService?: () => Promise<TaskService>;
   getProjectService?: () => Promise<ProjectService>;
+  getProjectIntegrationService?: () => Promise<ProjectIntegrationService>;
 }
 
 const registerTools = (pi: ExtensionAPI, dependencies: RegisterToolDependencies = {}): void => {
@@ -24,9 +27,13 @@ const registerTools = (pi: ExtensionAPI, dependencies: RegisterToolDependencies 
     (dependencies.getTaskService
       ? async () => createProjectServiceFromTaskService(await getTaskService())
       : () => runtime.ensureProjectServiceConnected());
+  const getProjectIntegrationService =
+    dependencies.getProjectIntegrationService ??
+    (() => runtime.ensureProjectIntegrationServiceConnected());
 
   registerTaskReadTools(pi, { getTaskService });
   registerProjectReadTools(pi, { getProjectService });
+  registerProjectIntegrationTools(pi, { getProjectIntegrationService, getProjectService });
   registerProjectMutationTools(pi, { getProjectService });
   registerTaskMutationTools(pi, { getTaskService });
 };

--- a/src/tools/project-integration-tools.ts
+++ b/src/tools/project-integration-tools.ts
@@ -1,0 +1,486 @@
+import { StringEnum } from "@mariozechner/pi-ai";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+
+import type { ProjectSummary, TaskPriority } from "../domain/task";
+import type {
+  IntegrationBinding,
+  ProjectIntegrationService,
+  RegisterRepositoryProjectInput,
+  RepositoryBindingCheckResult,
+  RepositoryProjectRegistrationResult,
+} from "../services/project-integration-service";
+import type { ProjectService } from "../services/project-service";
+import type { ResolvedRepositoryContext } from "../services/repo-context";
+import { ToduProjectIntegrationServiceError } from "../services/todu/todu-project-integration-service";
+import { ToduProjectServiceError } from "../services/todu/todu-project-service";
+
+const PROJECT_PRIORITY_VALUES = ["low", "medium", "high"] as const;
+
+const ProjectCheckParams = Type.Object({
+  repositoryPath: Type.Optional(Type.String({ description: "Optional repository path override" })),
+  provider: Type.Optional(Type.String({ description: "Optional explicit repository provider" })),
+  targetRef: Type.Optional(
+    Type.String({ description: "Optional explicit repository target reference, like owner/repo" })
+  ),
+});
+
+const ProjectRegisterParams = Type.Object({
+  projectName: Type.Optional(Type.String({ description: "Optional project name override" })),
+  repositoryPath: Type.Optional(Type.String({ description: "Optional repository path override" })),
+  provider: Type.Optional(Type.String({ description: "Optional explicit repository provider" })),
+  targetRef: Type.Optional(
+    Type.String({ description: "Optional explicit repository target reference, like owner/repo" })
+  ),
+  description: Type.Optional(Type.String({ description: "Optional project description" })),
+  priority: Type.Optional(
+    StringEnum(PROJECT_PRIORITY_VALUES, { description: "Optional project priority" })
+  ),
+});
+
+interface ProjectCheckToolParams {
+  repositoryPath?: string;
+  provider?: string;
+  targetRef?: string;
+}
+
+interface ProjectRegisterToolParams extends ProjectCheckToolParams {
+  projectName?: string;
+  description?: string;
+  priority?: TaskPriority;
+}
+
+interface ProjectCheckToolDetails {
+  kind: "project_check";
+  state: "registered" | "not-registered" | "ambiguous" | "missing-context" | "unsupported";
+  repositoryPath?: string;
+  repository?: ResolvedRepositoryContext;
+  reason?: string;
+  project?: ProjectSummary | null;
+  binding?: IntegrationBinding;
+  bindings?: IntegrationBinding[];
+  remotes?: string[];
+}
+
+interface ProjectRegisterToolDetails {
+  kind: "project_register";
+  state:
+    | "registered"
+    | "already-registered"
+    | "name-conflict"
+    | "ambiguous"
+    | "missing-context"
+    | "unsupported";
+  repositoryPath?: string;
+  repository?: ResolvedRepositoryContext;
+  project?: ProjectSummary | null;
+  binding?: IntegrationBinding;
+  createdProject?: boolean;
+  createdBinding?: boolean;
+  conflictingProjects?: ProjectSummary[];
+  reason?: string;
+  remotes?: string[];
+  bindings?: IntegrationBinding[];
+}
+
+interface ProjectIntegrationToolDependencies {
+  getProjectIntegrationService: () => Promise<ProjectIntegrationService>;
+  getProjectService: () => Promise<ProjectService>;
+}
+
+const createProjectCheckToolDefinition = ({
+  getProjectIntegrationService,
+}: Pick<ProjectIntegrationToolDependencies, "getProjectIntegrationService">) => ({
+  name: "project_check",
+  label: "Project Check",
+  description: "Check whether a repository is registered to a project.",
+  promptSnippet:
+    "Check whether a repository is registered through the integration-aware project service.",
+  promptGuidelines: [
+    "Use this tool for repository-aware registration checks in normal chat.",
+    "Keep project_check read-only and return explicit registered, not-registered, or ambiguous states.",
+    "Explicit repositoryPath, provider, and targetRef inputs override ambient repo detection where applicable.",
+  ],
+  parameters: ProjectCheckParams,
+  async execute(_toolCallId: string, params: ProjectCheckToolParams) {
+    try {
+      const input = normalizeProjectCheckInput(params);
+      const projectIntegrationService = await getProjectIntegrationService();
+      const result = await projectIntegrationService.checkRepositoryBinding(input);
+      const details = mapProjectCheckDetails(result, input.repositoryPath);
+
+      return {
+        content: [{ type: "text" as const, text: formatProjectCheckContent(details) }],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "project_check failed"), { cause: error });
+    }
+  },
+});
+
+const createProjectRegisterToolDefinition = ({
+  getProjectIntegrationService,
+  getProjectService,
+}: ProjectIntegrationToolDependencies) => ({
+  name: "project_register",
+  label: "Project Register",
+  description: "Register a repository-backed project through integration-aware services.",
+  promptSnippet:
+    "Register a repository-backed project without collapsing repo registration into plain project_create.",
+  promptGuidelines: [
+    "Use this tool only for repository-aware project registration in normal chat.",
+    "Do not use project_register as a synonym for plain local project_create.",
+    "Report name conflicts, duplicate bindings, ambiguous remotes, and missing repository context explicitly.",
+    "Explicit repositoryPath, provider, and targetRef inputs override ambient repo detection where applicable.",
+  ],
+  parameters: ProjectRegisterParams,
+  async execute(_toolCallId: string, params: ProjectRegisterToolParams) {
+    try {
+      const input = normalizeProjectRegisterInput(params);
+      const projectIntegrationService = await getProjectIntegrationService();
+      const initialCheck = await projectIntegrationService.checkRepositoryBinding(input);
+      const nameConflict =
+        initialCheck.kind === "not-registered"
+          ? await findProjectNameConflict(getProjectService, input, initialCheck)
+          : null;
+
+      if (nameConflict) {
+        const details: ProjectRegisterToolDetails = {
+          kind: "project_register",
+          state: "name-conflict",
+          repositoryPath: input.repositoryPath,
+          repository: initialCheck.kind === "not-registered" ? initialCheck.repository : undefined,
+          conflictingProjects: nameConflict,
+          reason: "project-name-conflict",
+        };
+
+        return {
+          content: [{ type: "text" as const, text: formatProjectRegisterContent(details) }],
+          details,
+        };
+      }
+
+      const result = await projectIntegrationService.registerRepositoryProject(input);
+      const details = mapProjectRegisterDetails(result, input.repositoryPath);
+
+      return {
+        content: [{ type: "text" as const, text: formatProjectRegisterContent(details) }],
+        details,
+      };
+    } catch (error) {
+      if (isProjectConflictError(error)) {
+        const details: ProjectRegisterToolDetails = {
+          kind: "project_register",
+          state: "name-conflict",
+          repositoryPath: params.repositoryPath?.trim() || undefined,
+          conflictingProjects: [],
+          reason: error.message,
+        };
+
+        return {
+          content: [{ type: "text" as const, text: formatProjectRegisterContent(details) }],
+          details,
+        };
+      }
+
+      throw new Error(formatToolError(error, "project_register failed"), { cause: error });
+    }
+  },
+});
+
+const registerProjectIntegrationTools = (
+  pi: Pick<ExtensionAPI, "registerTool">,
+  dependencies: ProjectIntegrationToolDependencies
+): void => {
+  pi.registerTool(createProjectCheckToolDefinition(dependencies));
+  pi.registerTool(createProjectRegisterToolDefinition(dependencies));
+};
+
+const normalizeProjectCheckInput = (params: ProjectCheckToolParams): ProjectCheckToolParams => ({
+  repositoryPath: normalizeOptionalText(params.repositoryPath),
+  provider: normalizeOptionalText(params.provider),
+  targetRef: normalizeOptionalText(params.targetRef),
+});
+
+const normalizeProjectRegisterInput = (
+  params: ProjectRegisterToolParams
+): RegisterRepositoryProjectInput => ({
+  projectName: normalizeOptionalText(params.projectName),
+  repositoryPath: normalizeOptionalText(params.repositoryPath),
+  provider: normalizeOptionalText(params.provider),
+  targetRef: normalizeOptionalText(params.targetRef),
+  description: hasOwn(params, "description")
+    ? normalizeNullableText(params.description)
+    : undefined,
+  priority: params.priority,
+});
+
+const mapProjectCheckDetails = (
+  result: RepositoryBindingCheckResult,
+  repositoryPath?: string
+): ProjectCheckToolDetails => {
+  switch (result.kind) {
+    case "registered":
+      return {
+        kind: "project_check",
+        state: "registered",
+        repositoryPath,
+        repository: result.repository,
+        project: result.project,
+        binding: result.binding,
+      };
+    case "not-registered":
+      return {
+        kind: "project_check",
+        state: "not-registered",
+        repositoryPath,
+        repository: result.repository,
+      };
+    case "ambiguous":
+      return {
+        kind: "project_check",
+        state: "ambiguous",
+        repositoryPath: result.repositoryPath ?? repositoryPath,
+        repository: result.repository,
+        bindings: result.bindings,
+        remotes: result.remotes,
+        reason: result.reason,
+      };
+    case "missing-context":
+      return {
+        kind: "project_check",
+        state: "missing-context",
+        repositoryPath: result.repositoryPath ?? repositoryPath,
+        reason: result.reason,
+      };
+    case "unsupported":
+      return {
+        kind: "project_check",
+        state: "unsupported",
+        repositoryPath: result.repositoryPath ?? repositoryPath,
+        reason: result.reason,
+      };
+  }
+};
+
+const mapProjectRegisterDetails = (
+  result: RepositoryProjectRegistrationResult,
+  repositoryPath?: string
+): ProjectRegisterToolDetails => {
+  if (result.kind === "registered" && "createdProject" in result) {
+    return {
+      kind: "project_register",
+      state: "registered",
+      repositoryPath,
+      repository: result.repository,
+      project: result.project,
+      binding: result.binding,
+      createdProject: result.createdProject,
+      createdBinding: result.createdBinding,
+    };
+  }
+
+  switch (result.kind) {
+    case "already-registered":
+      return {
+        kind: "project_register",
+        state: "already-registered",
+        repositoryPath,
+        repository: result.repository,
+        project: result.project,
+        binding: result.binding,
+      };
+    case "ambiguous":
+      return {
+        kind: "project_register",
+        state: "ambiguous",
+        repositoryPath: result.repositoryPath ?? repositoryPath,
+        repository: result.repository,
+        bindings: result.bindings,
+        remotes: result.remotes,
+        reason: result.reason,
+      };
+    case "missing-context":
+      return {
+        kind: "project_register",
+        state: "missing-context",
+        repositoryPath: result.repositoryPath ?? repositoryPath,
+        reason: result.reason,
+      };
+    case "unsupported":
+      return {
+        kind: "project_register",
+        state: "unsupported",
+        repositoryPath: result.repositoryPath ?? repositoryPath,
+        reason: result.reason,
+      };
+    case "not-registered":
+      return {
+        kind: "project_register",
+        state: "missing-context",
+        repositoryPath,
+        repository: result.repository,
+        reason: "not-registered",
+      };
+    case "registered":
+      return {
+        kind: "project_register",
+        state: "already-registered",
+        repositoryPath,
+        repository: result.repository,
+        project: result.project,
+        binding: result.binding,
+      };
+  }
+};
+
+const findProjectNameConflict = async (
+  getProjectService: () => Promise<ProjectService>,
+  input: RegisterRepositoryProjectInput,
+  result: Extract<RepositoryBindingCheckResult, { kind: "not-registered" }>
+): Promise<ProjectSummary[] | null> => {
+  const requestedName = normalizeProjectRegisterName(
+    input.projectName,
+    result.repository.targetRef
+  );
+  const projectService = await getProjectService();
+  const projects = await projectService.listProjects();
+  const matches = projects.filter((project) => project.name === requestedName);
+  return matches.length > 0 ? matches : null;
+};
+
+const normalizeProjectRegisterName = (
+  projectName: string | undefined,
+  targetRef: string
+): string => {
+  const trimmedName = projectName?.trim();
+  if (trimmedName && trimmedName.length > 0) {
+    return trimmedName;
+  }
+
+  const segments = targetRef.split("/");
+  return segments[segments.length - 1] ?? targetRef;
+};
+
+const formatProjectCheckContent = (details: ProjectCheckToolDetails): string => {
+  switch (details.state) {
+    case "registered":
+      return [
+        "Registration: Registered",
+        `Project: ${details.project?.name ?? details.binding?.projectId ?? "(missing project)"}`,
+        `Provider: ${details.repository?.provider ?? "-"}`,
+        `Repository: ${details.repository?.targetRef ?? "-"}`,
+        `Integration ID: ${details.binding?.id ?? "-"}`,
+      ].join("\n");
+    case "not-registered":
+      return [
+        "Registration: Not Registered",
+        `Provider: ${details.repository?.provider ?? "-"}`,
+        `Repository: ${details.repository?.targetRef ?? "-"}`,
+        "Integration ID: -",
+      ].join("\n");
+    case "ambiguous":
+      return [
+        "Registration: Ambiguous",
+        `Reason: ${details.reason ?? "ambiguous"}`,
+        details.remotes ? `Remotes: ${details.remotes.join(", ")}` : null,
+        details.bindings
+          ? `Matching Bindings: ${details.bindings.map((binding) => binding.id).join(", ")}`
+          : null,
+      ]
+        .filter((value): value is string => value !== null)
+        .join("\n");
+    case "missing-context":
+      return `Registration: Missing Repository Context\nReason: ${details.reason ?? "missing-context"}`;
+    case "unsupported":
+      return `Registration: Unsupported Repository Remote\nReason: ${details.reason ?? "unsupported-remote-format"}`;
+  }
+};
+
+const formatProjectRegisterContent = (details: ProjectRegisterToolDetails): string => {
+  switch (details.state) {
+    case "registered":
+      return [
+        `Registered project ${details.project?.id ?? "-"}: ${details.project?.name ?? "-"}`,
+        `Provider: ${details.repository?.provider ?? "-"}`,
+        `Repository: ${details.repository?.targetRef ?? "-"}`,
+        `Integration ID: ${details.binding?.id ?? "-"}`,
+      ].join("\n");
+    case "already-registered":
+      return [
+        "Repository is already registered.",
+        `Project: ${details.project?.name ?? details.binding?.projectId ?? "(missing project)"}`,
+        `Provider: ${details.repository?.provider ?? "-"}`,
+        `Repository: ${details.repository?.targetRef ?? "-"}`,
+      ].join("\n");
+    case "name-conflict":
+      return [
+        "Repository registration blocked by project name conflict.",
+        details.conflictingProjects && details.conflictingProjects.length > 0
+          ? `Conflicting Projects: ${details.conflictingProjects.map((project) => `${project.id} (${project.name})`).join(", ")}`
+          : null,
+        details.reason ? `Reason: ${details.reason}` : null,
+      ]
+        .filter((value): value is string => value !== null)
+        .join("\n");
+    case "ambiguous":
+      return [
+        "Repository registration is ambiguous.",
+        `Reason: ${details.reason ?? "ambiguous"}`,
+        details.remotes ? `Remotes: ${details.remotes.join(", ")}` : null,
+        details.bindings
+          ? `Matching Bindings: ${details.bindings.map((binding) => binding.id).join(", ")}`
+          : null,
+      ]
+        .filter((value): value is string => value !== null)
+        .join("\n");
+    case "missing-context":
+      return `Repository registration requires repository context.\nReason: ${details.reason ?? "missing-context"}`;
+    case "unsupported":
+      return `Repository registration failed for an unsupported remote.\nReason: ${details.reason ?? "unsupported-remote-format"}`;
+  }
+};
+
+const normalizeOptionalText = (value: string | undefined): string | undefined => {
+  const trimmedValue = value?.trim();
+  return trimmedValue && trimmedValue.length > 0 ? trimmedValue : undefined;
+};
+
+const normalizeNullableText = (value: string | undefined): string | null => {
+  const trimmedValue = value?.trim() ?? "";
+  return trimmedValue.length > 0 ? trimmedValue : null;
+};
+
+const hasOwn = <TObject extends object>(value: TObject, property: keyof TObject): boolean =>
+  Object.prototype.hasOwnProperty.call(value, property);
+
+const isProjectConflictError = (
+  error: unknown
+): error is ToduProjectServiceError | ToduProjectIntegrationServiceError =>
+  (error instanceof ToduProjectServiceError ||
+    error instanceof ToduProjectIntegrationServiceError) &&
+  error.causeCode === "conflict";
+
+const formatToolError = (error: unknown, prefix: string): string => {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return `${prefix}: ${error.message}`;
+  }
+
+  return prefix;
+};
+
+export type {
+  ProjectCheckToolDetails,
+  ProjectIntegrationToolDependencies,
+  ProjectRegisterToolDetails,
+};
+export {
+  createProjectCheckToolDefinition,
+  createProjectRegisterToolDefinition,
+  formatProjectCheckContent,
+  formatProjectRegisterContent,
+  normalizeProjectCheckInput,
+  normalizeProjectRegisterInput,
+  registerProjectIntegrationTools,
+};


### PR DESCRIPTION
## Summary
- add native project_check and project_register tools on top of the integration service boundary
- keep outcomes explicit for registration state, ambiguity, missing context, and name conflicts
- add focused tests for tool registration, success, precedence, conflict, and failure paths

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm test
- ./scripts/pre-pr.sh

Refs: task-895d60f4