### PR TITLE
feat: add native task_delete tool

### DIFF
--- a/src/__tests__/daemon-client.test.ts
+++ b/src/__tests__/daemon-client.test.ts
@@ -616,4 +616,38 @@ describe("createToduDaemonClient", () => {
     );
     expect(listener).toHaveBeenCalledWith({ name: "data.changed", payload: { ok: true } });
   });
+
+  it("deletes a task through task.delete", async () => {
+    const connection = createConnectionMock();
+    connection.request.mockResolvedValue({ ok: true, value: null });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    const result = await client.deleteTask("task-1");
+
+    expect(result).toEqual({ taskId: "task-1", deleted: true });
+    expect(connection.request).toHaveBeenCalledWith("task.delete", { id: "task-1" });
+  });
+
+  it("throws a client error when task.delete fails", async () => {
+    const connection = createConnectionMock();
+    connection.request.mockResolvedValue({
+      ok: false,
+      error: { code: "NOT_FOUND", message: "Task not found" },
+    });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await expect(client.deleteTask("task-missing")).rejects.toThrow("task.delete failed");
+  });
 });

--- a/src/__tests__/task-mutation-tools.test.ts
+++ b/src/__tests__/task-mutation-tools.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 import type { ProjectSummary, TaskComment, TaskDetail } from "@/domain/task";
 import { registerTools } from "@/extension/register-tools";
 import type { TaskService } from "@/services/task-service";
+import { ToduTaskServiceError } from "@/services/todu/todu-task-service";
 import {
   createTaskCommentCreateToolDefinition,
   createTaskCreateToolDefinition,
+  createTaskDeleteToolDefinition,
   createTaskUpdateToolDefinition,
   normalizeCreateTaskInput,
   normalizeTaskCommentInput,
@@ -478,5 +480,86 @@ describe("createTaskCommentCreateToolDefinition", () => {
         content: "Added a note",
       })
     ).rejects.toThrow("task_comment_create failed: daemon unavailable");
+  });
+});
+
+describe("registerTools", () => {
+  it("registers the task_delete tool", () => {
+    const pi = { registerTool: vi.fn() };
+
+    registerTools(pi as never, {
+      getTaskService: vi.fn().mockResolvedValue({} as TaskService),
+    });
+
+    const registeredToolNames = pi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(registeredToolNames).toEqual(expect.arrayContaining(["task_delete"]));
+  });
+});
+
+describe("createTaskDeleteToolDefinition", () => {
+  it("deletes a task and returns structured details", async () => {
+    const taskService = {
+      deleteTask: vi.fn().mockResolvedValue({ taskId: "task-1", deleted: true }),
+    } as unknown as TaskService;
+
+    const tool = createTaskDeleteToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    const result = await tool.execute("tc-1", { taskId: "task-1" });
+
+    expect(result.content[0]?.text).toContain("Deleted task task-1");
+    expect(result.details).toMatchObject({
+      kind: "task_delete",
+      taskId: "task-1",
+      found: true,
+      deleted: true,
+    });
+  });
+
+  it("returns not-found when task does not exist", async () => {
+    const taskService = {
+      deleteTask: vi.fn().mockRejectedValue(
+        new ToduTaskServiceError({
+          operation: "deleteTask",
+          causeCode: "not-found",
+          message: "deleteTask failed",
+        })
+      ),
+    } as unknown as TaskService;
+
+    const tool = createTaskDeleteToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    const result = await tool.execute("tc-1", { taskId: "task-missing" });
+
+    expect(result.content[0]?.text).toContain("Task not found: task-missing");
+    expect(result.details).toMatchObject({
+      kind: "task_delete",
+      taskId: "task-missing",
+      found: false,
+      deleted: false,
+    });
+  });
+
+  it("rejects empty taskId", async () => {
+    const tool = createTaskDeleteToolDefinition({
+      getTaskService: vi.fn(),
+    });
+
+    await expect(tool.execute("tc-1", { taskId: "  " })).rejects.toThrow("taskId is required");
+  });
+
+  it("throws on non-not-found service errors", async () => {
+    const taskService = {
+      deleteTask: vi.fn().mockRejectedValue(new Error("connection lost")),
+    } as unknown as TaskService;
+
+    const tool = createTaskDeleteToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    await expect(tool.execute("tc-1", { taskId: "task-1" })).rejects.toThrow("task_delete failed");
   });
 });

--- a/src/__tests__/todu-task-service.test.ts
+++ b/src/__tests__/todu-task-service.test.ts
@@ -49,6 +49,7 @@ describe("createToduTaskService", () => {
       updateHabit: vi.fn(),
       checkHabit: vi.fn(),
       deleteHabit: vi.fn(),
+      deleteTask: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -107,6 +108,7 @@ describe("createToduTaskService", () => {
       updateHabit: vi.fn(),
       checkHabit: vi.fn(),
       deleteHabit: vi.fn(),
+      deleteTask: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -168,6 +170,7 @@ describe("createToduTaskService", () => {
       updateHabit: vi.fn(),
       checkHabit: vi.fn(),
       deleteHabit: vi.fn(),
+      deleteTask: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -234,6 +237,7 @@ describe("createToduTaskService", () => {
       updateHabit: vi.fn(),
       checkHabit: vi.fn(),
       deleteHabit: vi.fn(),
+      deleteTask: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -311,6 +315,7 @@ describe("createToduTaskService", () => {
       updateHabit: vi.fn(),
       checkHabit: vi.fn(),
       deleteHabit: vi.fn(),
+      deleteTask: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -331,5 +336,36 @@ describe("createToduTaskService", () => {
     });
     expect(client.getTask).toHaveBeenCalledTimes(2);
     expect(client.getProject).toHaveBeenCalledTimes(2);
+  });
+
+  it("delegates deleteTask to the daemon client", async () => {
+    const client = {
+      deleteTask: vi.fn().mockResolvedValue({ taskId: "task-1", deleted: true }),
+    };
+    const taskService = createToduTaskService({ client: client as never });
+
+    const result = await taskService.deleteTask("task-1");
+
+    expect(result).toEqual({ taskId: "task-1", deleted: true });
+    expect(client.deleteTask).toHaveBeenCalledWith("task-1");
+  });
+
+  it("wraps daemon client errors for deleteTask", async () => {
+    const client = {
+      deleteTask: vi.fn().mockRejectedValue(
+        new ToduDaemonClientError({
+          code: "not-found",
+          method: "task.delete",
+          message: "Task not found",
+        })
+      ),
+    };
+    const taskService = createToduTaskService({ client: client as never });
+
+    await expect(taskService.deleteTask("task-missing")).rejects.toThrow(ToduTaskServiceError);
+    await expect(taskService.deleteTask("task-missing")).rejects.toMatchObject({
+      operation: "deleteTask",
+      causeCode: "not-found",
+    });
   });
 });

--- a/src/services/task-service.ts
+++ b/src/services/task-service.ts
@@ -29,6 +29,11 @@ export interface AddTaskCommentInput {
   content: string;
 }
 
+export interface DeleteTaskResult {
+  taskId: TaskId;
+  deleted: true;
+}
+
 export interface TaskService {
   listTasks(filter?: TaskFilter): Promise<TaskSummary[]>;
   getTask(taskId: TaskId): Promise<TaskDetail | null>;
@@ -39,5 +44,6 @@ export interface TaskService {
   // Future project-specific work should prefer ProjectService.
   listProjects(): Promise<ProjectSummary[]>;
   getProject(projectId: string): Promise<ProjectSummary | null>;
+  deleteTask(taskId: TaskId): Promise<DeleteTaskResult>;
   listTaskComments(taskId: TaskId): Promise<TaskComment[]>;
 }

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -47,7 +47,12 @@ import type {
   DeleteRecurringResult,
   UpdateRecurringInput,
 } from "../recurring-service";
-import type { AddTaskCommentInput, CreateTaskInput, UpdateTaskInput } from "../task-service";
+import type {
+  AddTaskCommentInput,
+  CreateTaskInput,
+  DeleteTaskResult,
+  UpdateTaskInput,
+} from "../task-service";
 import type { ToduDaemonConnection, ToduDaemonConnectionError } from "./daemon-connection";
 import type {
   ToduDaemonEvent,
@@ -110,6 +115,7 @@ export interface ToduDaemonClient {
   deleteRecurring(recurringId: string): Promise<DeleteRecurringResult>;
   listIntegrationBindings(filter?: IntegrationBindingFilter): Promise<IntegrationBinding[]>;
   createIntegrationBinding(input: CreateIntegrationBindingInput): Promise<IntegrationBinding>;
+  deleteTask(taskId: TaskId): Promise<DeleteTaskResult>;
   listHabits(filter?: HabitFilter): Promise<HabitSummary[]>;
   getHabit(habitId: string): Promise<HabitDetail | null>;
   createHabit(input: CreateHabitInput): Promise<HabitDetail>;
@@ -186,6 +192,18 @@ const createToduDaemonClient = ({
     }
 
     return mapTaskComment(noteResult.value);
+  },
+
+  async deleteTask(taskId: TaskId): Promise<DeleteTaskResult> {
+    const result = await connection.request<null>("task.delete", { id: taskId });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("task.delete", result.error);
+    }
+
+    return {
+      taskId,
+      deleted: true,
+    };
   },
 
   async listProjects(): Promise<ToduProjectSummary[]> {

--- a/src/services/todu/todu-task-service.ts
+++ b/src/services/todu/todu-task-service.ts
@@ -50,6 +50,7 @@ const createToduTaskService = ({ client }: ToduTaskServiceDependencies): TaskSer
     }),
   addTaskComment: (input) =>
     runTaskServiceOperation("addTaskComment", () => client.addTaskComment(input)),
+  deleteTask: (taskId) => runTaskServiceOperation("deleteTask", () => client.deleteTask(taskId)),
   listProjects: () => runTaskServiceOperation("listProjects", () => client.listProjects()),
   getProject: (projectId) =>
     runTaskServiceOperation("getProject", () => client.getProject(projectId)),

--- a/src/tools/task-mutation-tools.ts
+++ b/src/tools/task-mutation-tools.ts
@@ -16,9 +16,11 @@ import { updateTask } from "../flows/update-task";
 import type {
   AddTaskCommentInput,
   CreateTaskInput,
+  DeleteTaskResult,
   TaskService,
   UpdateTaskInput,
 } from "../services/task-service";
+import { ToduTaskServiceError } from "../services/todu/todu-task-service";
 
 const TASK_STATUS_VALUES = ["active", "inprogress", "waiting", "done", "cancelled"] as const;
 const TASK_PRIORITY_VALUES = ["low", "medium", "high"] as const;
@@ -48,6 +50,10 @@ const TaskUpdateParams = Type.Object({
 const TaskCommentCreateParams = Type.Object({
   taskId: Type.String({ description: "Task ID" }),
   content: Type.String({ description: "Comment content" }),
+});
+
+const TaskDeleteParams = Type.Object({
+  taskId: Type.String({ description: "Task ID" }),
 });
 
 interface TaskCreateToolParams {
@@ -85,6 +91,18 @@ interface TaskCommentCreateToolDetails {
   kind: "task_comment_create";
   taskId: TaskId;
   comment: TaskComment;
+}
+
+interface TaskDeleteToolParams {
+  taskId: string;
+}
+
+interface TaskDeleteToolDetails {
+  kind: "task_delete";
+  taskId: TaskId;
+  found: boolean;
+  deleted: boolean;
+  result?: DeleteTaskResult;
 }
 
 interface TaskMutationToolDependencies {
@@ -188,6 +206,55 @@ const createTaskCommentCreateToolDefinition = ({
   },
 });
 
+const createTaskDeleteToolDefinition = ({ getTaskService }: TaskMutationToolDependencies) => ({
+  name: "task_delete",
+  label: "Task Delete",
+  description: "Delete a task by explicit ID.",
+  promptSnippet: "Delete a task by explicit task ID.",
+  promptGuidelines: [
+    "Use this tool for backend task deletion in normal chat.",
+    "Provide the task ID explicitly.",
+    "Do not guess which task to delete.",
+  ],
+  parameters: TaskDeleteParams,
+  async execute(_toolCallId: string, params: TaskDeleteToolParams) {
+    const taskId = normalizeRequiredText(params.taskId, "taskId") as TaskId;
+
+    try {
+      const taskService = await getTaskService();
+      const result = await taskService.deleteTask(taskId);
+      const details: TaskDeleteToolDetails = {
+        kind: "task_delete",
+        taskId,
+        found: true,
+        deleted: true,
+        result,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: formatTaskDeleteContent(details) }],
+        details,
+      };
+    } catch (error) {
+      if (isTaskNotFoundError(error)) {
+        const details: TaskDeleteToolDetails = {
+          kind: "task_delete",
+          taskId,
+          found: false,
+          deleted: false,
+        };
+
+        return {
+          content: [{ type: "text" as const, text: formatTaskDeleteContent(details) }],
+          details,
+        };
+      }
+
+      throw new Error(formatToolError(error, "task_delete failed"), { cause: error });
+    }
+  },
+});
+
 const registerTaskMutationTools = (
   pi: Pick<ExtensionAPI, "registerTool">,
   dependencies: TaskMutationToolDependencies
@@ -195,6 +262,7 @@ const registerTaskMutationTools = (
   pi.registerTool(createTaskCreateToolDefinition(dependencies));
   pi.registerTool(createTaskUpdateToolDefinition(dependencies));
   pi.registerTool(createTaskCommentCreateToolDefinition(dependencies));
+  pi.registerTool(createTaskDeleteToolDefinition(dependencies));
 };
 
 const normalizeCreateTaskInput = (params: TaskCreateToolParams): CreateTaskInput => ({
@@ -334,6 +402,12 @@ const formatTaskUpdateContent = (task: TaskDetail, input: UpdateTaskInput): stri
 const formatTaskCommentCreateContent = (comment: TaskComment): string =>
   `Added comment ${comment.id} to task ${comment.taskId}.`;
 
+const formatTaskDeleteContent = (details: TaskDeleteToolDetails): string =>
+  details.found ? `Deleted task ${details.taskId}.` : `Task not found: ${details.taskId}`;
+
+const isTaskNotFoundError = (error: unknown): error is ToduTaskServiceError =>
+  error instanceof ToduTaskServiceError && error.causeCode === "not-found";
+
 const formatToolError = (error: unknown, prefix: string): string => {
   if (error instanceof Error && error.message.trim().length > 0) {
     return `${prefix}: ${error.message}`;
@@ -345,12 +419,14 @@ const formatToolError = (error: unknown, prefix: string): string => {
 export type {
   TaskCommentCreateToolDetails,
   TaskCreateToolDetails,
+  TaskDeleteToolDetails,
   TaskMutationToolDependencies,
   TaskUpdateToolDetails,
 };
 export {
   createTaskCommentCreateToolDefinition,
   createTaskCreateToolDefinition,
+  createTaskDeleteToolDefinition,
   createTaskUpdateToolDefinition,
   normalizeCreateTaskInput,
   normalizeTaskCommentInput,


### PR DESCRIPTION
## Summary

Add a native `task_delete` tool so task deletion is handled through the daemon-backed service layer.

### Changes

- **Daemon client**: `deleteTask` method calling `task.delete` RPC with error mapping
- **TaskService**: `deleteTask` interface method with `DeleteTaskResult` return type
- **ToduTaskService**: `deleteTask` implementation with `ToduTaskServiceError` wrapping
- **task_delete tool**: registered in task-mutation-tools with prompt guidelines, validation, and not-found handling
- **Tests**: daemon-client (success + error), service (delegation + error wrapping), tool (success, not-found, validation, service error) — 9 new tests

### Design

- Follows the established delete pattern from habit_delete and recurring_delete
- Not-found errors return structured details (`found: false, deleted: false`) instead of throwing
- Empty/whitespace taskId rejected before reaching the service

Task: #task-40183ed8