### PR TITLE
feat: add note_show tool for full note detail

### DIFF
--- a/src/__tests__/note-read-tools.test.ts
+++ b/src/__tests__/note-read-tools.test.ts
@@ -9,7 +9,9 @@ import { registerTools } from "@/extension/register-tools";
 import type { NoteService } from "@/services/note-service";
 import {
   createNoteListToolDefinition,
+  createNoteShowToolDefinition,
   formatNoteListContent,
+  formatNoteShowContent,
   normalizeNoteListFilter,
 } from "@/tools/note-read-tools";
 
@@ -34,6 +36,7 @@ describe("registerTools", () => {
 
     const registeredToolNames = pi.registerTool.mock.calls.map(([tool]) => tool.name);
     expect(registeredToolNames).toContain("note_list");
+    expect(registeredToolNames).toContain("note_show");
   });
 });
 
@@ -184,5 +187,82 @@ describe("formatNoteListContent", () => {
     });
 
     expect(content).toContain("journal");
+  });
+});
+
+describe("createNoteShowToolDefinition", () => {
+  it("returns full note details when note is found", async () => {
+    const note = createNoteSummary();
+    const noteService = {
+      listNotes: vi.fn(),
+      getNote: vi.fn().mockResolvedValue(note),
+    } as unknown as NoteService;
+    const tool = createNoteShowToolDefinition({
+      getNoteService: vi.fn().mockResolvedValue(noteService),
+    });
+
+    const result = await tool.execute("tool-call-1", { noteId: "note-1" });
+
+    expect(noteService.getNote).toHaveBeenCalledWith("note-1");
+    expect(result.content[0]?.text).toContain("Note note-1");
+    expect(result.content[0]?.text).toContain("user");
+    expect(result.content[0]?.text).toContain("review");
+    expect(result.content[0]?.text).toContain("task:task-123");
+    expect(result.content[0]?.text).toContain("This is a test note.");
+    expect(result.details).toEqual({
+      kind: "note_show",
+      noteId: "note-1",
+      found: true,
+      note,
+    });
+  });
+
+  it("returns not-found result when note does not exist", async () => {
+    const noteService = {
+      listNotes: vi.fn(),
+      getNote: vi.fn().mockResolvedValue(null),
+    } as unknown as NoteService;
+    const tool = createNoteShowToolDefinition({
+      getNoteService: vi.fn().mockResolvedValue(noteService),
+    });
+
+    const result = await tool.execute("tool-call-1", { noteId: "note-missing" });
+
+    expect(result.content[0]?.text).toBe("Note not found: note-missing");
+    expect(result.details).toEqual({
+      kind: "note_show",
+      noteId: "note-missing",
+      found: false,
+    });
+  });
+
+  it("surfaces service failures with tool-specific context", async () => {
+    const tool = createNoteShowToolDefinition({
+      getNoteService: vi.fn().mockResolvedValue({
+        getNote: vi.fn().mockRejectedValue(new Error("daemon unavailable")),
+      } as unknown as NoteService),
+    });
+
+    await expect(tool.execute("tool-call-1", { noteId: "note-1" })).rejects.toThrow(
+      "note_show failed: daemon unavailable"
+    );
+  });
+});
+
+describe("formatNoteShowContent", () => {
+  it("formats full note details", () => {
+    const content = formatNoteShowContent(createNoteSummary());
+
+    expect(content).toContain("Note note-1");
+    expect(content).toContain("Author: user");
+    expect(content).toContain("Entity: task:task-123");
+    expect(content).toContain("Tags: review");
+    expect(content).toContain("This is a test note.");
+  });
+
+  it("formats journal entries without entity binding", () => {
+    const content = formatNoteShowContent(createNoteSummary({ entityType: null, entityId: null }));
+
+    expect(content).toContain("Entity: journal");
   });
 });

--- a/src/__tests__/todu-task-service.test.ts
+++ b/src/__tests__/todu-task-service.test.ts
@@ -55,6 +55,7 @@ describe("createToduTaskService", () => {
       listTaskComments: vi.fn().mockResolvedValue([]),
       addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
+      getNote: vi.fn().mockResolvedValue(null),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -118,6 +119,7 @@ describe("createToduTaskService", () => {
       listTaskComments: vi.fn().mockResolvedValue([]),
       addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
+      getNote: vi.fn().mockResolvedValue(null),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -184,6 +186,7 @@ describe("createToduTaskService", () => {
       listTaskComments: vi.fn().mockResolvedValue([]),
       addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
+      getNote: vi.fn().mockResolvedValue(null),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -255,6 +258,7 @@ describe("createToduTaskService", () => {
       listTaskComments: vi.fn().mockResolvedValue([]),
       addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
+      getNote: vi.fn().mockResolvedValue(null),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -337,6 +341,7 @@ describe("createToduTaskService", () => {
       listTaskComments: vi.fn().mockResolvedValue([]),
       addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
+      getNote: vi.fn().mockResolvedValue(null),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });

--- a/src/services/note-service.ts
+++ b/src/services/note-service.ts
@@ -2,4 +2,5 @@ import type { NoteFilter, NoteSummary } from "../domain/note";
 
 export interface NoteService {
   listNotes(filter?: NoteFilter): Promise<NoteSummary[]>;
+  getNote(noteId: string): Promise<NoteSummary | null>;
 }

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -140,6 +140,7 @@ export interface ToduDaemonClient {
   getHabitStreak(habitId: string): Promise<HabitStreak>;
   addHabitNote(input: AddHabitNoteInput): Promise<NoteSummary>;
   deleteHabit(habitId: string): Promise<DeleteHabitResult>;
+  getNote(noteId: string): Promise<NoteSummary | null>;
   listNotes(filter?: NoteFilter): Promise<NoteSummary[]>;
   listTaskComments(taskId: TaskId): Promise<TaskComment[]>;
   on(
@@ -489,6 +490,19 @@ const createToduDaemonClient = ({
       habitId,
       deleted: true,
     };
+  },
+
+  async getNote(noteId: string): Promise<NoteSummary | null> {
+    const result = await connection.request<ToduNote>("note.get", { id: noteId });
+    if (!result.ok) {
+      if (result.error.code === "NOT_FOUND") {
+        return null;
+      }
+
+      throw mapDaemonErrorToClientError("note.get", result.error);
+    }
+
+    return mapNoteSummary(result.value);
   },
 
   async listNotes(filter: NoteFilter = {}): Promise<NoteSummary[]> {

--- a/src/services/todu/todu-note-service.ts
+++ b/src/services/todu/todu-note-service.ts
@@ -27,6 +27,7 @@ export interface ToduNoteServiceDependencies {
 
 const createToduNoteService = ({ client }: ToduNoteServiceDependencies): NoteService => ({
   listNotes: (filter) => runNoteServiceOperation("listNotes", () => client.listNotes(filter)),
+  getNote: (noteId) => runNoteServiceOperation("getNote", () => client.getNote(noteId)),
 });
 
 const runNoteServiceOperation = async <TResult>(

--- a/src/tools/note-read-tools.ts
+++ b/src/tools/note-read-tools.ts
@@ -10,6 +10,10 @@ const NOTE_ENTITY_TYPE_VALUES = ["task", "project", "habit"] as const;
 
 const MAX_NOTE_CONTENT_PREVIEW_LENGTH = 200;
 
+const NoteShowParams = Type.Object({
+  noteId: Type.String({ description: "Note ID" }),
+});
+
 const NoteListParams = Type.Object({
   entityType: Type.Optional(
     StringEnum(NOTE_ENTITY_TYPE_VALUES, {
@@ -46,6 +50,17 @@ interface NoteListToolDetails {
   notes: NoteSummary[];
   total: number;
   empty: boolean;
+}
+
+interface NoteShowToolParams {
+  noteId: string;
+}
+
+interface NoteShowToolDetails {
+  kind: "note_show";
+  noteId: string;
+  found: boolean;
+  note?: NoteSummary;
 }
 
 interface NoteReadToolDependencies {
@@ -89,11 +104,56 @@ const createNoteListToolDefinition = ({ getNoteService }: NoteReadToolDependenci
   },
 });
 
+const createNoteShowToolDefinition = ({ getNoteService }: NoteReadToolDependencies) => ({
+  name: "note_show",
+  label: "Note Show",
+  description: "Show full note details by note ID.",
+  promptSnippet: "Show details for a specific note by note ID.",
+  promptGuidelines: [
+    "Use this tool when the user asks for details about a known note ID.",
+    "If the note is missing, report the explicit not-found result instead of guessing.",
+  ],
+  parameters: NoteShowParams,
+  async execute(_toolCallId: string, params: NoteShowToolParams) {
+    try {
+      const noteService = await getNoteService();
+      const note = await noteService.getNote(params.noteId);
+      if (!note) {
+        const details: NoteShowToolDetails = {
+          kind: "note_show",
+          noteId: params.noteId,
+          found: false,
+        };
+
+        return {
+          content: [{ type: "text" as const, text: `Note not found: ${params.noteId}` }],
+          details,
+        };
+      }
+
+      const details: NoteShowToolDetails = {
+        kind: "note_show",
+        noteId: params.noteId,
+        found: true,
+        note,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: formatNoteShowContent(note) }],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "note_show failed"), { cause: error });
+    }
+  },
+});
+
 const registerNoteReadTools = (
   pi: Pick<ExtensionAPI, "registerTool">,
   dependencies: NoteReadToolDependencies
 ): void => {
   pi.registerTool(createNoteListToolDefinition(dependencies));
+  pi.registerTool(createNoteShowToolDefinition(dependencies));
 };
 
 const normalizeNoteListFilter = (params: NoteListToolParams): NoteFilter => ({
@@ -142,6 +202,23 @@ const truncateContent = (content: string, maxLength: number): string => {
   return singleLine.slice(0, maxLength - 3) + "...";
 };
 
+const formatNoteShowContent = (note: NoteSummary): string => {
+  const entityLabel = note.entityType ? `${note.entityType}:${note.entityId ?? "?"}` : "journal";
+  const tagLabel = note.tags.length > 0 ? note.tags.join(", ") : "no tags";
+
+  return [
+    `Note ${note.id}`,
+    "",
+    `Author: ${note.author}`,
+    `Entity: ${entityLabel}`,
+    `Tags: ${tagLabel}`,
+    `Created: ${note.createdAt}`,
+    "",
+    "Content:",
+    note.content.trim().length > 0 ? note.content : "(empty)",
+  ].join("\n");
+};
+
 const formatToolError = (error: unknown, prefix: string): string => {
   if (error instanceof Error && error.message.trim().length > 0) {
     return `${prefix}: ${error.message}`;
@@ -150,10 +227,12 @@ const formatToolError = (error: unknown, prefix: string): string => {
   return prefix;
 };
 
-export type { NoteListToolDetails, NoteReadToolDependencies };
+export type { NoteListToolDetails, NoteShowToolDetails, NoteReadToolDependencies };
 export {
   createNoteListToolDefinition,
+  createNoteShowToolDefinition,
   formatNoteListContent,
+  formatNoteShowContent,
   normalizeNoteListFilter,
   registerNoteReadTools,
 };


### PR DESCRIPTION
## Summary

Add a `note_show` tool that retrieves a single note by ID, completing the list+show pattern across all domains.

## Changes

- `src/services/note-service.ts` — added `getNote(noteId)` to interface
- `src/services/todu/daemon-client.ts` — added `getNote` using `note.get` RPC
- `src/services/todu/todu-note-service.ts` — added `getNote` delegation
- `src/tools/note-read-tools.ts` — added `note_show` tool definition, formatter, and registration
- `src/__tests__/note-read-tools.test.ts` — added tests for found, not-found, and error cases
- `src/__tests__/todu-task-service.test.ts` — added `getNote` to mock clients

## Verification

- `make check` passes (lint, typecheck, 325 tests)

Task: #task-176d5bd0