### PR TITLE
feat: add shared scheduling foundation

### DIFF
--- a/src/__tests__/project-integration-tools.test.ts
+++ b/src/__tests__/project-integration-tools.test.ts
@@ -454,11 +454,9 @@ describe("createProjectRegisterToolDefinition", () => {
     } as unknown as ProjectIntegrationService;
     const tool = createProjectRegisterToolDefinition({
       getProjectIntegrationService: vi.fn().mockResolvedValue(projectIntegrationService),
-      getProjectService: vi
-        .fn()
-        .mockResolvedValue({
-          listProjects: vi.fn().mockResolvedValue([]),
-        } as unknown as ProjectService),
+      getProjectService: vi.fn().mockResolvedValue({
+        listProjects: vi.fn().mockResolvedValue([]),
+      } as unknown as ProjectService),
     });
 
     await tool.execute("tool-call-1", {

--- a/src/__tests__/schedule.test.ts
+++ b/src/__tests__/schedule.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createScheduleValidationIssue,
+  normalizeSchedulePartValue,
+  parseScheduleRuleParts,
+  validateAndNormalizeScheduleRule,
+} from "@/utils/schedule";
+
+describe("normalizeSchedulePartValue", () => {
+  it("uppercases FREQ and WKST values", () => {
+    expect(normalizeSchedulePartValue("FREQ", "daily")).toBe("DAILY");
+    expect(normalizeSchedulePartValue("WKST", "su")).toBe("SU");
+  });
+
+  it("normalizes BYDAY lists", () => {
+    expect(normalizeSchedulePartValue("BYDAY", "mo, we,fr")).toBe("MO,WE,FR");
+  });
+
+  it("preserves non-uppercase values", () => {
+    expect(normalizeSchedulePartValue("INTERVAL", "2")).toBe("2");
+    expect(normalizeSchedulePartValue("BYMONTHDAY", "-1")).toBe("-1");
+  });
+});
+
+describe("parseScheduleRuleParts", () => {
+  it("parses and sorts entries with FREQ first", () => {
+    const result = parseScheduleRuleParts("byday=mo,we,fr; interval=2; freq=weekly");
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        entries: [
+          ["FREQ", "WEEKLY"],
+          ["BYDAY", "MO,WE,FR"],
+          ["INTERVAL", "2"],
+        ],
+      },
+    });
+  });
+
+  it("rejects duplicate keys", () => {
+    expect(parseScheduleRuleParts("FREQ=DAILY;FREQ=WEEKLY")).toEqual({
+      ok: false,
+      error: createScheduleValidationIssue(
+        "invalid-rrule",
+        "Duplicate RRULE part is not supported: FREQ"
+      ),
+    });
+  });
+
+  it("rejects malformed parts", () => {
+    expect(parseScheduleRuleParts("FREQ=DAILY;BYDAY")).toEqual({
+      ok: false,
+      error: createScheduleValidationIssue("invalid-rrule", "Invalid RRULE part: BYDAY"),
+    });
+  });
+
+  it("rejects blank input", () => {
+    expect(parseScheduleRuleParts("   ")).toEqual({
+      ok: false,
+      error: createScheduleValidationIssue("invalid-rrule", "RRULE is required"),
+    });
+  });
+});
+
+describe("validateAndNormalizeScheduleRule", () => {
+  it("normalizes casing, whitespace, and part ordering", () => {
+    const result = validateAndNormalizeScheduleRule(" byday=mo,we,fr ; interval=2 ; freq=weekly ");
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        rule: "FREQ=WEEKLY;BYDAY=MO,WE,FR;INTERVAL=2",
+        parts: {
+          FREQ: "WEEKLY",
+          BYDAY: "MO,WE,FR",
+          INTERVAL: "2",
+        },
+        changed: true,
+      },
+    });
+  });
+
+  it("returns unchanged false for canonical input", () => {
+    const result = validateAndNormalizeScheduleRule("FREQ=DAILY;INTERVAL=1");
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        rule: "FREQ=DAILY;INTERVAL=1",
+        parts: {
+          FREQ: "DAILY",
+          INTERVAL: "1",
+        },
+        changed: false,
+      },
+    });
+  });
+
+  it("maps unsupported sub-daily rules explicitly", () => {
+    const result = validateAndNormalizeScheduleRule("FREQ=HOURLY");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected invalid result");
+    }
+
+    expect(result.error.code).toBe("unsupported-rrule");
+    expect(result.error.field).toBe("schedule");
+    expect(result.error.message).toContain("Sub-daily");
+    expect(result.error.cause?.type).toBe("validation");
+  });
+
+  it("maps invalid rules explicitly", () => {
+    const result = validateAndNormalizeScheduleRule("INTERVAL=2");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected invalid result");
+    }
+
+    expect(result.error.code).toBe("invalid-rrule");
+    expect(result.error.field).toBe("schedule");
+    expect(result.error.message).toContain("FREQ");
+  });
+});

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -1,0 +1,185 @@
+import { type ValidationError, validateRRule } from "@todu/core";
+
+const FREQ_FIRST_PART = "FREQ";
+const UPPERCASE_VALUE_KEYS = new Set(["FREQ", "BYDAY", "WKST"]);
+
+export type ScheduleValidationCode = "invalid-rrule" | "unsupported-rrule";
+
+export interface NormalizedScheduleRule {
+  rule: string;
+  parts: Readonly<Record<string, string>>;
+  changed: boolean;
+}
+
+export interface ScheduleValidationIssue {
+  code: ScheduleValidationCode;
+  field: "schedule";
+  message: string;
+  cause?: ValidationError;
+}
+
+export type NormalizeScheduleRuleResult =
+  | {
+      ok: true;
+      value: NormalizedScheduleRule;
+    }
+  | {
+      ok: false;
+      error: ScheduleValidationIssue;
+    };
+
+const validateAndNormalizeScheduleRule = (rule: string): NormalizeScheduleRuleResult => {
+  const parseResult = parseScheduleRuleParts(rule);
+  if (!parseResult.ok) {
+    return parseResult;
+  }
+
+  const normalizedRule = formatNormalizedRule(parseResult.value.entries);
+  const validationError = validateRRule(normalizedRule);
+  if (validationError) {
+    return {
+      ok: false,
+      error: mapScheduleValidationError(validationError),
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      rule: normalizedRule,
+      parts: Object.freeze(Object.fromEntries(parseResult.value.entries)),
+      changed: normalizedRule !== rule.trim(),
+    },
+  };
+};
+
+const parseScheduleRuleParts = (
+  rule: string
+):
+  | {
+      ok: true;
+      value: {
+        entries: Array<[string, string]>;
+      };
+    }
+  | {
+      ok: false;
+      error: ScheduleValidationIssue;
+    } => {
+  const trimmedRule = rule.trim();
+  if (trimmedRule.length === 0) {
+    return {
+      ok: false,
+      error: createScheduleValidationIssue("invalid-rrule", "RRULE is required"),
+    };
+  }
+
+  const entries = new Map<string, string>();
+  for (const rawPart of trimmedRule.split(";")) {
+    const trimmedPart = rawPart.trim();
+    if (trimmedPart.length === 0) {
+      return {
+        ok: false,
+        error: createScheduleValidationIssue("invalid-rrule", "Invalid RRULE part: empty part"),
+      };
+    }
+
+    const separatorIndex = trimmedPart.indexOf("=");
+    if (separatorIndex <= 0 || separatorIndex === trimmedPart.length - 1) {
+      return {
+        ok: false,
+        error: createScheduleValidationIssue("invalid-rrule", `Invalid RRULE part: ${trimmedPart}`),
+      };
+    }
+
+    const key = trimmedPart.slice(0, separatorIndex).trim().toUpperCase();
+    const rawValue = trimmedPart.slice(separatorIndex + 1).trim();
+    if (key.length === 0 || rawValue.length === 0) {
+      return {
+        ok: false,
+        error: createScheduleValidationIssue("invalid-rrule", `Invalid RRULE part: ${trimmedPart}`),
+      };
+    }
+
+    if (entries.has(key)) {
+      return {
+        ok: false,
+        error: createScheduleValidationIssue(
+          "invalid-rrule",
+          `Duplicate RRULE part is not supported: ${key}`
+        ),
+      };
+    }
+
+    entries.set(key, normalizeSchedulePartValue(key, rawValue));
+  }
+
+  return {
+    ok: true,
+    value: {
+      entries: [...entries.entries()].sort(compareScheduleEntries),
+    },
+  };
+};
+
+const normalizeSchedulePartValue = (key: string, value: string): string => {
+  if (key === "BYDAY") {
+    return value
+      .split(",")
+      .map((entry) => entry.trim().toUpperCase())
+      .filter((entry) => entry.length > 0)
+      .join(",");
+  }
+
+  if (UPPERCASE_VALUE_KEYS.has(key)) {
+    return value.toUpperCase();
+  }
+
+  return value;
+};
+
+const compareScheduleEntries = (left: [string, string], right: [string, string]): number => {
+  if (left[0] === right[0]) {
+    return 0;
+  }
+
+  if (left[0] === FREQ_FIRST_PART) {
+    return -1;
+  }
+
+  if (right[0] === FREQ_FIRST_PART) {
+    return 1;
+  }
+
+  return left[0].localeCompare(right[0]);
+};
+
+const formatNormalizedRule = (entries: ReadonlyArray<readonly [string, string]>): string =>
+  entries.map(([key, value]) => `${key}=${value}`).join(";");
+
+const mapScheduleValidationError = (error: ValidationError): ScheduleValidationIssue => ({
+  code: error.message.includes("not supported") ? "unsupported-rrule" : "invalid-rrule",
+  field: "schedule",
+  message: error.message,
+  cause: error,
+});
+
+const createScheduleValidationIssue = (
+  code: ScheduleValidationCode,
+  message: string,
+  cause?: ValidationError
+): ScheduleValidationIssue => ({
+  code,
+  field: "schedule",
+  message,
+  cause,
+});
+
+export {
+  createScheduleValidationIssue,
+  formatNormalizedRule,
+  mapScheduleValidationError,
+  normalizeSchedulePartValue,
+  parseScheduleRuleParts,
+  validateAndNormalizeScheduleRule,
+};


### PR DESCRIPTION
## Summary
- add a shared RRULE scheduling helper for deterministic parse/validate/normalize behavior
- add focused tests for canonicalization, invalid rules, and unsupported sub-daily rules
- keep the helper narrowly scoped for future habit and recurring service reuse

## Verification
- ./scripts/pre-pr.sh

Task: #task-f8ff1869