### PR TITLE
feat: update task_list to use updated-date filters

### DIFF
--- a/src/__tests__/daemon-client.test.ts
+++ b/src/__tests__/daemon-client.test.ts
@@ -57,8 +57,8 @@ describe("createToduDaemonClient", () => {
         today: undefined,
         createdFrom: undefined,
         createdTo: undefined,
-        completedFrom: undefined,
-        completedTo: undefined,
+        updatedFrom: undefined,
+        updatedTo: undefined,
         timezone: undefined,
       },
     });
@@ -86,7 +86,7 @@ describe("createToduDaemonClient", () => {
     });
   });
 
-  it("passes creation date, completion date, and timezone filters to the daemon", async () => {
+  it("passes creation date, updated date, and timezone filters to the daemon", async () => {
     const connection = createConnectionMock();
     connection.request.mockResolvedValue({ ok: true, value: [] });
 
@@ -100,8 +100,8 @@ describe("createToduDaemonClient", () => {
     await client.listTasks({
       from: "2026-01-01",
       to: "2026-12-31",
-      completedFrom: "2026-03-01",
-      completedTo: "2026-03-31",
+      updatedFrom: "2026-03-01",
+      updatedTo: "2026-03-31",
       timezone: "America/Chicago",
     });
 
@@ -109,8 +109,8 @@ describe("createToduDaemonClient", () => {
       filter: expect.objectContaining({
         createdFrom: "2026-01-01",
         createdTo: "2026-12-31",
-        completedFrom: "2026-03-01",
-        completedTo: "2026-03-31",
+        updatedFrom: "2026-03-01",
+        updatedTo: "2026-03-31",
         timezone: "America/Chicago",
       }),
     });

--- a/src/__tests__/task-read-tools.test.ts
+++ b/src/__tests__/task-read-tools.test.ts
@@ -70,8 +70,8 @@ describe("normalizeTaskListFilter", () => {
       query: undefined,
       from: undefined,
       to: undefined,
-      completedFrom: undefined,
-      completedTo: undefined,
+      updatedFrom: undefined,
+      updatedTo: undefined,
       label: undefined,
       overdue: undefined,
       today: undefined,
@@ -86,8 +86,8 @@ describe("normalizeTaskListFilter", () => {
       normalizeTaskListFilter({
         from: "2026-01-01",
         to: "2026-03-31",
-        completedFrom: "2026-03-01",
-        completedTo: "2026-03-31",
+        updatedFrom: "2026-03-01",
+        updatedTo: "2026-03-31",
         label: "tools",
         overdue: true,
         today: false,
@@ -102,8 +102,8 @@ describe("normalizeTaskListFilter", () => {
       query: undefined,
       from: "2026-01-01",
       to: "2026-03-31",
-      completedFrom: "2026-03-01",
-      completedTo: "2026-03-31",
+      updatedFrom: "2026-03-01",
+      updatedTo: "2026-03-31",
       label: "tools",
       overdue: true,
       today: false,
@@ -138,8 +138,8 @@ describe("createTaskListToolDefinition", () => {
       query: "task tools",
       from: undefined,
       to: undefined,
-      completedFrom: undefined,
-      completedTo: undefined,
+      updatedFrom: undefined,
+      updatedTo: undefined,
       label: undefined,
       overdue: undefined,
       today: undefined,
@@ -159,8 +159,8 @@ describe("createTaskListToolDefinition", () => {
         query: "task tools",
         from: undefined,
         to: undefined,
-        completedFrom: undefined,
-        completedTo: undefined,
+        updatedFrom: undefined,
+        updatedTo: undefined,
         label: undefined,
         overdue: undefined,
         today: undefined,
@@ -194,8 +194,8 @@ describe("createTaskListToolDefinition", () => {
         query: undefined,
         from: undefined,
         to: undefined,
-        completedFrom: undefined,
-        completedTo: undefined,
+        updatedFrom: undefined,
+        updatedTo: undefined,
         label: undefined,
         overdue: undefined,
         today: undefined,
@@ -209,7 +209,7 @@ describe("createTaskListToolDefinition", () => {
     });
   });
 
-  it("passes explicit completion-date filters through to the service", async () => {
+  it("passes explicit updated-date filters through to the service", async () => {
     const taskService = {
       listTasks: vi.fn().mockResolvedValue([]),
     } as unknown as TaskService;
@@ -218,14 +218,14 @@ describe("createTaskListToolDefinition", () => {
     });
 
     await tool.execute("tool-call-1", {
-      completedFrom: "2026-03-01",
-      completedTo: "2026-03-31",
+      updatedFrom: "2026-03-01",
+      updatedTo: "2026-03-31",
     });
 
     expect(taskService.listTasks).toHaveBeenCalledWith(
       expect.objectContaining({
-        completedFrom: "2026-03-01",
-        completedTo: "2026-03-31",
+        updatedFrom: "2026-03-01",
+        updatedTo: "2026-03-31",
       })
     );
   });

--- a/src/domain/task.ts
+++ b/src/domain/task.ts
@@ -48,8 +48,8 @@ export interface TaskFilter {
   query?: string;
   from?: string;
   to?: string;
-  completedFrom?: string;
-  completedTo?: string;
+  updatedFrom?: string;
+  updatedTo?: string;
   label?: string;
   overdue?: boolean;
   today?: boolean;

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -834,8 +834,8 @@ const mapTaskFilter = (filter: TaskFilter): Record<string, unknown> => {
     today: filter.today,
     createdFrom: filter.from,
     createdTo: filter.to,
-    completedFrom: filter.completedFrom,
-    completedTo: filter.completedTo,
+    updatedFrom: filter.updatedFrom,
+    updatedTo: filter.updatedTo,
     timezone: filter.timezone,
   };
 };

--- a/src/tools/task-read-tools.ts
+++ b/src/tools/task-read-tools.ts
@@ -39,11 +39,11 @@ const TaskListParams = Type.Object({
   query: Type.Optional(Type.String({ description: "Optional title search query" })),
   from: Type.Optional(Type.String({ description: "Optional created-at start date (YYYY-MM-DD)" })),
   to: Type.Optional(Type.String({ description: "Optional created-at end date (YYYY-MM-DD)" })),
-  completedFrom: Type.Optional(
-    Type.String({ description: "Optional completed-at start date (YYYY-MM-DD)" })
+  updatedFrom: Type.Optional(
+    Type.String({ description: "Optional updated-at start date (YYYY-MM-DD)" })
   ),
-  completedTo: Type.Optional(
-    Type.String({ description: "Optional completed-at end date (YYYY-MM-DD)" })
+  updatedTo: Type.Optional(
+    Type.String({ description: "Optional updated-at end date (YYYY-MM-DD)" })
   ),
   label: Type.Optional(Type.String({ description: "Optional label filter" })),
   overdue: Type.Optional(Type.Boolean({ description: "Show overdue tasks only" })),
@@ -72,8 +72,8 @@ interface TaskListToolParams {
   query?: string;
   from?: string;
   to?: string;
-  completedFrom?: string;
-  completedTo?: string;
+  updatedFrom?: string;
+  updatedTo?: string;
   label?: string;
   overdue?: boolean;
   today?: boolean;
@@ -109,9 +109,9 @@ const createTaskListToolDefinition = ({ getTaskService }: TaskReadToolDependenci
   name: "task_list",
   label: "Task List",
   description:
-    "List tasks with optional status, priority, project, title, label, creation-date, completion-date, overdue, today, and sort filters.",
+    "List tasks with optional status, priority, project, title, label, creation-date, updated-date, overdue, today, and sort filters.",
   promptSnippet:
-    "List tasks using structured filters for status, priority, project, query, creation date, or completion date.",
+    "List tasks using structured filters for status, priority, project, query, creation date, or updated date.",
   promptGuidelines: [
     "Use this tool for backend task lookups in normal chat instead of slash-command task browsing.",
   ],
@@ -199,8 +199,8 @@ const normalizeTaskListFilter = (params: TaskListToolParams): TaskFilter => ({
   query: normalizeOptionalText(params.query),
   from: normalizeOptionalText(params.from),
   to: normalizeOptionalText(params.to),
-  completedFrom: normalizeOptionalText(params.completedFrom),
-  completedTo: normalizeOptionalText(params.completedTo),
+  updatedFrom: normalizeOptionalText(params.updatedFrom),
+  updatedTo: normalizeOptionalText(params.updatedTo),
   label: normalizeOptionalText(params.label),
   overdue: params.overdue ?? undefined,
   today: params.today ?? undefined,


### PR DESCRIPTION
## Summary

Align the native `task_list` tool with todu 0.16.0 by replacing completed-date filters with updated-date filters.

### Changes
- Replace `completedFrom` / `completedTo` with `updatedFrom` / `updatedTo` in local `TaskFilter`
- Update `task_list` schema, normalization, and help text to use updated-date terminology
- Update daemon-client mapping to pass `updatedFrom` / `updatedTo` to the backend
- Remove completed-date exposure from the native tool
- Preserve existing `from` / `to` creation-date filters
- Update tests for updated-date propagation

### Verification
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` — 320/320 passing ✅

Task: #task-957d65ec