### PR TITLE
feat: add habit_show tool

### DIFF
--- a/src/__tests__/habit-read-tools.test.ts
+++ b/src/__tests__/habit-read-tools.test.ts
@@ -1,15 +1,33 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { HabitSummaryWithStreak } from "@/domain/habit";
+import type { HabitDetail, HabitSummaryWithStreak } from "@/domain/habit";
 import { registerTools } from "@/extension/register-tools";
 import type { HabitService } from "@/services/habit-service";
 import type { TaskService } from "@/services/task-service";
 import {
   createHabitListToolDefinition,
+  createHabitShowToolDefinition,
   formatHabitListContent,
   formatStreakLabel,
   formatTodayLabel,
 } from "@/tools/habit-read-tools";
+
+const createHabitDetail = (overrides: Partial<HabitDetail> = {}): HabitDetail => ({
+  id: "habit-1",
+  title: "Morning meditation",
+  projectId: "proj-1",
+  projectName: "Personal",
+  schedule: "FREQ=DAILY",
+  timezone: "America/Chicago",
+  startDate: "2026-03-01",
+  endDate: null,
+  nextDue: "2026-03-31",
+  paused: false,
+  description: "10 minutes of mindfulness each morning.",
+  createdAt: "2026-03-01T00:00:00.000Z",
+  updatedAt: "2026-03-01T00:00:00.000Z",
+  ...overrides,
+});
 
 const createHabitWithStreak = (
   overrides: Partial<HabitSummaryWithStreak> = {}
@@ -154,5 +172,81 @@ describe("createHabitListToolDefinition", () => {
     });
 
     await expect(tool.execute("tool-call-1", {})).rejects.toThrow("habit_list failed");
+  });
+});
+
+describe("createHabitShowToolDefinition", () => {
+  it("returns habit detail with streak", async () => {
+    const habit = createHabitDetail();
+    const streak = { current: 5, longest: 10, completedToday: true, totalCheckins: 25 };
+    const habitService = {
+      getHabit: vi.fn().mockResolvedValue(habit),
+      getHabitStreak: vi.fn().mockResolvedValue(streak),
+    } as unknown as HabitService;
+    const tool = createHabitShowToolDefinition({
+      getHabitService: vi.fn().mockResolvedValue(habitService),
+    });
+
+    const result = await tool.execute("tool-call-1", { habitId: "habit-1" });
+
+    expect(habitService.getHabit).toHaveBeenCalledWith("habit-1");
+    expect(result.content[0]?.text).toContain("Habit habit-1: Morning meditation");
+    expect(result.content[0]?.text).toContain("Schedule: FREQ=DAILY");
+    expect(result.content[0]?.text).toContain("10 minutes of mindfulness");
+    expect(result.content[0]?.text).toContain("5 current, 10 longest");
+    expect(result.details).toMatchObject({
+      kind: "habit_show",
+      habitId: "habit-1",
+      found: true,
+      habit,
+      streak,
+    });
+  });
+
+  it("returns not-found when habit is missing", async () => {
+    const habitService = {
+      getHabit: vi.fn().mockResolvedValue(null),
+    } as unknown as HabitService;
+    const tool = createHabitShowToolDefinition({
+      getHabitService: vi.fn().mockResolvedValue(habitService),
+    });
+
+    const result = await tool.execute("tool-call-1", { habitId: "habit-missing" });
+
+    expect(result.content[0]?.text).toBe("Habit not found: habit-missing");
+    expect(result.details).toMatchObject({
+      kind: "habit_show",
+      habitId: "habit-missing",
+      found: false,
+    });
+  });
+
+  it("still returns habit detail when streak fetch fails", async () => {
+    const habit = createHabitDetail();
+    const habitService = {
+      getHabit: vi.fn().mockResolvedValue(habit),
+      getHabitStreak: vi.fn().mockRejectedValue(new Error("streak unavailable")),
+    } as unknown as HabitService;
+    const tool = createHabitShowToolDefinition({
+      getHabitService: vi.fn().mockResolvedValue(habitService),
+    });
+
+    const result = await tool.execute("tool-call-1", { habitId: "habit-1" });
+
+    expect(result.content[0]?.text).toContain("Habit habit-1");
+    expect(result.content[0]?.text).toContain("Streak: unknown");
+    expect(result.details).toMatchObject({ found: true, streak: undefined });
+  });
+
+  it("surfaces service failures with tool-specific context", async () => {
+    const tool = createHabitShowToolDefinition({
+      getHabitService: vi.fn().mockResolvedValue({
+        getHabit: vi.fn().mockRejectedValue(new Error("daemon unavailable")),
+      } as unknown as HabitService),
+    });
+
+    await expect(tool.execute("tool-call-1", { habitId: "habit-1" })).rejects.toThrow(
+      "habit_show failed: daemon unavailable"
+    );
   });
 });

--- a/src/tools/habit-read-tools.ts
+++ b/src/tools/habit-read-tools.ts
@@ -1,10 +1,13 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
-import type { HabitStreak, HabitSummaryWithStreak } from "../domain/habit";
+import type { HabitDetail, HabitId, HabitStreak, HabitSummaryWithStreak } from "../domain/habit";
 import type { HabitService } from "../services/habit-service";
-
 const HabitListParams = Type.Object({});
+
+const HabitShowParams = Type.Object({
+  habitId: Type.String({ description: "Habit ID" }),
+});
 const MAX_HABIT_LIST_PREVIEW_COUNT = 25;
 
 interface HabitListToolDetails {
@@ -12,6 +15,18 @@ interface HabitListToolDetails {
   habits: HabitSummaryWithStreak[];
   total: number;
   empty: boolean;
+}
+
+interface HabitShowToolParams {
+  habitId: HabitId;
+}
+
+interface HabitShowToolDetails {
+  kind: "habit_show";
+  habitId: HabitId;
+  found: boolean;
+  habit?: HabitDetail;
+  streak?: HabitStreak;
 }
 
 interface HabitReadToolDependencies {
@@ -49,11 +64,69 @@ const createHabitListToolDefinition = ({ getHabitService }: HabitReadToolDepende
   },
 });
 
+const createHabitShowToolDefinition = ({ getHabitService }: HabitReadToolDependencies) => ({
+  name: "habit_show",
+  label: "Habit Show",
+  description: "Show habit details, including description, schedule, and streak.",
+  promptSnippet: "Show details for a specific habit by habit ID.",
+  promptGuidelines: [
+    "Use this tool when the user asks for details about a known habit ID.",
+    "If the habit is missing, report the explicit not-found result instead of guessing.",
+  ],
+  parameters: HabitShowParams,
+  async execute(_toolCallId: string, params: HabitShowToolParams) {
+    try {
+      const habitService = await getHabitService();
+      const habit = await habitService.getHabit(params.habitId);
+      if (!habit) {
+        const details: HabitShowToolDetails = {
+          kind: "habit_show",
+          habitId: params.habitId,
+          found: false,
+        };
+
+        return {
+          content: [{ type: "text" as const, text: `Habit not found: ${params.habitId}` }],
+          details,
+        };
+      }
+
+      const streak = await safeGetStreak(habitService, params.habitId);
+      const details: HabitShowToolDetails = {
+        kind: "habit_show",
+        habitId: params.habitId,
+        found: true,
+        habit,
+        streak: streak ?? undefined,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: formatHabitShowContent(habit, streak) }],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "habit_show failed"), { cause: error });
+    }
+  },
+});
+
 const registerHabitReadTools = (
   pi: Pick<ExtensionAPI, "registerTool">,
   dependencies: HabitReadToolDependencies
 ): void => {
   pi.registerTool(createHabitListToolDefinition(dependencies));
+  pi.registerTool(createHabitShowToolDefinition(dependencies));
+};
+
+const safeGetStreak = async (
+  habitService: HabitService,
+  habitId: HabitId
+): Promise<HabitStreak | null> => {
+  try {
+    return await habitService.getHabitStreak(habitId);
+  } catch {
+    return null;
+  }
 };
 
 const formatHabitListContent = (details: HabitListToolDetails): string => {
@@ -100,6 +173,35 @@ const formatTodayLabel = (streak: HabitStreak | null): string => {
   return streak.completedToday ? "✅" : "—";
 };
 
+const formatHabitShowContent = (habit: HabitDetail, streak: HabitStreak | null): string => {
+  const status = habit.paused ? "paused" : "active";
+  const projectLabel = habit.projectName ?? habit.projectId;
+  const streakLabel = streak
+    ? `${streak.current} current, ${streak.longest} longest, ${streak.totalCheckins} total`
+    : "unknown";
+  const todayLabel = streak ? (streak.completedToday ? "✅" : "—") : "?";
+
+  const lines = [
+    `Habit ${habit.id}: ${habit.title}`,
+    "",
+    `Status: ${status}`,
+    `Project: ${projectLabel}`,
+    `Schedule: ${habit.schedule}`,
+    `Timezone: ${habit.timezone}`,
+    `Start: ${habit.startDate}`,
+    `End: ${habit.endDate ?? "none"}`,
+    `Next due: ${habit.nextDue}`,
+    "",
+    "Description:",
+    habit.description?.trim().length ? habit.description : "(none)",
+    "",
+    `Streak: ${streakLabel}`,
+    `Today: ${todayLabel}`,
+  ];
+
+  return lines.join("\n");
+};
+
 const formatToolError = (error: unknown, prefix: string): string => {
   if (error instanceof Error && error.message.trim().length > 0) {
     return `${prefix}: ${error.message}`;
@@ -108,10 +210,12 @@ const formatToolError = (error: unknown, prefix: string): string => {
   return prefix;
 };
 
-export type { HabitListToolDetails, HabitReadToolDependencies };
+export type { HabitListToolDetails, HabitReadToolDependencies, HabitShowToolDetails };
 export {
   createHabitListToolDefinition,
+  createHabitShowToolDefinition,
   formatHabitListContent,
+  formatHabitShowContent,
   formatStreakLabel,
   formatTodayLabel,
   registerHabitReadTools,


### PR DESCRIPTION
## Summary

Add a `habit_show` tool that retrieves a single habit's details by ID, including description, schedule, and streak info. Needed so skills like `habit-perform` can view specific habit details without listing all habits.

### Changes

- `src/tools/habit-read-tools.ts` — added `habit_show` tool with streak fetching and not-found handling
- `src/__tests__/habit-read-tools.test.ts` — 4 new tests (found, not-found, streak failure, service error)

### Verification
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` — 315/315 passing (4 new) ✅

Task: #task-24448c34