### PR TITLE
feat: add habit_note_add tool

### DIFF
--- a/src/__tests__/daemon-client-habit.test.ts
+++ b/src/__tests__/daemon-client-habit.test.ts
@@ -290,4 +290,40 @@ describe("createToduDaemonClient habit support", () => {
       })
     ).rejects.toThrow("habit.create failed");
   });
+
+  it("creates a habit note via note.create with entityType habit", async () => {
+    const connection = createConnectionMock();
+    connection.request.mockResolvedValue({
+      ok: true,
+      value: {
+        id: "note-1",
+        content: "Session done",
+        author: "user",
+        entityType: "habit",
+        entityId: "habit-1",
+        tags: [],
+        createdAt: "2026-03-31T00:00:00.000Z",
+      },
+    });
+
+    const client = createClient(connection);
+    const note = await client.addHabitNote({ habitId: "habit-1", content: "Session done" });
+
+    expect(note).toEqual({
+      id: "note-1",
+      content: "Session done",
+      author: "user",
+      entityType: "habit",
+      entityId: "habit-1",
+      tags: [],
+      createdAt: "2026-03-31T00:00:00.000Z",
+    });
+    expect(connection.request).toHaveBeenCalledWith("note.create", {
+      input: {
+        content: "Session done",
+        entityType: "habit",
+        entityId: "habit-1",
+      },
+    });
+  });
 });

--- a/src/__tests__/habit-mutation-tools.test.ts
+++ b/src/__tests__/habit-mutation-tools.test.ts
@@ -8,6 +8,7 @@ import {
   createHabitCheckToolDefinition,
   createHabitCreateToolDefinition,
   createHabitDeleteToolDefinition,
+  createHabitNoteAddToolDefinition,
   createHabitUpdateToolDefinition,
   normalizeCreateHabitInput,
   normalizeUpdateHabitInput,
@@ -298,5 +299,55 @@ describe("createHabitDeleteToolDefinition", () => {
 
     expect(result.content[0]?.text).toContain("Habit not found");
     expect(result.details).toMatchObject({ kind: "habit_delete", found: false, deleted: false });
+  });
+});
+
+describe("createHabitNoteAddToolDefinition", () => {
+  it("adds a note to a habit and returns structured details", async () => {
+    const note = {
+      id: "note-1",
+      content: "Session complete",
+      author: "user",
+      entityType: "habit" as const,
+      entityId: "habit-1",
+      tags: [],
+      createdAt: "2026-03-31T00:00:00.000Z",
+    };
+    const habitService = {
+      addHabitNote: vi.fn().mockResolvedValue(note),
+    } as unknown as HabitService;
+    const tool = createHabitNoteAddToolDefinition({
+      getHabitService: vi.fn().mockResolvedValue(habitService),
+      getProjectService: vi.fn().mockResolvedValue(createProjectService()),
+    });
+
+    const result = await tool.execute("tool-call-1", {
+      habitId: "habit-1",
+      content: "Session complete",
+    });
+
+    expect(habitService.addHabitNote).toHaveBeenCalledWith({
+      habitId: "habit-1",
+      content: "Session complete",
+    });
+    expect(result.content[0]?.text).toContain("Added note note-1 to habit habit-1");
+    expect(result.details).toEqual({
+      kind: "habit_note_add",
+      habitId: "habit-1",
+      note,
+    });
+  });
+
+  it("surfaces service failures with tool-specific context", async () => {
+    const tool = createHabitNoteAddToolDefinition({
+      getHabitService: vi.fn().mockResolvedValue({
+        addHabitNote: vi.fn().mockRejectedValue(new Error("daemon unavailable")),
+      } as unknown as HabitService),
+      getProjectService: vi.fn().mockResolvedValue(createProjectService()),
+    });
+
+    await expect(
+      tool.execute("tool-call-1", { habitId: "habit-1", content: "note" })
+    ).rejects.toThrow("habit_note_add failed: daemon unavailable");
   });
 });

--- a/src/__tests__/todu-task-service.test.ts
+++ b/src/__tests__/todu-task-service.test.ts
@@ -53,6 +53,7 @@ describe("createToduTaskService", () => {
       moveTask: vi.fn(),
       getHabitStreak: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
+      addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -115,6 +116,7 @@ describe("createToduTaskService", () => {
       moveTask: vi.fn(),
       getHabitStreak: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
+      addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -180,6 +182,7 @@ describe("createToduTaskService", () => {
       moveTask: vi.fn(),
       getHabitStreak: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
+      addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -250,6 +253,7 @@ describe("createToduTaskService", () => {
       moveTask: vi.fn(),
       getHabitStreak: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
+      addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
@@ -331,6 +335,7 @@ describe("createToduTaskService", () => {
       moveTask: vi.fn(),
       getHabitStreak: vi.fn(),
       listTaskComments: vi.fn().mockResolvedValue([]),
+      addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };

--- a/src/services/habit-service.ts
+++ b/src/services/habit-service.ts
@@ -7,6 +7,7 @@ import type {
   HabitSummary,
   HabitSummaryWithStreak,
 } from "../domain/habit";
+import type { NoteSummary } from "../domain/note";
 
 export interface CreateHabitInput {
   title: string;
@@ -32,6 +33,11 @@ export interface DeleteHabitResult {
   deleted: true;
 }
 
+export interface AddHabitNoteInput {
+  habitId: HabitId;
+  content: string;
+}
+
 export interface HabitService {
   listHabits(filter?: HabitFilter): Promise<HabitSummary[]>;
   listHabitsWithStreaks(filter?: HabitFilter): Promise<HabitSummaryWithStreak[]>;
@@ -41,4 +47,5 @@ export interface HabitService {
   updateHabit(input: UpdateHabitInput): Promise<HabitDetail>;
   checkHabit(habitId: HabitId): Promise<HabitCheckResult>;
   deleteHabit(habitId: HabitId): Promise<DeleteHabitResult>;
+  addHabitNote(input: AddHabitNoteInput): Promise<NoteSummary>;
 }

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -39,7 +39,12 @@ import type {
   TaskStatus,
   TaskSummary,
 } from "../../domain/task";
-import type { CreateHabitInput, DeleteHabitResult, UpdateHabitInput } from "../habit-service";
+import type {
+  AddHabitNoteInput,
+  CreateHabitInput,
+  DeleteHabitResult,
+  UpdateHabitInput,
+} from "../habit-service";
 import type {
   CreateIntegrationBindingInput,
   IntegrationBinding,
@@ -133,6 +138,7 @@ export interface ToduDaemonClient {
   updateHabit(input: UpdateHabitInput): Promise<HabitDetail>;
   checkHabit(habitId: string): Promise<HabitCheckResult>;
   getHabitStreak(habitId: string): Promise<HabitStreak>;
+  addHabitNote(input: AddHabitNoteInput): Promise<NoteSummary>;
   deleteHabit(habitId: string): Promise<DeleteHabitResult>;
   listNotes(filter?: NoteFilter): Promise<NoteSummary[]>;
   listTaskComments(taskId: TaskId): Promise<TaskComment[]>;
@@ -456,6 +462,21 @@ const createToduDaemonClient = ({
       completedToday: result.value.completedToday,
       totalCheckins: result.value.totalCheckins,
     };
+  },
+
+  async addHabitNote(input: AddHabitNoteInput): Promise<NoteSummary> {
+    const noteResult = await connection.request<ToduNote>("note.create", {
+      input: {
+        content: input.content,
+        entityType: "habit",
+        entityId: input.habitId,
+      },
+    });
+    if (!noteResult.ok) {
+      throw mapDaemonErrorToClientError("note.create", noteResult.error);
+    }
+
+    return mapNoteSummary(noteResult.value);
   },
 
   async deleteHabit(habitId: string): Promise<DeleteHabitResult> {

--- a/src/services/todu/todu-habit-service.ts
+++ b/src/services/todu/todu-habit-service.ts
@@ -60,6 +60,8 @@ const createToduHabitService = ({ client }: ToduHabitServiceDependencies): Habit
   checkHabit: (habitId) => runHabitServiceOperation("checkHabit", () => client.checkHabit(habitId)),
   deleteHabit: (habitId) =>
     runHabitServiceOperation("deleteHabit", () => client.deleteHabit(habitId)),
+  addHabitNote: (input) =>
+    runHabitServiceOperation("addHabitNote", () => client.addHabitNote(input)),
 });
 
 const listHabitsWithProjectNames = async (

--- a/src/tools/habit-mutation-tools.ts
+++ b/src/tools/habit-mutation-tools.ts
@@ -2,8 +2,10 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
 import type { HabitCheckResult, HabitDetail } from "../domain/habit";
+import type { NoteSummary } from "../domain/note";
 import type { ProjectSummary } from "../domain/task";
 import type {
+  AddHabitNoteInput,
   CreateHabitInput,
   DeleteHabitResult,
   HabitService,
@@ -52,6 +54,11 @@ const HabitDeleteParams = Type.Object({
   habitId: Type.String({ description: "Habit ID" }),
 });
 
+const HabitNoteAddParams = Type.Object({
+  habitId: Type.String({ description: "Habit ID" }),
+  content: Type.String({ description: "Note content" }),
+});
+
 interface HabitCreateToolParams {
   title: string;
   projectId: string;
@@ -79,6 +86,11 @@ interface HabitDeleteToolParams {
   habitId: string;
 }
 
+interface HabitNoteAddToolParams {
+  habitId: string;
+  content: string;
+}
+
 interface HabitCreateToolDetails {
   kind: "habit_create";
   input: CreateHabitInput;
@@ -104,6 +116,12 @@ interface HabitDeleteToolDetails {
   found: boolean;
   deleted: boolean;
   result?: DeleteHabitResult;
+}
+
+interface HabitNoteAddToolDetails {
+  kind: "habit_note_add";
+  habitId: string;
+  note: NoteSummary;
 }
 
 interface HabitMutationToolDependencies {
@@ -273,6 +291,38 @@ const createHabitDeleteToolDefinition = ({ getHabitService }: HabitMutationToolD
   },
 });
 
+const createHabitNoteAddToolDefinition = ({ getHabitService }: HabitMutationToolDependencies) => ({
+  name: "habit_note_add",
+  label: "Habit Note Add",
+  description: "Add a note to a habit.",
+  promptSnippet: "Attach a note to a habit by habit ID.",
+  promptGuidelines: [
+    "Use this tool to attach notes to habits in normal chat.",
+    "Provide the habit ID and note content explicitly.",
+  ],
+  parameters: HabitNoteAddParams,
+  async execute(_toolCallId: string, params: HabitNoteAddToolParams) {
+    const input = normalizeHabitNoteAddInput(params);
+
+    try {
+      const habitService = await getHabitService();
+      const note = await habitService.addHabitNote(input);
+      const details: HabitNoteAddToolDetails = {
+        kind: "habit_note_add",
+        habitId: input.habitId,
+        note,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: formatHabitNoteAddContent(note, input.habitId) }],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "habit_note_add failed"), { cause: error });
+    }
+  },
+});
+
 const registerHabitMutationTools = (
   pi: Pick<ExtensionAPI, "registerTool">,
   dependencies: HabitMutationToolDependencies
@@ -281,6 +331,7 @@ const registerHabitMutationTools = (
   pi.registerTool(createHabitUpdateToolDefinition(dependencies));
   pi.registerTool(createHabitCheckToolDefinition(dependencies));
   pi.registerTool(createHabitDeleteToolDefinition(dependencies));
+  pi.registerTool(createHabitNoteAddToolDefinition(dependencies));
 };
 
 const normalizeCreateHabitInput = (params: HabitCreateToolParams): CreateHabitInput => ({
@@ -461,6 +512,14 @@ const formatHabitCheckContent = (result: HabitCheckResult): string => {
 const formatHabitDeleteContent = (details: HabitDeleteToolDetails): string =>
   details.found ? `Deleted habit ${details.habitId}.` : `Habit not found: ${details.habitId}`;
 
+const normalizeHabitNoteAddInput = (params: HabitNoteAddToolParams): AddHabitNoteInput => ({
+  habitId: normalizeRequiredText(params.habitId, "habitId"),
+  content: normalizeRequiredText(params.content, "content"),
+});
+
+const formatHabitNoteAddContent = (note: NoteSummary, habitId: string): string =>
+  `Added note ${note.id} to habit ${habitId}.`;
+
 const formatToolError = (error: unknown, prefix: string): string => {
   if (error instanceof Error && error.message.trim().length > 0) {
     return `${prefix}: ${error.message}`;
@@ -474,14 +533,17 @@ export type {
   HabitCreateToolDetails,
   HabitDeleteToolDetails,
   HabitMutationToolDependencies,
+  HabitNoteAddToolDetails,
   HabitUpdateToolDetails,
 };
 export {
   createHabitCheckToolDefinition,
   createHabitCreateToolDefinition,
   createHabitDeleteToolDefinition,
+  createHabitNoteAddToolDefinition,
   createHabitUpdateToolDefinition,
   normalizeCreateHabitInput,
+  normalizeHabitNoteAddInput,
   normalizeUpdateHabitInput,
   registerHabitMutationTools,
   resolveCreateHabitInput,


### PR DESCRIPTION
## Summary

Add a `habit_note_add` tool that attaches a note to a habit by habit ID, analogous to `task_comment_create` but for habits. Needed so skills like `habit-perform` can record session notes without shelling out to the CLI.

### Changes

- `src/services/habit-service.ts` — added `AddHabitNoteInput` and `addHabitNote` to interface
- `src/services/todu/daemon-client.ts` — added `addHabitNote` (uses `note.create` with `entityType: habit`)
- `src/services/todu/todu-habit-service.ts` — wired through to client
- `src/tools/habit-mutation-tools.ts` — added `habit_note_add` tool definition
- Tests: 3 new tests (daemon client, tool success, tool error)

### Verification
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` — 311/311 passing (3 new) ✅

Task: #task-bf709486