### PR TITLE
fix: remove item caps from all list tool formatters

### DIFF
--- a/src/tools/habit-read-tools.ts
+++ b/src/tools/habit-read-tools.ts
@@ -8,7 +8,6 @@ const HabitListParams = Type.Object({});
 const HabitShowParams = Type.Object({
   habitId: Type.String({ description: "Habit ID" }),
 });
-const MAX_HABIT_LIST_PREVIEW_COUNT = 25;
 
 interface HabitListToolDetails {
   kind: "habit_list";
@@ -134,16 +133,10 @@ const formatHabitListContent = (details: HabitListToolDetails): string => {
     return "No habits found.";
   }
 
-  const previewHabits = details.habits.slice(0, MAX_HABIT_LIST_PREVIEW_COUNT);
   const lines = [`Habits (${details.total}):`];
 
-  for (const habit of previewHabits) {
+  for (const habit of details.habits) {
     lines.push(`- ${formatHabitSummaryLine(habit)}`);
-  }
-
-  const remainingCount = details.total - previewHabits.length;
-  if (remainingCount > 0) {
-    lines.push(`- ... ${remainingCount} more habit(s)`);
   }
 
   return lines.join("\n");

--- a/src/tools/note-read-tools.ts
+++ b/src/tools/note-read-tools.ts
@@ -7,7 +7,7 @@ import type { NoteService } from "../services/note-service";
 import { getSystemTimezone } from "../utils/timezone";
 
 const NOTE_ENTITY_TYPE_VALUES = ["task", "project", "habit"] as const;
-const MAX_NOTE_LIST_PREVIEW_COUNT = 25;
+
 const MAX_NOTE_CONTENT_PREVIEW_LENGTH = 200;
 
 const NoteListParams = Type.Object({
@@ -117,16 +117,10 @@ const formatNoteListContent = (details: NoteListToolDetails): string => {
     return "No notes found.";
   }
 
-  const previewNotes = details.notes.slice(0, MAX_NOTE_LIST_PREVIEW_COUNT);
   const lines = [`Notes (${details.total}):`];
 
-  for (const note of previewNotes) {
+  for (const note of details.notes) {
     lines.push(`- ${formatNoteSummaryLine(note)}`);
-  }
-
-  const remainingCount = details.total - previewNotes.length;
-  if (remainingCount > 0) {
-    lines.push(`- ... ${remainingCount} more note(s)`);
   }
 
   return lines.join("\n");

--- a/src/tools/project-read-tools.ts
+++ b/src/tools/project-read-tools.ts
@@ -8,7 +8,6 @@ const ProjectListParams = Type.Object({});
 const ProjectShowParams = Type.Object({
   projectRef: Type.String({ description: "Project ID or unique project name" }),
 });
-const MAX_PROJECT_LIST_PREVIEW_COUNT = 25;
 
 interface ProjectListToolDetails {
   kind: "project_list";
@@ -145,16 +144,10 @@ const formatProjectListContent = (details: ProjectListToolDetails): string => {
     return "No projects found.";
   }
 
-  const previewProjects = details.projects.slice(0, MAX_PROJECT_LIST_PREVIEW_COUNT);
   const lines = [`Projects (${details.total}):`];
 
-  for (const project of previewProjects) {
+  for (const project of details.projects) {
     lines.push(`- ${formatProjectSummaryLine(project)}`);
-  }
-
-  const remainingCount = details.total - previewProjects.length;
-  if (remainingCount > 0) {
-    lines.push(`- ... ${remainingCount} more project(s)`);
   }
 
   return lines.join("\n");

--- a/src/tools/recurring-read-tools.ts
+++ b/src/tools/recurring-read-tools.ts
@@ -5,7 +5,6 @@ import type { RecurringTemplateSummary } from "../domain/recurring";
 import type { RecurringService } from "../services/recurring-service";
 
 const RecurringListParams = Type.Object({});
-const MAX_RECURRING_LIST_PREVIEW_COUNT = 25;
 
 interface RecurringListToolDetails {
   kind: "recurring_list";
@@ -63,16 +62,10 @@ const formatRecurringListContent = (details: RecurringListToolDetails): string =
     return "No recurring templates found.";
   }
 
-  const previewTemplates = details.templates.slice(0, MAX_RECURRING_LIST_PREVIEW_COUNT);
   const lines = [`Recurring templates (${details.total}):`];
 
-  for (const template of previewTemplates) {
+  for (const template of details.templates) {
     lines.push(`- ${formatRecurringSummaryLine(template)}`);
-  }
-
-  const remainingCount = details.total - previewTemplates.length;
-  if (remainingCount > 0) {
-    lines.push(`- ... ${remainingCount} more recurring template(s)`);
   }
 
   return lines.join("\n");

--- a/src/tools/task-read-tools.ts
+++ b/src/tools/task-read-tools.ts
@@ -21,8 +21,6 @@ const TASK_STATUS_VALUES = ["active", "inprogress", "waiting", "done", "cancelle
 const TASK_PRIORITY_VALUES = ["low", "medium", "high"] as const;
 const TASK_SORT_FIELD_VALUES = ["priority", "dueDate", "createdAt", "updatedAt", "title"] as const;
 const TASK_SORT_DIRECTION_VALUES = ["asc", "desc"] as const;
-const MAX_TASK_LIST_PREVIEW_COUNT = 25;
-const MAX_COMMENT_PREVIEW_COUNT = 5;
 
 const TaskListParams = Type.Object({
   statuses: Type.Optional(
@@ -223,16 +221,10 @@ const formatTaskListContent = (details: TaskListToolDetails): string => {
     return "No tasks found.";
   }
 
-  const previewTasks = details.tasks.slice(0, MAX_TASK_LIST_PREVIEW_COUNT);
   const lines = [`Tasks (${details.total}):`];
 
-  for (const task of previewTasks) {
+  for (const task of details.tasks) {
     lines.push(`- ${formatTaskSummaryLine(task)}`);
-  }
-
-  const remainingCount = details.total - previewTasks.length;
-  if (remainingCount > 0) {
-    lines.push(`- ... ${remainingCount} more task(s)`);
   }
 
   return lines.join("\n");
@@ -263,17 +255,13 @@ const formatTaskShowContent = (task: TaskDetail): string => {
     return lines.join("\n");
   }
 
-  const previewComments = task.comments.slice(0, MAX_COMMENT_PREVIEW_COUNT);
-  for (const comment of previewComments) {
+  for (const comment of task.comments) {
     lines.push(`- [${comment.createdAt}] ${comment.author}`);
     lines.push(...indentLines(comment.content || "(empty)", 2));
     lines.push("");
   }
 
-  const remainingCount = task.comments.length - previewComments.length;
-  if (remainingCount > 0) {
-    lines.push(`- ... ${remainingCount} older comment(s) omitted`);
-  } else if (lines.at(-1) === "") {
+  if (lines.at(-1) === "") {
     lines.pop();
   }
 


### PR DESCRIPTION
## Summary

Remove all `MAX_*_LIST_PREVIEW_COUNT` and `MAX_COMMENT_PREVIEW_COUNT` constants and associated slicing logic so all matching results are returned from every list tool.

## Changes

- `src/tools/task-read-tools.ts` — removed `MAX_TASK_LIST_PREVIEW_COUNT` (25) and `MAX_COMMENT_PREVIEW_COUNT` (5)
- `src/tools/note-read-tools.ts` — removed `MAX_NOTE_LIST_PREVIEW_COUNT` (25)
- `src/tools/habit-read-tools.ts` — removed `MAX_HABIT_LIST_PREVIEW_COUNT` (25)
- `src/tools/project-read-tools.ts` — removed `MAX_PROJECT_LIST_PREVIEW_COUNT` (25)
- `src/tools/recurring-read-tools.ts` — removed `MAX_RECURRING_LIST_PREVIEW_COUNT` (25)

## Verification

- `make check` passes (lint, typecheck, 320 tests)

Task: #task-8ab51a11