### PR TITLE
feat: add missing filters to native task_list tool

### DIFF
--- a/src/__tests__/daemon-client.test.ts
+++ b/src/__tests__/daemon-client.test.ts
@@ -52,8 +52,117 @@ describe("createToduDaemonClient", () => {
         projectId: undefined,
         priority: undefined,
         status: "canceled",
+        label: undefined,
+        overdue: undefined,
+        today: undefined,
       },
     });
+  });
+
+  it("passes label, overdue, and today filters to the daemon", async () => {
+    const connection = createConnectionMock();
+    connection.request.mockResolvedValue({ ok: true, value: [] });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await client.listTasks({ label: "urgent", overdue: true, today: false });
+
+    expect(connection.request).toHaveBeenCalledWith("task.list", {
+      filter: expect.objectContaining({
+        label: "urgent",
+        overdue: true,
+        today: false,
+      }),
+    });
+  });
+
+  it("filters tasks by created-at date range client-side", async () => {
+    const connection = createConnectionMock();
+    connection.request.mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          id: "task-old",
+          title: "Old task",
+          status: "done",
+          priority: "low",
+          projectId: "proj-1",
+          labels: [],
+          assignees: [],
+          createdAt: "2025-12-01T00:00:00.000Z",
+          updatedAt: "2025-12-01T00:00:00.000Z",
+        },
+        {
+          id: "task-new",
+          title: "New task",
+          status: "done",
+          priority: "low",
+          projectId: "proj-1",
+          labels: [],
+          assignees: [],
+          createdAt: "2026-03-15T00:00:00.000Z",
+          updatedAt: "2026-03-15T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    const tasks = await client.listTasks({ from: "2026-01-01", to: "2026-12-31" });
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]?.id).toBe("task-new");
+  });
+
+  it("sorts tasks by the requested field and direction", async () => {
+    const connection = createConnectionMock();
+    connection.request.mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          id: "task-b",
+          title: "Bravo",
+          status: "active",
+          priority: "low",
+          projectId: "proj-1",
+          labels: [],
+          assignees: [],
+          createdAt: "2026-03-02T00:00:00.000Z",
+          updatedAt: "2026-03-02T00:00:00.000Z",
+        },
+        {
+          id: "task-a",
+          title: "Alpha",
+          status: "active",
+          priority: "high",
+          projectId: "proj-1",
+          labels: [],
+          assignees: [],
+          createdAt: "2026-03-01T00:00:00.000Z",
+          updatedAt: "2026-03-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    const tasks = await client.listTasks({ sort: "title", sortDirection: "asc" });
+    expect(tasks[0]?.id).toBe("task-a");
+    expect(tasks[1]?.id).toBe("task-b");
   });
 
   it("hydrates task detail with task notes", async () => {

--- a/src/__tests__/task-read-tools.test.ts
+++ b/src/__tests__/task-read-tools.test.ts
@@ -64,6 +64,39 @@ describe("normalizeTaskListFilter", () => {
       priorities: undefined,
       projectId: undefined,
       query: undefined,
+      from: undefined,
+      to: undefined,
+      label: undefined,
+      overdue: undefined,
+      today: undefined,
+      sort: undefined,
+      sortDirection: undefined,
+    });
+  });
+
+  it("preserves new filter fields when provided", () => {
+    expect(
+      normalizeTaskListFilter({
+        from: "2026-01-01",
+        to: "2026-03-31",
+        label: "tools",
+        overdue: true,
+        today: false,
+        sort: "createdAt",
+        sortDirection: "asc",
+      })
+    ).toEqual({
+      statuses: undefined,
+      priorities: undefined,
+      projectId: undefined,
+      query: undefined,
+      from: "2026-01-01",
+      to: "2026-03-31",
+      label: "tools",
+      overdue: true,
+      today: false,
+      sort: "createdAt",
+      sortDirection: "asc",
     });
   });
 });
@@ -90,6 +123,13 @@ describe("createTaskListToolDefinition", () => {
       priorities: ["high"],
       projectId: "proj-1",
       query: "task tools",
+      from: undefined,
+      to: undefined,
+      label: undefined,
+      overdue: undefined,
+      today: undefined,
+      sort: undefined,
+      sortDirection: undefined,
     });
     expect(result.content[0]?.type).toBe("text");
     expect(result.content[0]?.text).toContain("Tasks (1):");
@@ -101,6 +141,13 @@ describe("createTaskListToolDefinition", () => {
         priorities: ["high"],
         projectId: "proj-1",
         query: "task tools",
+        from: undefined,
+        to: undefined,
+        label: undefined,
+        overdue: undefined,
+        today: undefined,
+        sort: undefined,
+        sortDirection: undefined,
       },
       tasks,
       total: 1,
@@ -126,6 +173,13 @@ describe("createTaskListToolDefinition", () => {
         priorities: undefined,
         projectId: undefined,
         query: undefined,
+        from: undefined,
+        to: undefined,
+        label: undefined,
+        overdue: undefined,
+        today: undefined,
+        sort: undefined,
+        sortDirection: undefined,
       },
       tasks: [],
       total: 0,

--- a/src/domain/task.ts
+++ b/src/domain/task.ts
@@ -37,9 +37,20 @@ export interface TaskDetail extends TaskSummary {
   comments: TaskComment[];
 }
 
+export type TaskSortField = "priority" | "dueDate" | "createdAt" | "updatedAt" | "title";
+
+export type TaskSortDirection = "asc" | "desc";
+
 export interface TaskFilter {
   projectId?: ProjectId | null;
   statuses?: TaskStatus[];
   priorities?: TaskPriority[];
   query?: string;
+  from?: string;
+  to?: string;
+  label?: string;
+  overdue?: boolean;
+  today?: boolean;
+  sort?: TaskSortField;
+  sortDirection?: TaskSortDirection;
 }

--- a/src/extension/register-commands.ts
+++ b/src/extension/register-commands.ts
@@ -100,9 +100,7 @@ export interface ResolveDefaultProjectResult {
 export interface RegisterCommandDependencies {
   getTaskService?: () => Promise<TaskService>;
   getHabitService?: () => Promise<HabitService>;
-  resolveDefaultProject?: (
-    taskService: TaskService
-  ) => Promise<ResolveDefaultProjectResult | null>;
+  resolveDefaultProject?: (taskService: TaskService) => Promise<ResolveDefaultProjectResult | null>;
   getCurrentTaskId?: () => TaskId | null;
   clearCurrentTask?: (ctx: ExtensionCommandContext) => Promise<void>;
   promptTaskTitle?: (ctx: ExtensionCommandContext) => Promise<string | null>;
@@ -169,8 +167,7 @@ const createTasksCommandHandler = (
   const getTaskBrowseFilterController = () =>
     dependencies.taskBrowseFilterController ?? getDefaultTaskBrowseFilterContextController();
   const editTaskBrowseFilters = dependencies.editTaskBrowseFilters ?? showTaskBrowseFilterMode;
-  const resolveDefaultProject =
-    dependencies.resolveDefaultProject ?? resolveDefaultProjectFromRepo;
+  const resolveDefaultProject = dependencies.resolveDefaultProject ?? resolveDefaultProjectFromRepo;
   const loadTasks = dependencies.loadTasks ?? loadTasksWithLoader;
   const showTaskBrowseView = dependencies.showTaskBrowseView ?? selectTaskBrowseViewAction;
   const showEmptyState = dependencies.showEmptyState ?? showEmptyTasksState;
@@ -1733,9 +1730,7 @@ const resolveRequestedTaskId = (args: string, currentTaskId: TaskId | null): Tas
 
 const resolveDefaultTaskBrowseFilterState = async (
   taskService: TaskService,
-  resolveDefaultProject: (
-    taskService: TaskService
-  ) => Promise<ResolveDefaultProjectResult | null>
+  resolveDefaultProject: (taskService: TaskService) => Promise<ResolveDefaultProjectResult | null>
 ): Promise<TaskBrowseFilterState> => {
   const project = await resolveDefaultProject(taskService).catch(() => null);
   return createTaskBrowseFilterState({
@@ -1784,7 +1779,10 @@ const matchProjectByName = (
   const normalized = candidateName.toLowerCase();
   return (
     projects.find((project) => project.name.toLowerCase() === normalized) ??
-    projects.find((project) => project.name.toLowerCase().replace(/[\s_-]+/g, "-") === normalized.replace(/[\s_-]+/g, "-")) ??
+    projects.find(
+      (project) =>
+        project.name.toLowerCase().replace(/[\s_-]+/g, "-") === normalized.replace(/[\s_-]+/g, "-")
+    ) ??
     null
   );
 };

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -487,6 +487,8 @@ const listRawTasks = async (
   connection: Pick<ToduDaemonConnection, "request">,
   filter: TaskFilter
 ): Promise<ToduTask[]> => {
+  let tasks: ToduTask[];
+
   if (filter.query && filter.query.trim().length > 0) {
     const result = await connection.request<ToduTask[]>("task.search", {
       query: filter.query,
@@ -495,17 +497,53 @@ const listRawTasks = async (
       throw mapDaemonErrorToClientError("task.search", result.error);
     }
 
-    return result.value.filter((task) => matchesTaskFilter(task, filter));
+    tasks = result.value.filter((task) => matchesTaskFilter(task, filter));
+  } else {
+    const result = await connection.request<ToduTask[]>("task.list", {
+      filter: mapTaskFilter(filter),
+    });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("task.list", result.error);
+    }
+
+    tasks = result.value.filter((task) => matchesTaskFilter(task, filter));
   }
 
-  const result = await connection.request<ToduTask[]>("task.list", {
-    filter: mapTaskFilter(filter),
+  if (filter.sort) {
+    tasks = sortTasks(tasks, filter.sort, filter.sortDirection ?? "desc");
+  }
+
+  return tasks;
+};
+
+const sortTasks = (tasks: ToduTask[], field: string, direction: "asc" | "desc"): ToduTask[] => {
+  const sorted = [...tasks].sort((a, b) => {
+    const aVal = getTaskSortValue(a, field);
+    const bVal = getTaskSortValue(b, field);
+    if (aVal < bVal) return -1;
+    if (aVal > bVal) return 1;
+    return 0;
   });
-  if (!result.ok) {
-    throw mapDaemonErrorToClientError("task.list", result.error);
-  }
+  return direction === "asc" ? sorted : sorted.reverse();
+};
 
-  return result.value.filter((task) => matchesTaskFilter(task, filter));
+const PRIORITY_ORDER: Record<string, number> = { urgent: 0, high: 1, medium: 2, low: 3, none: 4 };
+
+const getTaskSortValue = (task: ToduTask, field: string): string | number => {
+  switch (field) {
+    case "priority":
+      return PRIORITY_ORDER[task.priority] ?? 99;
+    case "dueDate":
+      return task.dueDate ?? "9999-12-31";
+    case "createdAt":
+      return task.createdAt;
+    case "updatedAt":
+      return task.updatedAt;
+    case "title":
+      return task.title.toLowerCase();
+    default:
+      return task.createdAt;
+  }
 };
 
 const fetchTaskComments = async (
@@ -733,6 +771,9 @@ const mapTaskFilter = (filter: TaskFilter): Record<string, unknown> => {
     projectId: filter.projectId,
     status: status?.length === 1 ? status[0] : status,
     priority,
+    label: filter.label,
+    overdue: filter.overdue,
+    today: filter.today,
   };
 };
 
@@ -774,6 +815,24 @@ const matchesTaskFilter = (task: ToduTask, filter: TaskFilter): boolean => {
   if (filter.query && filter.query.trim().length > 0) {
     const normalizedQuery = filter.query.trim().toLowerCase();
     if (!task.title.toLowerCase().includes(normalizedQuery)) {
+      return false;
+    }
+  }
+
+  if (filter.label && !task.labels.includes(filter.label)) {
+    return false;
+  }
+
+  if (filter.from) {
+    const fromDate = filter.from;
+    if (task.createdAt < fromDate) {
+      return false;
+    }
+  }
+
+  if (filter.to) {
+    const toDate = filter.to + "T23:59:59.999Z";
+    if (task.createdAt > toDate) {
       return false;
     }
   }

--- a/src/tools/task-read-tools.ts
+++ b/src/tools/task-read-tools.ts
@@ -7,6 +7,8 @@ import type {
   TaskFilter,
   TaskId,
   TaskPriority,
+  TaskSortDirection,
+  TaskSortField,
   TaskStatus,
   TaskSummary,
 } from "../domain/task";
@@ -16,6 +18,8 @@ import type { TaskService } from "../services/task-service";
 
 const TASK_STATUS_VALUES = ["active", "inprogress", "waiting", "done", "cancelled"] as const;
 const TASK_PRIORITY_VALUES = ["low", "medium", "high"] as const;
+const TASK_SORT_FIELD_VALUES = ["priority", "dueDate", "createdAt", "updatedAt", "title"] as const;
+const TASK_SORT_DIRECTION_VALUES = ["asc", "desc"] as const;
 const MAX_TASK_LIST_PREVIEW_COUNT = 25;
 const MAX_COMMENT_PREVIEW_COUNT = 5;
 
@@ -32,6 +36,21 @@ const TaskListParams = Type.Object({
   ),
   projectId: Type.Optional(Type.String({ description: "Optional project ID filter" })),
   query: Type.Optional(Type.String({ description: "Optional title search query" })),
+  from: Type.Optional(Type.String({ description: "Optional created-at start date (YYYY-MM-DD)" })),
+  to: Type.Optional(Type.String({ description: "Optional created-at end date (YYYY-MM-DD)" })),
+  label: Type.Optional(Type.String({ description: "Optional label filter" })),
+  overdue: Type.Optional(Type.Boolean({ description: "Show overdue tasks only" })),
+  today: Type.Optional(Type.Boolean({ description: "Show tasks due or scheduled today" })),
+  sort: Type.Optional(
+    StringEnum(TASK_SORT_FIELD_VALUES, {
+      description: "Sort by field (priority, dueDate, createdAt, updatedAt, title)",
+    })
+  ),
+  sortDirection: Type.Optional(
+    StringEnum(TASK_SORT_DIRECTION_VALUES, {
+      description: "Sort direction (asc or desc)",
+    })
+  ),
 });
 
 const TaskShowParams = Type.Object({
@@ -43,6 +62,13 @@ interface TaskListToolParams {
   priorities?: TaskPriority[];
   projectId?: string;
   query?: string;
+  from?: string;
+  to?: string;
+  label?: string;
+  overdue?: boolean;
+  today?: boolean;
+  sort?: TaskSortField;
+  sortDirection?: TaskSortDirection;
 }
 
 interface TaskShowToolParams {
@@ -71,7 +97,8 @@ interface TaskReadToolDependencies {
 const createTaskListToolDefinition = ({ getTaskService }: TaskReadToolDependencies) => ({
   name: "task_list",
   label: "Task List",
-  description: "List tasks with optional status, priority, project, or title filters.",
+  description:
+    "List tasks with optional status, priority, project, title, label, date range, overdue, today, and sort filters.",
   promptSnippet: "List tasks using structured filters for status, priority, project, or query.",
   promptGuidelines: [
     "Use this tool for backend task lookups in normal chat instead of slash-command task browsing.",
@@ -158,6 +185,13 @@ const normalizeTaskListFilter = (params: TaskListToolParams): TaskFilter => ({
   priorities: normalizeArrayFilter(params.priorities),
   projectId: normalizeOptionalText(params.projectId),
   query: normalizeOptionalText(params.query),
+  from: normalizeOptionalText(params.from),
+  to: normalizeOptionalText(params.to),
+  label: normalizeOptionalText(params.label),
+  overdue: params.overdue ?? undefined,
+  today: params.today ?? undefined,
+  sort: params.sort ?? undefined,
+  sortDirection: params.sortDirection ?? undefined,
 });
 
 const normalizeArrayFilter = <TValue extends string>(


### PR DESCRIPTION
## Summary

Add missing filters to the `task_list` native tool to match CLI capabilities.

### New filters
- **from/to** — filter by created-at date range (client-side)
- **label** — filter by label (daemon + client-side)
- **overdue** — show overdue tasks only (daemon)
- **today** — show tasks due/scheduled today (daemon)
- **sort** — sort by field: priority, dueDate, createdAt, updatedAt, title (client-side)
- **sortDirection** — asc or desc (client-side)

### Changes
- `src/domain/task.ts` — added `TaskSortField`, `TaskSortDirection`, extended `TaskFilter`
- `src/tools/task-read-tools.ts` — new tool parameters, updated normalization
- `src/services/todu/daemon-client.ts` — extended `mapTaskFilter`, `matchesTaskFilter`, added sort
- Tests updated for all new fields

### Verification
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` — 296/296 passing ✅

Task: #task-af04e54d