### PR TITLE
chore: update pi dependencies to latest stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,15 @@
       "name": "todu-pi-extensions",
       "version": "0.1.0",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.60.0",
-        "@mariozechner/pi-tui": "^0.60.0",
+        "@mariozechner/pi-ai": "^0.64.0",
+        "@mariozechner/pi-tui": "^0.64.0",
         "@sinclair/typebox": "^0.34.48",
         "@todu/core": "^0.15.0",
         "yaml": "^2.8.2"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@mariozechner/pi-coding-agent": "^0.60.0",
+        "@mariozechner/pi-coding-agent": "^0.64.0",
         "@types/node": "^25.3.5",
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^10.0.3",
@@ -1315,22 +1315,22 @@
       }
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.60.0.tgz",
-      "integrity": "sha512-1zQcfFp8r0iwZCxCBQ9/ccFJoagns68cndLPTJJXl1ZqkYirzSld1zBOPxLAgeAKWIz3OX8dB2WQwTJFhmEojQ==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.64.0.tgz",
+      "integrity": "sha512-IN/sIxWOD0v1OFVXHB605SGiZhO5XdEWG5dO8EAV08n3jz/p12o4OuYGvhGXmHhU28WXa/FGWC+FO5xiIih8Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.60.0"
+        "@mariozechner/pi-ai": "^0.64.0"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.60.0.tgz",
-      "integrity": "sha512-OiMuXQturnEDPmA+ho7eLe4G8plO2z21yjNMs9niQREauoblWOz7Glv58I66KPzczLED4aZTlQLTRdU6t1rz8A==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.64.0.tgz",
+      "integrity": "sha512-Z/Jnf+JSVDPLRcxJsa8XhYTJKIqKekNueaCpBLGQHgizL1F9RQ1Rur3rIfZpfXkt2cLu/AIPtOs223ueuoWaWg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -1355,17 +1355,18 @@
       }
     },
     "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.60.0.tgz",
-      "integrity": "sha512-IOv7cTU4nbznFNUE5ofi13k2dmSG39coBoGWIBQTVw3iVyl0HxuHbg0NiTx3ktrPIDNtkii+y7tWXzWqwoo4lw==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.64.0.tgz",
+      "integrity": "sha512-Q4tcqSqFGQtOgCtRyIp1D80Nv2if13Q2pfbnrOlaT/mix90mLcZGML9jKVnT1jGSy5GMYudU1HsS7cx53kxb0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.60.0",
-        "@mariozechner/pi-ai": "^0.60.0",
-        "@mariozechner/pi-tui": "^0.60.0",
+        "@mariozechner/pi-agent-core": "^0.64.0",
+        "@mariozechner/pi-ai": "^0.64.0",
+        "@mariozechner/pi-tui": "^0.64.0",
         "@silvia-odwyer/photon-node": "^0.3.4",
+        "ajv": "^8.17.1",
         "chalk": "^5.5.0",
         "cli-highlight": "^2.1.11",
         "diff": "^8.0.2",
@@ -1392,9 +1393,9 @@
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.60.0.tgz",
-      "integrity": "sha512-ZAK5gxYhGmfJqMjfWcRBjB8glITltDbTrYJXvcDtfengbKTZN0p39p5uO5pvUB8/PiAWKTRS06yaNMhf/LG26g==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.64.0.tgz",
+      "integrity": "sha512-W1qLry9MAuN/V3YJmMv/BJa0VaYv721NkXPg/DGItdqWxuDc+1VdNbyAnRwxblNkIpXVUWL26x64BlyFXpxmkg==",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mariozechner/pi-coding-agent": "^0.60.0",
+    "@mariozechner/pi-coding-agent": "^0.64.0",
     "@types/node": "^25.3.5",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^10.0.3",
@@ -47,8 +47,8 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "@mariozechner/pi-ai": "^0.60.0",
-    "@mariozechner/pi-tui": "^0.60.0",
+    "@mariozechner/pi-ai": "^0.64.0",
+    "@mariozechner/pi-tui": "^0.64.0",
     "@sinclair/typebox": "^0.34.48",
     "@todu/core": "^0.15.0",
     "yaml": "^2.8.2"


### PR DESCRIPTION
## Summary

Update core pi package dependencies to the latest stable compatible versions.

### Updated packages
- `@mariozechner/pi-ai`: `^0.60.0` → `^0.64.0`
- `@mariozechner/pi-coding-agent`: `^0.60.0` → `^0.64.0`
- `@mariozechner/pi-tui`: `^0.60.0` → `^0.64.0`

### Compatibility
No code changes were required. The current codebase remained compatible with the updated pi APIs/types.

### Verification
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` — 320/320 passing ✅

### Notes
- No prerelease versions were introduced
- Resulting dependency set is internally compatible based on successful verification

Task: #task-b121537e