### PR TITLE
feat: add actor-aware task and note flows

### DIFF
--- a/src/__tests__/current-task-context.test.ts
+++ b/src/__tests__/current-task-context.test.ts
@@ -16,6 +16,9 @@ const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
   projectId: overrides.projectId ?? "proj-1",
   projectName: overrides.projectName ?? "Todu Pi Extensions",
   labels: overrides.labels ?? ["ui"],
+  assigneeActorIds: overrides.assigneeActorIds ?? ["actor-user"],
+  assigneeDisplayNames: overrides.assigneeDisplayNames ?? ["Erik"],
+  assignees: overrides.assignees ?? ["Erik"],
   description: overrides.description ?? "Persist and restore current task context",
   comments: overrides.comments ?? [],
 });
@@ -69,7 +72,7 @@ describe("createCurrentTaskContextController", () => {
     );
     expect(ctx.ui.setWidget).toHaveBeenCalledWith(CURRENT_TASK_WIDGET_KEY, [
       task.title,
-      "active • high • Todu Pi Extensions",
+      "active • high • Todu Pi Extensions • assignees: Erik",
     ]);
     expect(appendEntry).not.toHaveBeenCalled();
     expect(controller.getState()).toEqual({ currentTaskId: task.id, currentTask: task });
@@ -101,7 +104,7 @@ describe("createCurrentTaskContextController", () => {
     );
     expect(ctx.ui.setWidget).toHaveBeenCalledWith(CURRENT_TASK_WIDGET_KEY, [
       task.title,
-      "active • high • Todu Pi Extensions",
+      "active • high • Todu Pi Extensions • assignees: Erik",
     ]);
 
     await controller.clearCurrentTask(ctx as never);
@@ -141,7 +144,7 @@ describe("createCurrentTaskContextController", () => {
     });
     expect(ctx.ui.setWidget).toHaveBeenLastCalledWith(CURRENT_TASK_WIDGET_KEY, [
       refreshedTask.title,
-      "active • medium • Todu Pi Extensions",
+      "active • medium • Todu Pi Extensions • assignees: Erik",
     ]);
   });
 

--- a/src/__tests__/daemon-client-habit.test.ts
+++ b/src/__tests__/daemon-client-habit.test.ts
@@ -346,6 +346,8 @@ describe("createToduDaemonClient habit support", () => {
     expect(note).toEqual({
       id: "note-1",
       content: "Session done",
+      authorActorId: null,
+      authorDisplayName: "user",
       author: "user",
       entityType: "habit",
       entityId: "habit-1",

--- a/src/__tests__/daemon-client.test.ts
+++ b/src/__tests__/daemon-client.test.ts
@@ -45,6 +45,9 @@ describe("createToduDaemonClient", () => {
         projectId: "proj-1",
         projectName: null,
         labels: ["daemon"],
+        assigneeActorIds: [],
+        assigneeDisplayNames: [],
+        assignees: [],
       },
     ]);
     expect(connection.request).toHaveBeenCalledWith("task.list", {
@@ -206,12 +209,17 @@ describe("createToduDaemonClient", () => {
       projectId: "proj-1",
       projectName: null,
       labels: ["daemon"],
+      assigneeActorIds: [],
+      assigneeDisplayNames: [],
+      assignees: [],
       description: "Implement the typed client wrapper",
       comments: [
         {
           id: "note-1",
           taskId: "task-1",
           content: "First note",
+          authorActorId: null,
+          authorDisplayName: "user",
           author: "user",
           createdAt: "2026-03-19T01:00:00.000Z",
         },
@@ -348,6 +356,8 @@ describe("createToduDaemonClient", () => {
       id: "note-1",
       taskId: "task-1",
       content: "Looks good",
+      authorActorId: null,
+      authorDisplayName: "user",
       author: "user",
       createdAt: "2026-03-19T02:00:00.000Z",
     });
@@ -843,6 +853,8 @@ describe("createToduDaemonClient", () => {
       {
         id: "note-1",
         content: "Journal entry",
+        authorActorId: null,
+        authorDisplayName: "user",
         author: "user",
         entityType: null,
         entityId: null,
@@ -856,6 +868,7 @@ describe("createToduDaemonClient", () => {
         entityId: undefined,
         tag: "daily",
         author: undefined,
+        authorActorId: undefined,
         createdFrom: "2026-03-01",
         createdTo: "2026-03-31",
         journal: true,

--- a/src/__tests__/daemon-client.test.ts
+++ b/src/__tests__/daemon-client.test.ts
@@ -161,6 +161,47 @@ describe("createToduDaemonClient", () => {
     expect(tasks[1]?.id).toBe("task-b");
   });
 
+  it("uses legacy assignee names when actor ids cannot be resolved", async () => {
+    const connection = createConnectionMock();
+    connection.request
+      .mockResolvedValueOnce({
+        ok: true,
+        value: [
+          {
+            id: "task-1",
+            title: "Ship wrapper",
+            status: "active",
+            priority: "high",
+            projectId: "proj-1",
+            labels: ["daemon"],
+            assigneeActorIds: ["actor-user", "actor-reviewer"],
+            assignees: ["Erik", "Reviewer"],
+            createdAt: "2026-03-19T00:00:00.000Z",
+            updatedAt: "2026-03-19T00:00:00.000Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: [{ id: "actor-reviewer", displayName: "Reviewer" }],
+      });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await expect(client.listTasks()).resolves.toEqual([
+      expect.objectContaining({
+        assigneeActorIds: ["actor-user", "actor-reviewer"],
+        assigneeDisplayNames: ["Erik", "Reviewer"],
+        assignees: ["Erik", "Reviewer"],
+      }),
+    ]);
+  });
+
   it("hydrates task detail with task notes", async () => {
     const connection = createConnectionMock();
     connection.request

--- a/src/__tests__/daemon-client.test.ts
+++ b/src/__tests__/daemon-client.test.ts
@@ -202,6 +202,45 @@ describe("createToduDaemonClient", () => {
     ]);
   });
 
+  it("falls back cleanly when actor.list fails during actor-backed task hydration", async () => {
+    const connection = createConnectionMock();
+    connection.request
+      .mockResolvedValueOnce({
+        ok: true,
+        value: [
+          {
+            id: "task-1",
+            title: "Ship wrapper",
+            status: "active",
+            priority: "high",
+            projectId: "proj-1",
+            labels: ["daemon"],
+            assigneeActorIds: ["actor-user"],
+            assignees: ["Erik"],
+            createdAt: "2026-03-19T00:00:00.000Z",
+            updatedAt: "2026-03-19T00:00:00.000Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: { code: "DAEMON_UNAVAILABLE", message: "actor list unavailable" },
+      });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await expect(client.listTasks()).resolves.toEqual([
+      expect.objectContaining({
+        assigneeDisplayNames: ["Erik"],
+      }),
+    ]);
+  });
+
   it("hydrates task detail with task notes", async () => {
     const connection = createConnectionMock();
     connection.request

--- a/src/__tests__/example.test.ts
+++ b/src/__tests__/example.test.ts
@@ -12,12 +12,15 @@ describe("task list UI scaffolding", () => {
       projectId: "proj-1",
       projectName: "Foundation",
       labels: ["foundation"],
+      assigneeActorIds: ["actor-user"],
+      assigneeDisplayNames: ["Erik"],
+      assignees: ["Erik"],
     });
 
     expect(item).toEqual({
       value: "task-123",
       label: "Implement module layout",
-      description: "active • high • Foundation",
+      description: "active • high • Foundation • assignees: Erik",
     });
   });
 });

--- a/src/__tests__/note-read-tools.test.ts
+++ b/src/__tests__/note-read-tools.test.ts
@@ -18,6 +18,8 @@ import {
 const createNoteSummary = (overrides: Partial<NoteSummary> = {}): NoteSummary => ({
   id: "note-1",
   content: "This is a test note.",
+  authorActorId: "actor-user",
+  authorDisplayName: "Erik",
   author: "user",
   entityType: "task",
   entityId: "task-123",
@@ -47,6 +49,7 @@ describe("normalizeNoteListFilter", () => {
         entityId: "   ",
         tag: "   ",
         author: "   ",
+        authorActorId: "   ",
         from: "   ",
         to: "   ",
       })
@@ -55,6 +58,7 @@ describe("normalizeNoteListFilter", () => {
       entityId: undefined,
       tag: undefined,
       author: undefined,
+      authorActorId: undefined,
       from: undefined,
       to: undefined,
       journal: undefined,
@@ -69,6 +73,7 @@ describe("normalizeNoteListFilter", () => {
         entityId: "task-123",
         tag: "review",
         author: "user",
+        authorActorId: "actor-user",
         from: "2026-01-01",
         to: "2026-03-31",
         journal: true,
@@ -79,6 +84,7 @@ describe("normalizeNoteListFilter", () => {
       entityId: "task-123",
       tag: "review",
       author: "user",
+      authorActorId: "actor-user",
       from: "2026-01-01",
       to: "2026-03-31",
       journal: true,
@@ -108,6 +114,7 @@ describe("createNoteListToolDefinition", () => {
       entityId: "task-123",
       tag: "review",
       author: undefined,
+      authorActorId: undefined,
       from: undefined,
       to: undefined,
       journal: undefined,
@@ -123,6 +130,7 @@ describe("createNoteListToolDefinition", () => {
         entityId: "task-123",
         tag: "review",
         author: undefined,
+        authorActorId: undefined,
         from: undefined,
         to: undefined,
         journal: undefined,
@@ -152,6 +160,7 @@ describe("createNoteListToolDefinition", () => {
         entityId: undefined,
         tag: undefined,
         author: undefined,
+        authorActorId: undefined,
         from: undefined,
         to: undefined,
         journal: undefined,
@@ -205,7 +214,7 @@ describe("createNoteShowToolDefinition", () => {
 
     expect(noteService.getNote).toHaveBeenCalledWith("note-1");
     expect(result.content[0]?.text).toContain("Note note-1");
-    expect(result.content[0]?.text).toContain("user");
+    expect(result.content[0]?.text).toContain("Erik");
     expect(result.content[0]?.text).toContain("review");
     expect(result.content[0]?.text).toContain("task:task-123");
     expect(result.content[0]?.text).toContain("This is a test note.");
@@ -254,7 +263,7 @@ describe("formatNoteShowContent", () => {
     const content = formatNoteShowContent(createNoteSummary());
 
     expect(content).toContain("Note note-1");
-    expect(content).toContain("Author: user");
+    expect(content).toContain("Author: Erik");
     expect(content).toContain("Entity: task:task-123");
     expect(content).toContain("Tags: review");
     expect(content).toContain("This is a test note.");

--- a/src/__tests__/note-service.test.ts
+++ b/src/__tests__/note-service.test.ts
@@ -16,6 +16,8 @@ describe("createToduNoteService", () => {
       {
         id: "note-1",
         content: "Hello",
+        authorActorId: "actor-user",
+        authorDisplayName: "Erik",
         author: "user",
         entityType: null,
         entityId: null,

--- a/src/__tests__/task-detail-view.test.ts
+++ b/src/__tests__/task-detail-view.test.ts
@@ -14,12 +14,17 @@ const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
   projectId: "proj-1",
   projectName: "Todu Pi Extensions",
   labels: ["ui", "detail"],
+  assigneeActorIds: ["actor-user", "actor-reviewer"],
+  assigneeDisplayNames: ["Erik", "Reviewer"],
+  assignees: ["Erik", "Reviewer"],
   description: "Show metadata, description, and comments inside pi.",
   comments: [
     {
       id: "comment-1",
       taskId: "task-123",
       content: "First note",
+      authorActorId: "actor-user",
+      authorDisplayName: "Erik",
       author: "user",
       createdAt: "2026-03-19T00:00:00.000Z",
     },
@@ -27,6 +32,8 @@ const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
       id: "comment-2",
       taskId: "task-123",
       content: "Second note",
+      authorActorId: "actor-user",
+      authorDisplayName: "Erik",
       author: "user",
       createdAt: "2026-03-19T01:00:00.000Z",
     },
@@ -44,6 +51,7 @@ describe("task detail view model", () => {
     expect(viewModel.body).toContain("Status: Active");
     expect(viewModel.body).toContain("Priority: high");
     expect(viewModel.body).toContain("Project: Todu Pi Extensions");
+    expect(viewModel.body).toContain("Assignees: Erik, Reviewer");
     expect(viewModel.body).toContain("Labels: ui, detail");
     expect(viewModel.body).toContain("Description");
     expect(viewModel.body).toContain("Show metadata, description, and comments inside pi.");

--- a/src/__tests__/task-mutation-tools.test.ts
+++ b/src/__tests__/task-mutation-tools.test.ts
@@ -15,6 +15,7 @@ import {
   normalizeUpdateTaskInput,
   resolveCreateTaskInput,
   resolveProjectForTaskCreate,
+  resolveUpdateTaskInput,
 } from "@/tools/task-mutation-tools";
 
 const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
@@ -25,6 +26,9 @@ const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
   projectId: "proj-1",
   projectName: "Todu Pi Extensions",
   labels: [],
+  assigneeActorIds: ["actor-user"],
+  assigneeDisplayNames: ["Erik"],
+  assignees: ["Erik"],
   description: "Add create, update, and comment tools.",
   comments: [],
   ...overrides,
@@ -33,6 +37,8 @@ const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
 const createTaskComment = (overrides: Partial<TaskComment> = {}): TaskComment => ({
   id: "comment-1",
   taskId: "task-123",
+  authorActorId: "actor-user",
+  authorDisplayName: "Erik",
   author: "user",
   createdAt: "2026-03-19T00:00:00.000Z",
   content: "Looks good",
@@ -93,7 +99,7 @@ describe("normalizeCreateTaskInput", () => {
 describe("normalizeUpdateTaskInput", () => {
   it("requires at least one supported mutation field", () => {
     expect(() => normalizeUpdateTaskInput({ taskId: "task-123" })).toThrow(
-      "task_update requires at least one supported field: title, status, priority, or description"
+      "task_update requires at least one supported field: title, status, priority, description, or assigneeActorIds"
     );
   });
 
@@ -123,6 +129,55 @@ describe("normalizeUpdateTaskInput", () => {
       priority: undefined,
       description: null,
     });
+  });
+});
+
+describe("resolveUpdateTaskInput", () => {
+  it("supports replacing assignees directly", async () => {
+    await expect(
+      resolveUpdateTaskInput({} as TaskService, {
+        taskId: "task-123",
+        assigneeActorIds: [" actor-user ", "actor-reviewer"],
+      })
+    ).resolves.toEqual({
+      taskId: "task-123",
+      status: undefined,
+      priority: undefined,
+      assigneeActorIds: ["actor-user", "actor-reviewer"],
+    });
+  });
+
+  it("supports incremental assignee updates", async () => {
+    const taskService = {
+      getTask: vi.fn().mockResolvedValue(
+        createTaskDetail({ assigneeActorIds: ["actor-user"], assigneeDisplayNames: ["Erik"] })
+      ),
+    } as unknown as TaskService;
+
+    await expect(
+      resolveUpdateTaskInput(taskService, {
+        taskId: "task-123",
+        addAssigneeActorIds: ["actor-reviewer", "actor-user"],
+        removeAssigneeActorIds: ["actor-user"],
+      })
+    ).resolves.toEqual({
+      taskId: "task-123",
+      status: undefined,
+      priority: undefined,
+      assigneeActorIds: ["actor-reviewer"],
+    });
+  });
+
+  it("rejects mixing direct and incremental assignee updates", async () => {
+    await expect(
+      resolveUpdateTaskInput({} as TaskService, {
+        taskId: "task-123",
+        assigneeActorIds: ["actor-user"],
+        addAssigneeActorIds: ["actor-reviewer"],
+      })
+    ).rejects.toThrow(
+      "task_update cannot combine assigneeActorIds with addAssigneeActorIds or removeAssigneeActorIds"
+    );
   });
 });
 
@@ -395,7 +450,7 @@ describe("createTaskUpdateToolDefinition", () => {
     });
 
     await expect(tool.execute("tool-call-1", { taskId: "task-123" })).rejects.toThrow(
-      "task_update failed: task_update requires at least one supported field: title, status, priority, or description"
+      "task_update failed: task_update requires at least one supported field: title, status, priority, description, or assigneeActorIds"
     );
   });
 

--- a/src/__tests__/task-read-tools.test.ts
+++ b/src/__tests__/task-read-tools.test.ts
@@ -21,6 +21,9 @@ const createTaskSummary = (overrides: Partial<TaskSummary> = {}): TaskSummary =>
   projectId: "proj-1",
   projectName: "Todu Pi Extensions",
   labels: ["tools"],
+  assigneeActorIds: ["actor-user", "actor-reviewer"],
+  assigneeDisplayNames: ["Erik", "Reviewer"],
+  assignees: ["Erik", "Reviewer"],
   ...overrides,
 });
 
@@ -31,6 +34,8 @@ const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
     {
       id: "comment-1",
       taskId: "task-123",
+      authorActorId: "actor-user",
+      authorDisplayName: "Erik",
       author: "user",
       createdAt: "2026-03-19T00:00:00.000Z",
       content: "Looks good",
@@ -150,6 +155,7 @@ describe("createTaskListToolDefinition", () => {
     expect(result.content[0]?.type).toBe("text");
     expect(result.content[0]?.text).toContain("Tasks (1):");
     expect(result.content[0]?.text).toContain("task-123");
+    expect(result.content[0]?.text).toContain("assignees: Erik, Reviewer");
     expect(result.details).toEqual({
       kind: "task_list",
       filter: {
@@ -258,6 +264,7 @@ describe("createTaskShowToolDefinition", () => {
     expect(taskService.getTask).toHaveBeenCalledWith(task.id);
     expect(result.content[0]?.text).toContain(`Task ${task.id}: ${task.title}`);
     expect(result.content[0]?.text).toContain("Description:");
+    expect(result.content[0]?.text).toContain("Assignees: Erik, Reviewer");
     expect(result.content[0]?.text).toContain("Recent comments (1):");
     expect(result.details).toEqual({
       kind: "task_show",

--- a/src/__tests__/tasks-command.test.ts
+++ b/src/__tests__/tasks-command.test.ts
@@ -26,6 +26,9 @@ const createTaskSummary = (): TaskSummary => ({
   projectId: "proj-1",
   projectName: "Todu Pi Extensions",
   labels: ["ui"],
+  assigneeActorIds: ["actor-user"],
+  assigneeDisplayNames: ["Erik"],
+  assignees: ["Erik"],
 });
 
 const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
@@ -871,6 +874,8 @@ describe("openTaskDetailHub", () => {
           id: "comment-1",
           taskId: task.id,
           content: "Looks good",
+          authorActorId: "actor-user",
+          authorDisplayName: "Erik",
           author: "user",
           createdAt: "2026-03-19T00:00:00.000Z",
         },

--- a/src/__tests__/todu-task-service.test.ts
+++ b/src/__tests__/todu-task-service.test.ts
@@ -16,6 +16,9 @@ describe("createToduTaskService", () => {
       projectId: "proj-1",
       projectName: null,
       labels: ["foundation"],
+      assigneeActorIds: ["actor-user"],
+      assigneeDisplayNames: ["Erik"],
+      assignees: ["Erik"],
     };
     const project: ProjectSummary = {
       id: "proj-1",
@@ -56,6 +59,7 @@ describe("createToduTaskService", () => {
       addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
       getNote: vi.fn().mockResolvedValue(null),
+      listActors: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -79,6 +83,9 @@ describe("createToduTaskService", () => {
       projectId: "proj-1",
       projectName: null,
       labels: ["foundation"],
+      assigneeActorIds: ["actor-user"],
+      assigneeDisplayNames: ["Erik"],
+      assignees: ["Erik"],
       description: "Create the initial module layout",
       comments: [],
     };
@@ -120,6 +127,7 @@ describe("createToduTaskService", () => {
       addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
       getNote: vi.fn().mockResolvedValue(null),
+      listActors: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -136,6 +144,7 @@ describe("createToduTaskService", () => {
         "Status: Active",
         "Priority: high",
         "Project: Foundation",
+        "Assignees: Erik",
         "Labels: foundation",
         "",
         "Description",
@@ -187,6 +196,7 @@ describe("createToduTaskService", () => {
       addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
       getNote: vi.fn().mockResolvedValue(null),
+      listActors: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -210,6 +220,9 @@ describe("createToduTaskService", () => {
       projectId: "proj-1",
       projectName: null,
       labels: ["foundation"],
+      assigneeActorIds: ["actor-user"],
+      assigneeDisplayNames: ["Erik"],
+      assignees: ["Erik"],
     };
     const project: ProjectSummary = {
       id: "proj-1",
@@ -259,6 +272,7 @@ describe("createToduTaskService", () => {
       addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
       getNote: vi.fn().mockResolvedValue(null),
+      listActors: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -291,6 +305,9 @@ describe("createToduTaskService", () => {
       projectId: "proj-1",
       projectName: null,
       labels: ["foundation"],
+      assigneeActorIds: ["actor-user"],
+      assigneeDisplayNames: ["Erik"],
+      assignees: ["Erik"],
       description: "Create the initial module layout",
       comments: [],
     };
@@ -342,6 +359,7 @@ describe("createToduTaskService", () => {
       addHabitNote: vi.fn().mockResolvedValue({}),
       listNotes: vi.fn().mockResolvedValue([]),
       getNote: vi.fn().mockResolvedValue(null),
+      listActors: vi.fn().mockResolvedValue([]),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -403,6 +421,9 @@ describe("createToduTaskService", () => {
       projectId: "proj-2",
       projectName: null,
       labels: [],
+      assigneeActorIds: ["actor-reviewer"],
+      assigneeDisplayNames: ["Reviewer"],
+      assignees: ["Reviewer"],
       description: null,
       comments: [],
     };

--- a/src/domain/actor.ts
+++ b/src/domain/actor.ts
@@ -1,0 +1,5 @@
+export interface ActorSummary {
+  id: string;
+  displayName: string;
+  archived: boolean;
+}

--- a/src/domain/note.ts
+++ b/src/domain/note.ts
@@ -5,7 +5,9 @@ export type NoteEntityType = "task" | "project" | "habit";
 export interface NoteSummary {
   id: NoteId;
   content: string;
-  author: string;
+  authorActorId: string | null;
+  authorDisplayName: string;
+  author: string | null;
   entityType: NoteEntityType | null;
   entityId: string | null;
   tags: string[];
@@ -17,6 +19,7 @@ export interface NoteFilter {
   entityId?: string;
   tag?: string;
   author?: string;
+  authorActorId?: string;
   from?: string;
   to?: string;
   journal?: boolean;

--- a/src/domain/task.ts
+++ b/src/domain/task.ts
@@ -1,5 +1,6 @@
 export type TaskId = string;
 export type ProjectId = string;
+export type ActorId = string;
 export type TaskCommentId = string;
 
 export type TaskStatus = "active" | "inprogress" | "waiting" | "done" | "cancelled";
@@ -18,7 +19,9 @@ export interface TaskComment {
   id: TaskCommentId;
   taskId: TaskId;
   content: string;
-  author: string;
+  authorActorId: ActorId | null;
+  authorDisplayName: string;
+  author: string | null;
   createdAt: string;
 }
 
@@ -30,6 +33,9 @@ export interface TaskSummary {
   projectId: ProjectId | null;
   projectName: string | null;
   labels: string[];
+  assigneeActorIds: ActorId[];
+  assigneeDisplayNames: string[];
+  assignees: string[];
 }
 
 export interface TaskDetail extends TaskSummary {

--- a/src/services/task-service.ts
+++ b/src/services/task-service.ts
@@ -22,6 +22,7 @@ export interface UpdateTaskInput {
   status?: TaskStatus;
   priority?: TaskPriority;
   description?: string | null;
+  assigneeActorIds?: string[];
 }
 
 export interface AddTaskCommentInput {

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -29,6 +29,7 @@ import type {
   RecurringTemplateDetail,
   RecurringTemplateSummary,
 } from "../../domain/recurring";
+import type { ActorSummary } from "../../domain/actor";
 import type {
   ProjectSummary,
   TaskComment,
@@ -115,6 +116,7 @@ export interface ToduProjectSummary {
 export interface ToduDaemonClient {
   listTasks(filter?: TaskFilter): Promise<TaskSummary[]>;
   getTask(taskId: TaskId): Promise<TaskDetail | null>;
+  listActors(): Promise<ActorSummary[]>;
   createTask(input: CreateTaskInput): Promise<TaskDetail>;
   updateTask(input: UpdateTaskInput): Promise<TaskDetail>;
   addTaskComment(input: AddTaskCommentInput): Promise<TaskComment>;
@@ -153,16 +155,30 @@ export interface CreateToduDaemonClientOptions {
   connection: Pick<ToduDaemonConnection, "request" | "subscribeToEvents">;
 }
 
+type ToduActorLike = {
+  id: string;
+  displayName: string;
+  archived?: boolean;
+};
+
+type ToduTaskWithActorFields = ToduTask & { assigneeActorIds?: string[] };
+type ToduTaskWithDetailWithActorFields = ToduTaskWithDetail & { assigneeActorIds?: string[] };
+type ToduNoteWithActorFields = ToduNote & { authorActorId?: string };
+type ToduNoteFilterWithActorFields = ToduNoteFilter & { authorActorId?: string };
+
 const createToduDaemonClient = ({
   connection,
 }: CreateToduDaemonClientOptions): ToduDaemonClient => ({
   async listTasks(filter = {}): Promise<TaskSummary[]> {
     const tasks = await listRawTasks(connection, filter);
-    return tasks.map(mapTaskSummary);
+    const actorMap = hasActorBackedTaskAssignments(tasks)
+      ? buildActorMap(await listActors(connection))
+      : new Map<string, ActorSummary>();
+    return tasks.map((task) => mapTaskSummary(task, actorMap));
   },
 
   async getTask(taskId: TaskId): Promise<TaskDetail | null> {
-    const taskResult = await connection.request<ToduTaskWithDetail>("task.get", { id: taskId });
+    const taskResult = await connection.request<ToduTaskWithDetailWithActorFields>("task.get", { id: taskId });
     if (!taskResult.ok) {
       if (taskResult.error.code === "NOT_FOUND") {
         return null;
@@ -172,22 +188,28 @@ const createToduDaemonClient = ({
     }
 
     const comments = await fetchTaskComments(connection, taskId);
-    return mapTaskDetail(taskResult.value, comments);
+    const actorMap = shouldLoadTaskActors(taskResult.value, comments)
+      ? buildActorMap(await listActors(connection))
+      : new Map<string, ActorSummary>();
+    return mapTaskDetail(taskResult.value, comments, actorMap);
   },
 
   async createTask(input: CreateTaskInput): Promise<TaskDetail> {
-    const taskResult = await connection.request<ToduTaskWithDetail>("task.create", {
+    const taskResult = await connection.request<ToduTaskWithDetailWithActorFields>("task.create", {
       input: mapCreateTaskInput(input),
     });
     if (!taskResult.ok) {
       throw mapDaemonErrorToClientError("task.create", taskResult.error);
     }
 
-    return mapTaskDetail(taskResult.value, []);
+    const actorMap = hasActorBackedTaskAssignments([taskResult.value])
+      ? buildActorMap(await listActors(connection))
+      : new Map<string, ActorSummary>();
+    return mapTaskDetail(taskResult.value, [], actorMap);
   },
 
   async updateTask(input: UpdateTaskInput): Promise<TaskDetail> {
-    const taskResult = await connection.request<ToduTaskWithDetail>("task.update", {
+    const taskResult = await connection.request<ToduTaskWithDetailWithActorFields>("task.update", {
       id: input.taskId,
       input: mapUpdateTaskInput(input),
     });
@@ -196,11 +218,14 @@ const createToduDaemonClient = ({
     }
 
     const comments = await fetchTaskComments(connection, input.taskId);
-    return mapTaskDetail(taskResult.value, comments);
+    const actorMap = shouldLoadTaskActors(taskResult.value, comments)
+      ? buildActorMap(await listActors(connection))
+      : new Map<string, ActorSummary>();
+    return mapTaskDetail(taskResult.value, comments, actorMap);
   },
 
   async addTaskComment(input: AddTaskCommentInput): Promise<TaskComment> {
-    const noteResult = await connection.request<ToduNote>("note.create", {
+    const noteResult = await connection.request<ToduNoteWithActorFields>("note.create", {
       input: {
         content: input.content,
         entityType: "task",
@@ -211,7 +236,10 @@ const createToduDaemonClient = ({
       throw mapDaemonErrorToClientError("note.create", noteResult.error);
     }
 
-    return mapTaskComment(noteResult.value);
+    const actorMap = noteResult.value.authorActorId
+      ? buildActorMap(await listActors(connection))
+      : new Map<string, ActorSummary>();
+    return mapTaskComment(noteResult.value, actorMap);
   },
 
   async deleteTask(taskId: TaskId): Promise<DeleteTaskResult> {
@@ -227,7 +255,7 @@ const createToduDaemonClient = ({
   },
 
   async moveTask(input: MoveTaskInput): Promise<MoveTaskResult> {
-    const result = await connection.request<ToduTaskWithDetail>("task.move", {
+    const result = await connection.request<ToduTaskWithDetailWithActorFields>("task.move", {
       id: input.taskId,
       targetProjectId: input.targetProjectId,
     });
@@ -236,10 +264,17 @@ const createToduDaemonClient = ({
     }
 
     const comments = await fetchTaskComments(connection, result.value.id);
+    const actorMap = shouldLoadTaskActors(result.value, comments)
+      ? buildActorMap(await listActors(connection))
+      : new Map<string, ActorSummary>();
     return {
       sourceTaskId: input.taskId,
-      targetTask: mapTaskDetail(result.value, comments),
+      targetTask: mapTaskDetail(result.value, comments, actorMap),
     };
+  },
+
+  async listActors(): Promise<ActorSummary[]> {
+    return listActors(connection);
   },
 
   async listProjects(): Promise<ToduProjectSummary[]> {
@@ -466,7 +501,7 @@ const createToduDaemonClient = ({
   },
 
   async addHabitNote(input: AddHabitNoteInput): Promise<NoteSummary> {
-    const noteResult = await connection.request<ToduNote>("note.create", {
+    const noteResult = await connection.request<ToduNoteWithActorFields>("note.create", {
       input: {
         content: input.content,
         entityType: "habit",
@@ -477,7 +512,10 @@ const createToduDaemonClient = ({
       throw mapDaemonErrorToClientError("note.create", noteResult.error);
     }
 
-    return mapNoteSummary(noteResult.value);
+    const actorMap = noteResult.value.authorActorId
+      ? buildActorMap(await listActors(connection))
+      : new Map<string, ActorSummary>();
+    return mapNoteSummary(noteResult.value, actorMap);
   },
 
   async deleteHabit(habitId: string): Promise<DeleteHabitResult> {
@@ -493,7 +531,7 @@ const createToduDaemonClient = ({
   },
 
   async getNote(noteId: string): Promise<NoteSummary | null> {
-    const result = await connection.request<ToduNote>("note.get", { id: noteId });
+    const result = await connection.request<ToduNoteWithActorFields>("note.get", { id: noteId });
     if (!result.ok) {
       if (result.error.code === "NOT_FOUND") {
         return null;
@@ -502,18 +540,24 @@ const createToduDaemonClient = ({
       throw mapDaemonErrorToClientError("note.get", result.error);
     }
 
-    return mapNoteSummary(result.value);
+    const actorMap = result.value.authorActorId
+      ? buildActorMap(await listActors(connection))
+      : new Map<string, ActorSummary>();
+    return mapNoteSummary(result.value, actorMap);
   },
 
   async listNotes(filter: NoteFilter = {}): Promise<NoteSummary[]> {
-    const result = await connection.request<ToduNote[]>("note.list", {
+    const result = await connection.request<ToduNoteWithActorFields[]>("note.list", {
       filter: mapNoteFilter(filter),
     });
     if (!result.ok) {
       throw mapDaemonErrorToClientError("note.list", result.error);
     }
 
-    return result.value.map(mapNoteSummary);
+    const actorMap = result.value.some((note) => note.authorActorId)
+      ? buildActorMap(await listActors(connection))
+      : new Map<string, ActorSummary>();
+    return result.value.map((note) => mapNoteSummary(note, actorMap));
   },
 
   async listTaskComments(taskId: TaskId): Promise<TaskComment[]> {
@@ -535,11 +579,11 @@ const createToduDaemonClient = ({
 const listRawTasks = async (
   connection: Pick<ToduDaemonConnection, "request">,
   filter: TaskFilter
-): Promise<ToduTask[]> => {
-  let tasks: ToduTask[];
+): Promise<ToduTaskWithActorFields[]> => {
+  let tasks: ToduTaskWithActorFields[];
 
   if (filter.query && filter.query.trim().length > 0) {
-    const result = await connection.request<ToduTask[]>("task.search", {
+    const result = await connection.request<ToduTaskWithActorFields[]>("task.search", {
       query: filter.query,
     });
     if (!result.ok) {
@@ -548,7 +592,7 @@ const listRawTasks = async (
 
     tasks = result.value.filter((task) => matchesTaskFilter(task, filter));
   } else {
-    const result = await connection.request<ToduTask[]>("task.list", {
+    const result = await connection.request<ToduTaskWithActorFields[]>("task.list", {
       filter: mapTaskFilter(filter),
     });
     if (!result.ok) {
@@ -565,7 +609,11 @@ const listRawTasks = async (
   return tasks;
 };
 
-const sortTasks = (tasks: ToduTask[], field: string, direction: "asc" | "desc"): ToduTask[] => {
+const sortTasks = (
+  tasks: ToduTaskWithActorFields[],
+  field: string,
+  direction: "asc" | "desc"
+): ToduTaskWithActorFields[] => {
   const sorted = [...tasks].sort((a, b) => {
     const aVal = getTaskSortValue(a, field);
     const bVal = getTaskSortValue(b, field);
@@ -595,24 +643,83 @@ const getTaskSortValue = (task: ToduTask, field: string): string | number => {
   }
 };
 
+const listActors = async (
+  connection: Pick<ToduDaemonConnection, "request">
+): Promise<ActorSummary[]> => {
+  const result = await connection.request<ToduActorLike[]>("actor.list", {});
+  if (!result.ok) {
+    throw mapDaemonErrorToClientError("actor.list", result.error);
+  }
+
+  return result.value.map((actor) => ({
+    id: actor.id,
+    displayName: actor.displayName,
+    archived: actor.archived ?? false,
+  }));
+};
+
+const buildActorMap = (actors: ActorSummary[]): Map<string, ActorSummary> =>
+  new Map(actors.map((actor) => [actor.id, actor]));
+
+const resolveActorDisplayName = (
+  actorId: string | undefined,
+  actorMap: Map<string, ActorSummary>,
+  fallback?: string | null
+): string => {
+  if (!actorId) {
+    return fallback?.trim() || "Unknown";
+  }
+
+  return actorMap.get(actorId)?.displayName ?? fallback?.trim() ?? actorId;
+};
+
+const resolveActorDisplayNames = (
+  actorIds: readonly string[],
+  actorMap: Map<string, ActorSummary>,
+  fallbackNames: readonly string[] = []
+): string[] => {
+  if (actorIds.length > 0) {
+    return actorIds.map((actorId) => resolveActorDisplayName(actorId, actorMap));
+  }
+
+  return fallbackNames.filter((name) => name.trim().length > 0);
+};
+
+const hasActorBackedTaskAssignments = (
+  tasks: ReadonlyArray<{ assigneeActorIds?: string[] }>
+): boolean =>
+  tasks.some((task) => (task.assigneeActorIds ?? []).length > 0);
+
+const shouldLoadTaskActors = (
+  task: { assigneeActorIds?: string[] },
+  comments: ReadonlyArray<{ authorActorId?: string | null }>
+): boolean =>
+  (task.assigneeActorIds ?? []).length > 0 || comments.some((comment) => comment.authorActorId);
+
 const fetchTaskComments = async (
   connection: Pick<ToduDaemonConnection, "request">,
   taskId: TaskId
 ): Promise<TaskComment[]> => {
-  const result = await connection.request<ToduNote[]>("note.list", {
+  const notes = await connection.request<ToduNoteWithActorFields[]>("note.list", {
     filter: {
       entityType: "task",
       entityId: taskId,
     },
   });
-  if (!result.ok) {
-    throw mapDaemonErrorToClientError("note.list", result.error);
+  if (!notes.ok) {
+    throw mapDaemonErrorToClientError("note.list", notes.error);
   }
 
-  return result.value.map(mapTaskComment);
+  const actorMap = notes.value.some((note) => note.authorActorId)
+    ? buildActorMap(await listActors(connection))
+    : new Map<string, ActorSummary>();
+  return notes.value.map((note) => mapTaskComment(note, actorMap));
 };
 
-const mapTaskSummary = (task: ToduTask): TaskSummary => ({
+const mapTaskSummary = (
+  task: ToduTaskWithActorFields,
+  actorMap: Map<string, ActorSummary>
+): TaskSummary => ({
   id: task.id,
   title: task.title,
   status: toLocalTaskStatus(task.status),
@@ -620,37 +727,59 @@ const mapTaskSummary = (task: ToduTask): TaskSummary => ({
   projectId: task.projectId ?? null,
   projectName: null,
   labels: [...task.labels],
+  assigneeActorIds: [...(task.assigneeActorIds ?? [])],
+  assigneeDisplayNames: resolveActorDisplayNames(
+    task.assigneeActorIds ?? [],
+    actorMap,
+    task.assignees ?? []
+  ),
+  assignees: [...(task.assignees ?? [])],
 });
 
-const mapTaskDetail = (task: ToduTaskWithDetail, comments: TaskComment[]): TaskDetail => ({
-  ...mapTaskSummary(task),
+const mapTaskDetail = (
+  task: ToduTaskWithDetailWithActorFields,
+  comments: TaskComment[],
+  actorMap: Map<string, ActorSummary>
+): TaskDetail => ({
+  ...mapTaskSummary(task, actorMap),
   description: task.description ?? null,
   comments,
 });
 
-const mapTaskComment = (note: ToduNote): TaskComment => ({
+const mapTaskComment = (
+  note: ToduNoteWithActorFields,
+  actorMap: Map<string, ActorSummary>
+): TaskComment => ({
   id: note.id,
   taskId: note.entityId ?? "",
   content: note.content,
-  author: note.author,
+  authorActorId: note.authorActorId ?? null,
+  authorDisplayName: resolveActorDisplayName(note.authorActorId, actorMap, note.author),
+  author: note.author ?? null,
   createdAt: note.createdAt,
 });
 
-const mapNoteSummary = (note: ToduNote): NoteSummary => ({
+const mapNoteSummary = (
+  note: ToduNoteWithActorFields,
+  actorMap: Map<string, ActorSummary>
+): NoteSummary => ({
   id: note.id,
   content: note.content,
-  author: note.author,
+  authorActorId: note.authorActorId ?? null,
+  authorDisplayName: resolveActorDisplayName(note.authorActorId, actorMap, note.author),
+  author: note.author ?? null,
   entityType: (note.entityType as NoteEntityType) ?? null,
   entityId: note.entityId ?? null,
   tags: [...note.tags],
   createdAt: note.createdAt,
 });
 
-const mapNoteFilter = (filter: NoteFilter): ToduNoteFilter => ({
+const mapNoteFilter = (filter: NoteFilter): ToduNoteFilterWithActorFields => ({
   entityType: filter.entityType,
   entityId: filter.entityId,
   tag: filter.tag,
   author: filter.author,
+  authorActorId: filter.authorActorId,
   createdFrom: filter.from,
   createdTo: filter.to,
   journal: filter.journal,
@@ -866,6 +995,7 @@ const mapUpdateTaskInput = (input: UpdateTaskInput): Record<string, unknown> => 
   status: input.status ? toRemoteTaskStatus(input.status) : undefined,
   priority: input.priority ? toRemoteTaskPriority(input.priority) : undefined,
   description: input.description ?? undefined,
+  assigneeActorIds: input.assigneeActorIds,
 });
 
 const matchesTaskFilter = (task: ToduTask, filter: TaskFilter): boolean => {

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -679,7 +679,9 @@ const resolveActorDisplayNames = (
   fallbackNames: readonly string[] = []
 ): string[] => {
   if (actorIds.length > 0) {
-    return actorIds.map((actorId) => resolveActorDisplayName(actorId, actorMap));
+    return actorIds.map((actorId, index) =>
+      resolveActorDisplayName(actorId, actorMap, fallbackNames[index])
+    );
   }
 
   return fallbackNames.filter((name) => name.trim().length > 0);

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -172,7 +172,7 @@ const createToduDaemonClient = ({
   async listTasks(filter = {}): Promise<TaskSummary[]> {
     const tasks = await listRawTasks(connection, filter);
     const actorMap = hasActorBackedTaskAssignments(tasks)
-      ? buildActorMap(await listActors(connection))
+      ? buildActorMap(await listActorsBestEffort(connection))
       : new Map<string, ActorSummary>();
     return tasks.map((task) => mapTaskSummary(task, actorMap));
   },
@@ -189,7 +189,7 @@ const createToduDaemonClient = ({
 
     const comments = await fetchTaskComments(connection, taskId);
     const actorMap = shouldLoadTaskActors(taskResult.value, comments)
-      ? buildActorMap(await listActors(connection))
+      ? buildActorMap(await listActorsBestEffort(connection))
       : new Map<string, ActorSummary>();
     return mapTaskDetail(taskResult.value, comments, actorMap);
   },
@@ -203,7 +203,7 @@ const createToduDaemonClient = ({
     }
 
     const actorMap = hasActorBackedTaskAssignments([taskResult.value])
-      ? buildActorMap(await listActors(connection))
+      ? buildActorMap(await listActorsBestEffort(connection))
       : new Map<string, ActorSummary>();
     return mapTaskDetail(taskResult.value, [], actorMap);
   },
@@ -219,7 +219,7 @@ const createToduDaemonClient = ({
 
     const comments = await fetchTaskComments(connection, input.taskId);
     const actorMap = shouldLoadTaskActors(taskResult.value, comments)
-      ? buildActorMap(await listActors(connection))
+      ? buildActorMap(await listActorsBestEffort(connection))
       : new Map<string, ActorSummary>();
     return mapTaskDetail(taskResult.value, comments, actorMap);
   },
@@ -237,7 +237,7 @@ const createToduDaemonClient = ({
     }
 
     const actorMap = noteResult.value.authorActorId
-      ? buildActorMap(await listActors(connection))
+      ? buildActorMap(await listActorsBestEffort(connection))
       : new Map<string, ActorSummary>();
     return mapTaskComment(noteResult.value, actorMap);
   },
@@ -265,7 +265,7 @@ const createToduDaemonClient = ({
 
     const comments = await fetchTaskComments(connection, result.value.id);
     const actorMap = shouldLoadTaskActors(result.value, comments)
-      ? buildActorMap(await listActors(connection))
+      ? buildActorMap(await listActorsBestEffort(connection))
       : new Map<string, ActorSummary>();
     return {
       sourceTaskId: input.taskId,
@@ -513,7 +513,7 @@ const createToduDaemonClient = ({
     }
 
     const actorMap = noteResult.value.authorActorId
-      ? buildActorMap(await listActors(connection))
+      ? buildActorMap(await listActorsBestEffort(connection))
       : new Map<string, ActorSummary>();
     return mapNoteSummary(noteResult.value, actorMap);
   },
@@ -541,7 +541,7 @@ const createToduDaemonClient = ({
     }
 
     const actorMap = result.value.authorActorId
-      ? buildActorMap(await listActors(connection))
+      ? buildActorMap(await listActorsBestEffort(connection))
       : new Map<string, ActorSummary>();
     return mapNoteSummary(result.value, actorMap);
   },
@@ -555,7 +555,7 @@ const createToduDaemonClient = ({
     }
 
     const actorMap = result.value.some((note) => note.authorActorId)
-      ? buildActorMap(await listActors(connection))
+      ? buildActorMap(await listActorsBestEffort(connection))
       : new Map<string, ActorSummary>();
     return result.value.map((note) => mapNoteSummary(note, actorMap));
   },
@@ -658,6 +658,16 @@ const listActors = async (
   }));
 };
 
+const listActorsBestEffort = async (
+  connection: Pick<ToduDaemonConnection, "request">
+): Promise<ActorSummary[]> => {
+  try {
+    return await listActors(connection);
+  } catch {
+    return [];
+  }
+};
+
 const buildActorMap = (actors: ActorSummary[]): Map<string, ActorSummary> =>
   new Map(actors.map((actor) => [actor.id, actor]));
 
@@ -713,7 +723,7 @@ const fetchTaskComments = async (
   }
 
   const actorMap = notes.value.some((note) => note.authorActorId)
-    ? buildActorMap(await listActors(connection))
+    ? buildActorMap(await listActorsBestEffort(connection))
     : new Map<string, ActorSummary>();
   return notes.value.map((note) => mapTaskComment(note, actorMap));
 };

--- a/src/tools/note-read-tools.ts
+++ b/src/tools/note-read-tools.ts
@@ -22,7 +22,8 @@ const NoteListParams = Type.Object({
     Type.String({ description: "Optional entity ID filter (task ID, project ID, or habit ID)" })
   ),
   tag: Type.Optional(Type.String({ description: "Optional tag filter" })),
-  author: Type.Optional(Type.String({ description: "Optional author filter" })),
+  author: Type.Optional(Type.String({ description: "Optional legacy author display filter" })),
+  authorActorId: Type.Optional(Type.String({ description: "Optional author actor ID filter" })),
   from: Type.Optional(Type.String({ description: "Optional created-at start date (YYYY-MM-DD)" })),
   to: Type.Optional(Type.String({ description: "Optional created-at end date (YYYY-MM-DD)" })),
   journal: Type.Optional(
@@ -36,6 +37,7 @@ interface NoteListToolParams {
   entityId?: string;
   tag?: string;
   author?: string;
+  authorActorId?: string;
   from?: string;
   to?: string;
   journal?: boolean;
@@ -159,6 +161,7 @@ const normalizeNoteListFilter = (params: NoteListToolParams): NoteFilter => ({
   entityId: normalizeOptionalText(params.entityId),
   tag: normalizeOptionalText(params.tag),
   author: normalizeOptionalText(params.author),
+  authorActorId: normalizeOptionalText(params.authorActorId),
   from: normalizeOptionalText(params.from),
   to: normalizeOptionalText(params.to),
   journal: params.journal ?? undefined,
@@ -187,7 +190,7 @@ const formatNoteListContent = (details: NoteListToolDetails): string => {
 const formatNoteSummaryLine = (note: NoteSummary): string => {
   const entityLabel = note.entityType ? `${note.entityType}:${note.entityId ?? "?"}` : "journal";
   const tagLabel = note.tags.length > 0 ? note.tags.join(", ") : "no tags";
-  return `${note.id} • ${entityLabel} • ${note.author} • ${tagLabel} • ${note.createdAt}\n    ${note.content}`;
+  return `${note.id} • ${entityLabel} • ${note.authorDisplayName} • ${tagLabel} • ${note.createdAt}\n    ${note.content}`;
 };
 
 const formatNoteShowContent = (note: NoteSummary): string => {
@@ -197,7 +200,7 @@ const formatNoteShowContent = (note: NoteSummary): string => {
   return [
     `Note ${note.id}`,
     "",
-    `Author: ${note.author}`,
+    `Author: ${note.authorDisplayName}`,
     `Entity: ${entityLabel}`,
     `Tags: ${tagLabel}`,
     `Created: ${note.createdAt}`,

--- a/src/tools/task-mutation-tools.ts
+++ b/src/tools/task-mutation-tools.ts
@@ -46,6 +46,21 @@ const TaskUpdateParams = Type.Object({
       description: "Optional replacement description. Use an empty string to clear it.",
     })
   ),
+  assigneeActorIds: Type.Optional(
+    Type.Array(Type.String({ description: "Actor ID" }), {
+      description: "Optional full replacement assignee actor ID list",
+    })
+  ),
+  addAssigneeActorIds: Type.Optional(
+    Type.Array(Type.String({ description: "Actor ID" }), {
+      description: "Optional actor IDs to add to the current assignee list",
+    })
+  ),
+  removeAssigneeActorIds: Type.Optional(
+    Type.Array(Type.String({ description: "Actor ID" }), {
+      description: "Optional actor IDs to remove from the current assignee list",
+    })
+  ),
 });
 
 const TaskCommentCreateParams = Type.Object({
@@ -74,6 +89,9 @@ interface TaskUpdateToolParams {
   status?: TaskStatus;
   priority?: TaskPriority;
   description?: string;
+  assigneeActorIds?: string[];
+  addAssigneeActorIds?: string[];
+  removeAssigneeActorIds?: string[];
 }
 
 interface TaskCommentCreateToolParams {
@@ -164,17 +182,19 @@ const createTaskCreateToolDefinition = ({ getTaskService }: TaskMutationToolDepe
 const createTaskUpdateToolDefinition = ({ getTaskService }: TaskMutationToolDependencies) => ({
   name: "task_update",
   label: "Task Update",
-  description: "Update a task's title, status, priority, or description.",
-  promptSnippet: "Update a task's supported metadata fields by task ID.",
+  description: "Update a task's title, status, priority, description, or assignees.",
+  promptSnippet: "Update a task's supported metadata and assignee fields by task ID.",
   promptGuidelines: [
     "Use this tool for backend task updates in normal chat.",
-    "Supported fields are title, status, priority, and description.",
+    "Supported fields are title, status, priority, description, and actor-based assignee updates.",
+    "Use assigneeActorIds to replace the full assignee list.",
+    "Use addAssigneeActorIds or removeAssigneeActorIds for incremental multi-actor assignment changes.",
   ],
   parameters: TaskUpdateParams,
   async execute(_toolCallId: string, params: TaskUpdateToolParams) {
     try {
-      const input = normalizeUpdateTaskInput(params);
       const taskService = await getTaskService();
+      const input = await resolveUpdateTaskInput(taskService, params);
       const task = await updateTask({ taskService }, input);
       const details: TaskUpdateToolDetails = {
         kind: "task_update",
@@ -403,24 +423,106 @@ const normalizeUpdateTaskInput = (params: TaskUpdateToolParams): UpdateTaskInput
     input.description = normalizeNullableText(params.description);
   }
 
+  if (hasOwn(params, "assigneeActorIds")) {
+    input.assigneeActorIds = normalizeActorIdList(params.assigneeActorIds, "assigneeActorIds");
+  }
+
   if (
     input.title === undefined &&
     input.status === undefined &&
     input.priority === undefined &&
-    !hasOwn(input, "description")
+    !hasOwn(input, "description") &&
+    !hasOwn(input, "assigneeActorIds")
   ) {
     throw new Error(
-      "task_update requires at least one supported field: title, status, priority, or description"
+      "task_update requires at least one supported field: title, status, priority, description, or assigneeActorIds"
     );
   }
 
   return input;
 };
 
+const resolveUpdateTaskInput = async (
+  taskService: TaskService,
+  params: TaskUpdateToolParams
+): Promise<UpdateTaskInput> => {
+  if (params.assigneeActorIds !== undefined) {
+    if (params.addAssigneeActorIds !== undefined || params.removeAssigneeActorIds !== undefined) {
+      throw new Error(
+        "task_update cannot combine assigneeActorIds with addAssigneeActorIds or removeAssigneeActorIds"
+      );
+    }
+
+    return normalizeUpdateTaskInput(params);
+  }
+
+  const addAssigneeActorIds = hasOwn(params, "addAssigneeActorIds")
+    ? normalizeActorIdList(params.addAssigneeActorIds, "addAssigneeActorIds")
+    : undefined;
+  const removeAssigneeActorIds = hasOwn(params, "removeAssigneeActorIds")
+    ? normalizeActorIdList(params.removeAssigneeActorIds, "removeAssigneeActorIds")
+    : undefined;
+
+  const hasIncrementalAssigneeUpdate =
+    addAssigneeActorIds !== undefined || removeAssigneeActorIds !== undefined;
+
+  const baseInput: UpdateTaskInput = {
+    taskId: normalizeRequiredText(params.taskId, "taskId") as TaskId,
+    status: params.status,
+    priority: params.priority,
+  };
+
+  if (hasOwn(params, "title")) {
+    baseInput.title = normalizeRequiredText(params.title ?? "", "title");
+  }
+
+  if (hasOwn(params, "description")) {
+    baseInput.description = normalizeNullableText(params.description);
+  }
+
+  if (!hasIncrementalAssigneeUpdate) {
+    return normalizeUpdateTaskInput(params);
+  }
+
+  const task = await taskService.getTask(baseInput.taskId);
+  if (!task) {
+    throw new Error(`task not found: ${baseInput.taskId}`);
+  }
+
+  const nextAssigneeActorIds = new Set(task.assigneeActorIds);
+  for (const actorId of addAssigneeActorIds ?? []) {
+    nextAssigneeActorIds.add(actorId);
+  }
+  for (const actorId of removeAssigneeActorIds ?? []) {
+    nextAssigneeActorIds.delete(actorId);
+  }
+
+  return {
+    ...baseInput,
+    assigneeActorIds: [...nextAssigneeActorIds],
+  };
+};
+
 const normalizeTaskCommentInput = (params: TaskCommentCreateToolParams): AddTaskCommentInput => ({
   taskId: normalizeRequiredText(params.taskId, "taskId") as TaskId,
   content: normalizeRequiredText(params.content, "content"),
 });
+
+const normalizeActorIdList = (
+  values: string[] | undefined,
+  fieldName: string
+): string[] => {
+  if (values === undefined) {
+    throw new Error(`${fieldName} is required`);
+  }
+
+  const normalizedValues = values.map((value, index) => {
+    const normalizedValue = normalizeRequiredText(value ?? "", `${fieldName}[${index}]`);
+    return normalizedValue;
+  });
+
+  return [...new Set(normalizedValues)];
+};
 
 const normalizeRequiredText = (value: string, fieldName: string): string => {
   const trimmedValue = value.trim();
@@ -465,6 +567,9 @@ const formatTaskUpdateContent = (task: TaskDetail, input: UpdateTaskInput): stri
     input.priority !== undefined ? `priority=${input.priority}` : null,
     hasOwn(input, "description")
       ? `description=${input.description === null ? "cleared" : "updated"}`
+      : null,
+    hasOwn(input, "assigneeActorIds")
+      ? `assigneeActorIds=${JSON.stringify(input.assigneeActorIds ?? [])}`
       : null,
   ].filter((value): value is string => value !== null);
 
@@ -522,6 +627,7 @@ export {
   normalizeTaskCommentInput,
   normalizeUpdateTaskInput,
   registerTaskMutationTools,
+  resolveUpdateTaskInput,
   resolveCreateTaskInput,
   resolveProjectForTaskCreate,
 };

--- a/src/tools/task-read-tools.ts
+++ b/src/tools/task-read-tools.ts
@@ -232,7 +232,9 @@ const formatTaskListContent = (details: TaskListToolDetails): string => {
 
 const formatTaskSummaryLine = (task: TaskSummary): string => {
   const projectLabel = task.projectName ?? task.projectId ?? "no project";
-  return `${task.id} • ${task.title} • ${task.status} • ${task.priority} • ${projectLabel}`;
+  const assigneeLabel =
+    task.assigneeDisplayNames.length > 0 ? task.assigneeDisplayNames.join(", ") : "none";
+  return `${task.id} • ${task.title} • ${task.status} • ${task.priority} • ${projectLabel} • assignees: ${assigneeLabel}`;
 };
 
 const formatTaskShowContent = (task: TaskDetail): string => {
@@ -242,6 +244,7 @@ const formatTaskShowContent = (task: TaskDetail): string => {
     `Status: ${task.status}`,
     `Priority: ${task.priority}`,
     `Project: ${task.projectName ?? task.projectId ?? "No project"}`,
+    `Assignees: ${task.assigneeDisplayNames.length > 0 ? task.assigneeDisplayNames.join(", ") : "none"}`,
     `Labels: ${task.labels.length > 0 ? task.labels.join(", ") : "none"}`,
     "",
     "Description:",
@@ -256,7 +259,7 @@ const formatTaskShowContent = (task: TaskDetail): string => {
   }
 
   for (const comment of task.comments) {
-    lines.push(`- [${comment.createdAt}] ${comment.author}`);
+    lines.push(`- [${comment.createdAt}] ${comment.authorDisplayName}`);
     lines.push(...indentLines(comment.content || "(empty)", 2));
     lines.push("");
   }

--- a/src/ui/components/task-detail.ts
+++ b/src/ui/components/task-detail.ts
@@ -73,6 +73,7 @@ const createTaskDetailBody = (task: TaskDetail, recentCommentLimit: number): str
     `Status: ${formatTaskStatusLabel(task.status)}`,
     `Priority: ${task.priority}`,
     `Project: ${task.projectName ?? task.projectId ?? "No project"}`,
+    `Assignees: ${task.assigneeDisplayNames.length > 0 ? task.assigneeDisplayNames.join(", ") : "None"}`,
     `Labels: ${task.labels.length > 0 ? task.labels.join(", ") : "None"}`,
     "",
     "Description",
@@ -96,7 +97,7 @@ const formatRecentComments = (task: TaskDetail, recentCommentLimit: number): str
       .split("\n")
       .map((line) => (line.trim().length > 0 ? `  ${line}` : "  "));
 
-    return [`- ${comment.author} · ${comment.createdAt}`, ...contentLines];
+    return [`- ${comment.authorDisplayName} · ${comment.createdAt}`, ...contentLines];
   });
 };
 

--- a/src/utils/task-format.ts
+++ b/src/utils/task-format.ts
@@ -1,11 +1,20 @@
 import type { TaskDetail, TaskSummary } from "../domain/task";
 
 const formatTaskSummary = (task: TaskSummary): string =>
-  [task.status, task.priority, task.projectName ?? task.projectId ?? "no-project"].join(" • ");
+  [
+    task.status,
+    task.priority,
+    task.projectName ?? task.projectId ?? "no-project",
+    task.assigneeDisplayNames.length > 0 ? `assignees: ${task.assigneeDisplayNames.join(", ")}` : null,
+  ]
+    .filter((value): value is string => value !== null)
+    .join(" • ");
 
 const formatTaskDetail = (task: TaskDetail): string => {
   const description = task.description?.trim() ?? "No description";
-  return `${task.title}\n${description}`;
+  const assignees =
+    task.assigneeDisplayNames.length > 0 ? task.assigneeDisplayNames.join(", ") : "None";
+  return `${task.title}\nAssignees: ${assignees}\n${description}`;
 };
 
 export { formatTaskDetail, formatTaskSummary };


### PR DESCRIPTION
## Summary
- make task and note flows actor-aware with compatibility fallbacks for legacy assignee/author strings
- add actor-based assignee update support to task mutation tools, including incremental add/remove flows
- update daemon mapping, rendering, and tests for multi-assignee and actor-author display

## Testing
- npm test
- npm run lint
- npm run typecheck

Task: #task-e30c83c0