### PR TITLE
feat: expose completion-date filters in task_list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@mariozechner/pi-ai": "^0.60.0",
         "@mariozechner/pi-tui": "^0.60.0",
         "@sinclair/typebox": "^0.34.48",
-        "@todu/core": "^0.14.2",
+        "@todu/core": "^0.15.0",
         "yaml": "^2.8.2"
       },
       "devDependencies": {
@@ -2455,9 +2455,9 @@
       "license": "MIT"
     },
     "node_modules/@todu/core": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/@todu/core/-/core-0.14.2.tgz",
-      "integrity": "sha512-/Z/yJdwwP8IJz51IC9zi2H1mjVJBnbYWiLjvzDF5Un39y0IZNeqoOax78tPa1kYRN10l5SKua044woOSwzYuGg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@todu/core/-/core-0.15.0.tgz",
+      "integrity": "sha512-sAZec9R2I2MkhvzCi7VYO+twrk0vJzEjcOi2Lq5smXnl4NZT2odwI1Dmj+vnGoAKdI7iFr91ktu9LR2P9Hs4yQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@mariozechner/pi-ai": "^0.60.0",
     "@mariozechner/pi-tui": "^0.60.0",
     "@sinclair/typebox": "^0.34.48",
-    "@todu/core": "^0.14.2",
+    "@todu/core": "^0.15.0",
     "yaml": "^2.8.2"
   }
 }

--- a/src/__tests__/daemon-client.test.ts
+++ b/src/__tests__/daemon-client.test.ts
@@ -57,6 +57,8 @@ describe("createToduDaemonClient", () => {
         today: undefined,
         createdFrom: undefined,
         createdTo: undefined,
+        completedFrom: undefined,
+        completedTo: undefined,
         timezone: undefined,
       },
     });
@@ -84,7 +86,7 @@ describe("createToduDaemonClient", () => {
     });
   });
 
-  it("passes date range and timezone filters to the daemon", async () => {
+  it("passes creation date, completion date, and timezone filters to the daemon", async () => {
     const connection = createConnectionMock();
     connection.request.mockResolvedValue({ ok: true, value: [] });
 
@@ -95,12 +97,20 @@ describe("createToduDaemonClient", () => {
       >,
     });
 
-    await client.listTasks({ from: "2026-01-01", to: "2026-12-31", timezone: "America/Chicago" });
+    await client.listTasks({
+      from: "2026-01-01",
+      to: "2026-12-31",
+      completedFrom: "2026-03-01",
+      completedTo: "2026-03-31",
+      timezone: "America/Chicago",
+    });
 
     expect(connection.request).toHaveBeenCalledWith("task.list", {
       filter: expect.objectContaining({
         createdFrom: "2026-01-01",
         createdTo: "2026-12-31",
+        completedFrom: "2026-03-01",
+        completedTo: "2026-03-31",
         timezone: "America/Chicago",
       }),
     });

--- a/src/__tests__/task-read-tools.test.ts
+++ b/src/__tests__/task-read-tools.test.ts
@@ -70,6 +70,8 @@ describe("normalizeTaskListFilter", () => {
       query: undefined,
       from: undefined,
       to: undefined,
+      completedFrom: undefined,
+      completedTo: undefined,
       label: undefined,
       overdue: undefined,
       today: undefined,
@@ -84,6 +86,8 @@ describe("normalizeTaskListFilter", () => {
       normalizeTaskListFilter({
         from: "2026-01-01",
         to: "2026-03-31",
+        completedFrom: "2026-03-01",
+        completedTo: "2026-03-31",
         label: "tools",
         overdue: true,
         today: false,
@@ -98,6 +102,8 @@ describe("normalizeTaskListFilter", () => {
       query: undefined,
       from: "2026-01-01",
       to: "2026-03-31",
+      completedFrom: "2026-03-01",
+      completedTo: "2026-03-31",
       label: "tools",
       overdue: true,
       today: false,
@@ -132,6 +138,8 @@ describe("createTaskListToolDefinition", () => {
       query: "task tools",
       from: undefined,
       to: undefined,
+      completedFrom: undefined,
+      completedTo: undefined,
       label: undefined,
       overdue: undefined,
       today: undefined,
@@ -151,6 +159,8 @@ describe("createTaskListToolDefinition", () => {
         query: "task tools",
         from: undefined,
         to: undefined,
+        completedFrom: undefined,
+        completedTo: undefined,
         label: undefined,
         overdue: undefined,
         today: undefined,
@@ -184,6 +194,8 @@ describe("createTaskListToolDefinition", () => {
         query: undefined,
         from: undefined,
         to: undefined,
+        completedFrom: undefined,
+        completedTo: undefined,
         label: undefined,
         overdue: undefined,
         today: undefined,
@@ -195,6 +207,27 @@ describe("createTaskListToolDefinition", () => {
       total: 0,
       empty: true,
     });
+  });
+
+  it("passes explicit completion-date filters through to the service", async () => {
+    const taskService = {
+      listTasks: vi.fn().mockResolvedValue([]),
+    } as unknown as TaskService;
+    const tool = createTaskListToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    await tool.execute("tool-call-1", {
+      completedFrom: "2026-03-01",
+      completedTo: "2026-03-31",
+    });
+
+    expect(taskService.listTasks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        completedFrom: "2026-03-01",
+        completedTo: "2026-03-31",
+      })
+    );
   });
 
   it("surfaces service failures with tool-specific context", async () => {

--- a/src/domain/task.ts
+++ b/src/domain/task.ts
@@ -48,6 +48,8 @@ export interface TaskFilter {
   query?: string;
   from?: string;
   to?: string;
+  completedFrom?: string;
+  completedTo?: string;
   label?: string;
   overdue?: boolean;
   today?: boolean;

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -834,6 +834,8 @@ const mapTaskFilter = (filter: TaskFilter): Record<string, unknown> => {
     today: filter.today,
     createdFrom: filter.from,
     createdTo: filter.to,
+    completedFrom: filter.completedFrom,
+    completedTo: filter.completedTo,
     timezone: filter.timezone,
   };
 };

--- a/src/tools/task-read-tools.ts
+++ b/src/tools/task-read-tools.ts
@@ -39,6 +39,12 @@ const TaskListParams = Type.Object({
   query: Type.Optional(Type.String({ description: "Optional title search query" })),
   from: Type.Optional(Type.String({ description: "Optional created-at start date (YYYY-MM-DD)" })),
   to: Type.Optional(Type.String({ description: "Optional created-at end date (YYYY-MM-DD)" })),
+  completedFrom: Type.Optional(
+    Type.String({ description: "Optional completed-at start date (YYYY-MM-DD)" })
+  ),
+  completedTo: Type.Optional(
+    Type.String({ description: "Optional completed-at end date (YYYY-MM-DD)" })
+  ),
   label: Type.Optional(Type.String({ description: "Optional label filter" })),
   overdue: Type.Optional(Type.Boolean({ description: "Show overdue tasks only" })),
   today: Type.Optional(Type.Boolean({ description: "Show tasks due or scheduled today" })),
@@ -66,6 +72,8 @@ interface TaskListToolParams {
   query?: string;
   from?: string;
   to?: string;
+  completedFrom?: string;
+  completedTo?: string;
   label?: string;
   overdue?: boolean;
   today?: boolean;
@@ -101,8 +109,9 @@ const createTaskListToolDefinition = ({ getTaskService }: TaskReadToolDependenci
   name: "task_list",
   label: "Task List",
   description:
-    "List tasks with optional status, priority, project, title, label, date range, overdue, today, and sort filters.",
-  promptSnippet: "List tasks using structured filters for status, priority, project, or query.",
+    "List tasks with optional status, priority, project, title, label, creation-date, completion-date, overdue, today, and sort filters.",
+  promptSnippet:
+    "List tasks using structured filters for status, priority, project, query, creation date, or completion date.",
   promptGuidelines: [
     "Use this tool for backend task lookups in normal chat instead of slash-command task browsing.",
   ],
@@ -190,6 +199,8 @@ const normalizeTaskListFilter = (params: TaskListToolParams): TaskFilter => ({
   query: normalizeOptionalText(params.query),
   from: normalizeOptionalText(params.from),
   to: normalizeOptionalText(params.to),
+  completedFrom: normalizeOptionalText(params.completedFrom),
+  completedTo: normalizeOptionalText(params.completedTo),
   label: normalizeOptionalText(params.label),
   overdue: params.overdue ?? undefined,
   today: params.today ?? undefined,


### PR DESCRIPTION
## Summary

Expose explicit completion-date filters in the native `task_list` tool, aligned with todu 0.15.0 semantics.

### Changes
- Upgrade `@todu/core` from 0.14.2 to 0.15.0
- Add `completedFrom` / `completedTo` to local `TaskFilter`
- Expose explicit completed-date params in `task_list`
- Preserve existing `from` / `to` behavior as creation-date filters
- Pass both creation-date and completion-date filters through `daemon-client`
- Update tool descriptions/help text to distinguish creation vs completion-date filtering
- Add tests for completion-date propagation

### Verification
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` — 320/320 passing ✅

Task: #task-a9297c40