### PR TITLE
feat: add native task_move tool

### DIFF
--- a/src/__tests__/daemon-client.test.ts
+++ b/src/__tests__/daemon-client.test.ts
@@ -650,4 +650,60 @@ describe("createToduDaemonClient", () => {
 
     await expect(client.deleteTask("task-missing")).rejects.toThrow("task.delete failed");
   });
+
+  it("moves a task through task.move", async () => {
+    const connection = createConnectionMock();
+    connection.request
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          id: "task-new",
+          title: "Moved task",
+          status: "active",
+          priority: "medium",
+          projectId: "proj-2",
+          labels: [],
+          description: "desc",
+          assignees: [],
+          createdAt: "2026-03-31T00:00:00.000Z",
+          updatedAt: "2026-03-31T00:00:00.000Z",
+        },
+      })
+      .mockResolvedValueOnce({ ok: true, value: [] });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    const result = await client.moveTask({ taskId: "task-1", targetProjectId: "proj-2" });
+
+    expect(result.sourceTaskId).toBe("task-1");
+    expect(result.targetTask.id).toBe("task-new");
+    expect(connection.request).toHaveBeenCalledWith("task.move", {
+      id: "task-1",
+      targetProjectId: "proj-2",
+    });
+  });
+
+  it("throws a client error when task.move fails", async () => {
+    const connection = createConnectionMock();
+    connection.request.mockResolvedValue({
+      ok: false,
+      error: { code: "NOT_FOUND", message: "Task not found" },
+    });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await expect(
+      client.moveTask({ taskId: "task-missing", targetProjectId: "proj-2" })
+    ).rejects.toThrow("task.move failed");
+  });
 });

--- a/src/__tests__/task-mutation-tools.test.ts
+++ b/src/__tests__/task-mutation-tools.test.ts
@@ -8,6 +8,7 @@ import {
   createTaskCommentCreateToolDefinition,
   createTaskCreateToolDefinition,
   createTaskDeleteToolDefinition,
+  createTaskMoveToolDefinition,
   createTaskUpdateToolDefinition,
   normalizeCreateTaskInput,
   normalizeTaskCommentInput,
@@ -561,5 +562,133 @@ describe("createTaskDeleteToolDefinition", () => {
     });
 
     await expect(tool.execute("tc-1", { taskId: "task-1" })).rejects.toThrow("task_delete failed");
+  });
+});
+
+describe("createTaskMoveToolDefinition", () => {
+  it("registers the task_move tool", () => {
+    const pi = { registerTool: vi.fn() };
+
+    registerTools(pi as never, {
+      getTaskService: vi.fn().mockResolvedValue({} as TaskService),
+    });
+
+    const registeredToolNames = pi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(registeredToolNames).toEqual(expect.arrayContaining(["task_move"]));
+  });
+
+  it("moves a task and returns structured details", async () => {
+    const targetTask = createTaskDetail({
+      id: "task-new",
+      projectId: "proj-2",
+      projectName: "Target",
+    });
+    const taskService = {
+      moveTask: vi.fn().mockResolvedValue({ sourceTaskId: "task-1", targetTask }),
+      getProject: vi.fn().mockResolvedValue({ id: "proj-2", name: "Target" }),
+      listProjects: vi.fn().mockResolvedValue([{ id: "proj-2", name: "Target" }]),
+    } as unknown as TaskService;
+
+    const tool = createTaskMoveToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    const result = await tool.execute("tc-1", { taskId: "task-1", projectId: "proj-2" });
+
+    expect(result.content[0]?.text).toContain("Moved task task-1");
+    expect(result.content[0]?.text).toContain("task-new");
+    expect(result.details).toMatchObject({
+      kind: "task_move",
+      sourceTaskId: "task-1",
+      found: true,
+      moved: true,
+    });
+  });
+
+  it("resolves project by name", async () => {
+    const targetTask = createTaskDetail({
+      id: "task-new",
+      projectId: "proj-2",
+      projectName: "Target",
+    });
+    const taskService = {
+      moveTask: vi.fn().mockResolvedValue({ sourceTaskId: "task-1", targetTask }),
+      getProject: vi.fn().mockResolvedValue(null),
+      listProjects: vi
+        .fn()
+        .mockResolvedValue([
+          { id: "proj-2", name: "Target", status: "active", priority: "medium" },
+        ]),
+    } as unknown as TaskService;
+
+    const tool = createTaskMoveToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    const result = await tool.execute("tc-1", { taskId: "task-1", projectId: "Target" });
+
+    expect(taskService.moveTask).toHaveBeenCalledWith({
+      taskId: "task-1",
+      targetProjectId: "proj-2",
+    });
+    expect(result.details).toMatchObject({ kind: "task_move", moved: true });
+  });
+
+  it("returns not-found when task does not exist", async () => {
+    const taskService = {
+      moveTask: vi.fn().mockRejectedValue(
+        new ToduTaskServiceError({
+          operation: "moveTask",
+          causeCode: "not-found",
+          message: "moveTask failed",
+        })
+      ),
+      getProject: vi.fn().mockResolvedValue({ id: "proj-2", name: "Target" }),
+      listProjects: vi.fn(),
+    } as unknown as TaskService;
+
+    const tool = createTaskMoveToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    const result = await tool.execute("tc-1", { taskId: "task-missing", projectId: "proj-2" });
+
+    expect(result.content[0]?.text).toContain("Task not found: task-missing");
+    expect(result.details).toMatchObject({ kind: "task_move", found: false, moved: false });
+  });
+
+  it("throws when project is not found", async () => {
+    const taskService = {
+      getProject: vi.fn().mockResolvedValue(null),
+      listProjects: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskService;
+
+    const tool = createTaskMoveToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    await expect(
+      tool.execute("tc-1", { taskId: "task-1", projectId: "NonExistent" })
+    ).rejects.toThrow("project not found");
+  });
+
+  it("rejects empty taskId", async () => {
+    const tool = createTaskMoveToolDefinition({
+      getTaskService: vi.fn(),
+    });
+
+    await expect(tool.execute("tc-1", { taskId: "  ", projectId: "proj-2" })).rejects.toThrow(
+      "taskId is required"
+    );
+  });
+
+  it("rejects empty projectId", async () => {
+    const tool = createTaskMoveToolDefinition({
+      getTaskService: vi.fn(),
+    });
+
+    await expect(tool.execute("tc-1", { taskId: "task-1", projectId: "  " })).rejects.toThrow(
+      "projectId is required"
+    );
   });
 });

--- a/src/__tests__/todu-task-service.test.ts
+++ b/src/__tests__/todu-task-service.test.ts
@@ -50,6 +50,7 @@ describe("createToduTaskService", () => {
       checkHabit: vi.fn(),
       deleteHabit: vi.fn(),
       deleteTask: vi.fn(),
+      moveTask: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -109,6 +110,7 @@ describe("createToduTaskService", () => {
       checkHabit: vi.fn(),
       deleteHabit: vi.fn(),
       deleteTask: vi.fn(),
+      moveTask: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -171,6 +173,7 @@ describe("createToduTaskService", () => {
       checkHabit: vi.fn(),
       deleteHabit: vi.fn(),
       deleteTask: vi.fn(),
+      moveTask: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -238,6 +241,7 @@ describe("createToduTaskService", () => {
       checkHabit: vi.fn(),
       deleteHabit: vi.fn(),
       deleteTask: vi.fn(),
+      moveTask: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -316,6 +320,7 @@ describe("createToduTaskService", () => {
       checkHabit: vi.fn(),
       deleteHabit: vi.fn(),
       deleteTask: vi.fn(),
+      moveTask: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -365,6 +370,53 @@ describe("createToduTaskService", () => {
     await expect(taskService.deleteTask("task-missing")).rejects.toThrow(ToduTaskServiceError);
     await expect(taskService.deleteTask("task-missing")).rejects.toMatchObject({
       operation: "deleteTask",
+      causeCode: "not-found",
+    });
+  });
+
+  it("delegates moveTask to the daemon client and hydrates project name", async () => {
+    const targetTask = {
+      id: "task-new",
+      title: "Moved task",
+      status: "active" as const,
+      priority: "medium" as const,
+      projectId: "proj-2",
+      projectName: null,
+      labels: [],
+      description: null,
+      comments: [],
+    };
+    const client = {
+      moveTask: vi.fn().mockResolvedValue({ sourceTaskId: "task-1", targetTask }),
+      getProject: vi.fn().mockResolvedValue({ id: "proj-2", name: "Target Project" }),
+    };
+    const taskService = createToduTaskService({ client: client as never });
+
+    const result = await taskService.moveTask({ taskId: "task-1", targetProjectId: "proj-2" });
+
+    expect(result.sourceTaskId).toBe("task-1");
+    expect(result.targetTask.projectName).toBe("Target Project");
+  });
+
+  it("wraps daemon client errors for moveTask", async () => {
+    const client = {
+      moveTask: vi.fn().mockRejectedValue(
+        new ToduDaemonClientError({
+          code: "not-found",
+          method: "task.move",
+          message: "Task not found",
+        })
+      ),
+    };
+    const taskService = createToduTaskService({ client: client as never });
+
+    await expect(
+      taskService.moveTask({ taskId: "task-missing", targetProjectId: "proj-2" })
+    ).rejects.toThrow(ToduTaskServiceError);
+    await expect(
+      taskService.moveTask({ taskId: "task-missing", targetProjectId: "proj-2" })
+    ).rejects.toMatchObject({
+      operation: "moveTask",
       causeCode: "not-found",
     });
   });

--- a/src/services/task-service.ts
+++ b/src/services/task-service.ts
@@ -34,6 +34,16 @@ export interface DeleteTaskResult {
   deleted: true;
 }
 
+export interface MoveTaskInput {
+  taskId: TaskId;
+  targetProjectId: string;
+}
+
+export interface MoveTaskResult {
+  sourceTaskId: TaskId;
+  targetTask: TaskDetail;
+}
+
 export interface TaskService {
   listTasks(filter?: TaskFilter): Promise<TaskSummary[]>;
   getTask(taskId: TaskId): Promise<TaskDetail | null>;
@@ -45,5 +55,6 @@ export interface TaskService {
   listProjects(): Promise<ProjectSummary[]>;
   getProject(projectId: string): Promise<ProjectSummary | null>;
   deleteTask(taskId: TaskId): Promise<DeleteTaskResult>;
+  moveTask(input: MoveTaskInput): Promise<MoveTaskResult>;
   listTaskComments(taskId: TaskId): Promise<TaskComment[]>;
 }

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -51,6 +51,8 @@ import type {
   AddTaskCommentInput,
   CreateTaskInput,
   DeleteTaskResult,
+  MoveTaskInput,
+  MoveTaskResult,
   UpdateTaskInput,
 } from "../task-service";
 import type { ToduDaemonConnection, ToduDaemonConnectionError } from "./daemon-connection";
@@ -116,6 +118,7 @@ export interface ToduDaemonClient {
   listIntegrationBindings(filter?: IntegrationBindingFilter): Promise<IntegrationBinding[]>;
   createIntegrationBinding(input: CreateIntegrationBindingInput): Promise<IntegrationBinding>;
   deleteTask(taskId: TaskId): Promise<DeleteTaskResult>;
+  moveTask(input: MoveTaskInput): Promise<MoveTaskResult>;
   listHabits(filter?: HabitFilter): Promise<HabitSummary[]>;
   getHabit(habitId: string): Promise<HabitDetail | null>;
   createHabit(input: CreateHabitInput): Promise<HabitDetail>;
@@ -203,6 +206,22 @@ const createToduDaemonClient = ({
     return {
       taskId,
       deleted: true,
+    };
+  },
+
+  async moveTask(input: MoveTaskInput): Promise<MoveTaskResult> {
+    const result = await connection.request<ToduTaskWithDetail>("task.move", {
+      id: input.taskId,
+      targetProjectId: input.targetProjectId,
+    });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("task.move", result.error);
+    }
+
+    const comments = await fetchTaskComments(connection, result.value.id);
+    return {
+      sourceTaskId: input.taskId,
+      targetTask: mapTaskDetail(result.value, comments),
     };
   },
 

--- a/src/services/todu/todu-task-service.ts
+++ b/src/services/todu/todu-task-service.ts
@@ -51,6 +51,12 @@ const createToduTaskService = ({ client }: ToduTaskServiceDependencies): TaskSer
   addTaskComment: (input) =>
     runTaskServiceOperation("addTaskComment", () => client.addTaskComment(input)),
   deleteTask: (taskId) => runTaskServiceOperation("deleteTask", () => client.deleteTask(taskId)),
+  moveTask: (input) =>
+    runTaskServiceOperation("moveTask", async () => {
+      const result = await client.moveTask(input);
+      const targetTask = await hydrateTaskDetailProjectName(client, result.targetTask);
+      return { ...result, targetTask };
+    }),
   listProjects: () => runTaskServiceOperation("listProjects", () => client.listProjects()),
   getProject: (projectId) =>
     runTaskServiceOperation("getProject", () => client.getProject(projectId)),

--- a/src/tools/task-mutation-tools.ts
+++ b/src/tools/task-mutation-tools.ts
@@ -17,6 +17,7 @@ import type {
   AddTaskCommentInput,
   CreateTaskInput,
   DeleteTaskResult,
+  MoveTaskResult,
   TaskService,
   UpdateTaskInput,
 } from "../services/task-service";
@@ -54,6 +55,11 @@ const TaskCommentCreateParams = Type.Object({
 
 const TaskDeleteParams = Type.Object({
   taskId: Type.String({ description: "Task ID" }),
+});
+
+const TaskMoveParams = Type.Object({
+  taskId: Type.String({ description: "Task ID" }),
+  projectId: Type.String({ description: "Target project ID or unique project name" }),
 });
 
 interface TaskCreateToolParams {
@@ -103,6 +109,19 @@ interface TaskDeleteToolDetails {
   found: boolean;
   deleted: boolean;
   result?: DeleteTaskResult;
+}
+
+interface TaskMoveToolParams {
+  taskId: string;
+  projectId: string;
+}
+
+interface TaskMoveToolDetails {
+  kind: "task_move";
+  sourceTaskId: TaskId;
+  found: boolean;
+  moved: boolean;
+  result?: MoveTaskResult;
 }
 
 interface TaskMutationToolDependencies {
@@ -255,6 +274,60 @@ const createTaskDeleteToolDefinition = ({ getTaskService }: TaskMutationToolDepe
   },
 });
 
+const createTaskMoveToolDefinition = ({ getTaskService }: TaskMutationToolDependencies) => ({
+  name: "task_move",
+  label: "Task Move",
+  description: "Move a task to a different project.",
+  promptSnippet: "Move a task to a different project by task ID and target project reference.",
+  promptGuidelines: [
+    "Use this tool to move a task between projects in normal chat.",
+    "Provide the task ID and target project ID or unique project name explicitly.",
+    "The original task is cancelled and a new task is created in the target project.",
+  ],
+  parameters: TaskMoveParams,
+  async execute(_toolCallId: string, params: TaskMoveToolParams) {
+    const taskId = normalizeRequiredText(params.taskId, "taskId") as TaskId;
+    const projectRef = normalizeRequiredText(params.projectId, "projectId");
+
+    try {
+      const taskService = await getTaskService();
+      const project = await resolveProjectForTaskCreate(taskService, projectRef);
+      const result = await taskService.moveTask({
+        taskId,
+        targetProjectId: project.id,
+      });
+      const details: TaskMoveToolDetails = {
+        kind: "task_move",
+        sourceTaskId: taskId,
+        found: true,
+        moved: true,
+        result,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: formatTaskMoveContent(details) }],
+        details,
+      };
+    } catch (error) {
+      if (isTaskNotFoundError(error)) {
+        const details: TaskMoveToolDetails = {
+          kind: "task_move",
+          sourceTaskId: taskId,
+          found: false,
+          moved: false,
+        };
+
+        return {
+          content: [{ type: "text" as const, text: formatTaskMoveContent(details) }],
+          details,
+        };
+      }
+
+      throw new Error(formatToolError(error, "task_move failed"), { cause: error });
+    }
+  },
+});
+
 const registerTaskMutationTools = (
   pi: Pick<ExtensionAPI, "registerTool">,
   dependencies: TaskMutationToolDependencies
@@ -263,6 +336,7 @@ const registerTaskMutationTools = (
   pi.registerTool(createTaskUpdateToolDefinition(dependencies));
   pi.registerTool(createTaskCommentCreateToolDefinition(dependencies));
   pi.registerTool(createTaskDeleteToolDefinition(dependencies));
+  pi.registerTool(createTaskMoveToolDefinition(dependencies));
 };
 
 const normalizeCreateTaskInput = (params: TaskCreateToolParams): CreateTaskInput => ({
@@ -408,6 +482,20 @@ const formatTaskDeleteContent = (details: TaskDeleteToolDetails): string =>
 const isTaskNotFoundError = (error: unknown): error is ToduTaskServiceError =>
   error instanceof ToduTaskServiceError && error.causeCode === "not-found";
 
+const formatTaskMoveContent = (details: TaskMoveToolDetails): string => {
+  if (!details.found) {
+    return `Task not found: ${details.sourceTaskId}`;
+  }
+
+  const target = details.result?.targetTask;
+  const projectLabel = target?.projectName ?? target?.projectId ?? "unknown";
+  return [
+    `Moved task ${details.sourceTaskId} → ${target?.id ?? "unknown"}`,
+    `Target project: ${projectLabel}`,
+    `New task: ${target?.id}: ${target?.title}`,
+  ].join("\n");
+};
+
 const formatToolError = (error: unknown, prefix: string): string => {
   if (error instanceof Error && error.message.trim().length > 0) {
     return `${prefix}: ${error.message}`;
@@ -420,6 +508,7 @@ export type {
   TaskCommentCreateToolDetails,
   TaskCreateToolDetails,
   TaskDeleteToolDetails,
+  TaskMoveToolDetails,
   TaskMutationToolDependencies,
   TaskUpdateToolDetails,
 };
@@ -427,6 +516,7 @@ export {
   createTaskCommentCreateToolDefinition,
   createTaskCreateToolDefinition,
   createTaskDeleteToolDefinition,
+  createTaskMoveToolDefinition,
   createTaskUpdateToolDefinition,
   normalizeCreateTaskInput,
   normalizeTaskCommentInput,


### PR DESCRIPTION
## Summary

Add a native `task_move` tool so moving tasks between projects is handled through the daemon-backed service layer.

### Changes

- **Daemon client**: `moveTask` method calling `task.move` RPC, returns new task with comments
- **TaskService**: `moveTask` with `MoveTaskInput` and `MoveTaskResult` types
- **ToduTaskService**: `moveTask` implementation with project name hydration and error wrapping
- **task_move tool**: registered with project resolution (ID then name), not-found handling, validation
- **Tests**: daemon-client (success + error), service (delegation + hydration + error wrapping), tool (success, project-by-name, not-found, project-not-found, empty taskId, empty projectId) — 11 new tests

### Design

- Reuses `resolveProjectForTaskCreate` for project resolution
- Not-found errors return structured details (`found: false, moved: false`)
- Output includes source task ID, target task ID, and target project

Task: #task-2da1b5f1