### PR TITLE
feat: add actor and project auth tools

### DIFF
--- a/src/__tests__/actor-tools.test.ts
+++ b/src/__tests__/actor-tools.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ActorSummary } from "@/domain/actor";
+import { registerTools } from "@/extension/register-tools";
+import type { ActorService } from "@/services/actor-service";
+import type { TaskService } from "@/services/task-service";
+import {
+  createActorArchiveToolDefinition,
+  createActorCreateToolDefinition,
+  createActorRenameToolDefinition,
+  createActorUnarchiveToolDefinition,
+} from "@/tools/actor-mutation-tools";
+import { createActorListToolDefinition } from "@/tools/actor-read-tools";
+
+const createActor = (overrides: Partial<ActorSummary> = {}): ActorSummary => ({
+  id: "actor-user",
+  displayName: "Erik",
+  archived: false,
+  ...overrides,
+});
+
+describe("registerTools", () => {
+  it("registers actor management tools", () => {
+    const pi = { registerTool: vi.fn() };
+
+    registerTools(pi as never, {
+      getTaskService: vi.fn().mockResolvedValue({} as TaskService),
+      getActorService: vi.fn().mockResolvedValue({} as ActorService),
+    });
+
+    const registeredToolNames = pi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(registeredToolNames).toEqual(
+      expect.arrayContaining([
+        "actor_list",
+        "actor_create",
+        "actor_rename",
+        "actor_archive",
+        "actor_unarchive",
+      ])
+    );
+  });
+});
+
+describe("actor tools", () => {
+  it("lists actors", async () => {
+    const actorService = { listActors: vi.fn().mockResolvedValue([createActor()]) } as unknown as ActorService;
+    const tool = createActorListToolDefinition({
+      getActorService: vi.fn().mockResolvedValue(actorService),
+    });
+
+    const result = await tool.execute("tool-call-1", {});
+
+    expect(result.content[0]?.text).toContain("Actors (1):");
+    expect(result.content[0]?.text).toContain("actor-user • Erik • active");
+  });
+
+  it("creates, renames, archives, and unarchives actors", async () => {
+    const actorService = {
+      createActor: vi.fn().mockResolvedValue(createActor()),
+      renameActor: vi.fn().mockResolvedValue(createActor({ displayName: "Updated Erik" })),
+      archiveActor: vi.fn().mockResolvedValue(createActor({ archived: true })),
+      unarchiveActor: vi.fn().mockResolvedValue(createActor()),
+    } as unknown as ActorService;
+
+    const createTool = createActorCreateToolDefinition({
+      getActorService: vi.fn().mockResolvedValue(actorService),
+    });
+    const renameTool = createActorRenameToolDefinition({
+      getActorService: vi.fn().mockResolvedValue(actorService),
+    });
+    const archiveTool = createActorArchiveToolDefinition({
+      getActorService: vi.fn().mockResolvedValue(actorService),
+    });
+    const unarchiveTool = createActorUnarchiveToolDefinition({
+      getActorService: vi.fn().mockResolvedValue(actorService),
+    });
+
+    await expect(
+      createTool.execute("tool-call-1", { id: " actor-user ", displayName: " Erik " })
+    ).resolves.toMatchObject({ content: [{ text: expect.stringContaining("Created actor actor-user") }] });
+    await expect(
+      renameTool.execute("tool-call-2", { actorId: " actor-user ", displayName: " Updated Erik " })
+    ).resolves.toMatchObject({ content: [{ text: expect.stringContaining("Renamed actor actor-user") }] });
+    await expect(archiveTool.execute("tool-call-3", { actorId: " actor-user " })).resolves.toMatchObject({
+      content: [{ text: expect.stringContaining("Archived actor actor-user") }],
+    });
+    await expect(unarchiveTool.execute("tool-call-4", { actorId: " actor-user " })).resolves.toMatchObject({
+      content: [{ text: expect.stringContaining("Unarchived actor actor-user") }],
+    });
+  });
+});

--- a/src/__tests__/daemon-client.test.ts
+++ b/src/__tests__/daemon-client.test.ts
@@ -484,6 +484,7 @@ describe("createToduDaemonClient", () => {
       status: "active",
       priority: "high",
       description: "Created from tests",
+      authorizedAssigneeActorIds: [],
     });
     expect(connection.request).toHaveBeenCalledWith("project.create", {
       input: {
@@ -530,6 +531,7 @@ describe("createToduDaemonClient", () => {
       status: "cancelled",
       priority: "low",
       description: "Updated from tests",
+      authorizedAssigneeActorIds: [],
     });
     expect(connection.request).toHaveBeenCalledWith("project.update", {
       id: "proj-1",

--- a/src/__tests__/project-integration-service.test.ts
+++ b/src/__tests__/project-integration-service.test.ts
@@ -19,6 +19,7 @@ const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectS
   status: "active",
   priority: "medium",
   description: "Primary project",
+  authorizedAssigneeActorIds: [],
   ...overrides,
 });
 

--- a/src/__tests__/project-integration-tools.test.ts
+++ b/src/__tests__/project-integration-tools.test.ts
@@ -21,6 +21,7 @@ const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectS
   status: "active",
   priority: "medium",
   description: "Primary project",
+  authorizedAssigneeActorIds: [],
   ...overrides,
 });
 

--- a/src/__tests__/project-mutation-tools.test.ts
+++ b/src/__tests__/project-mutation-tools.test.ts
@@ -12,6 +12,7 @@ import {
   normalizeCreateProjectInput,
   normalizeUpdateProjectInput,
 } from "@/tools/project-mutation-tools";
+import type { ActorService } from "@/services/actor-service";
 
 const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectSummary => ({
   id: "proj-1",
@@ -19,6 +20,7 @@ const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectS
   status: "active",
   priority: "medium",
   description: "Primary project",
+  authorizedAssigneeActorIds: [],
   ...overrides,
 });
 
@@ -63,7 +65,7 @@ describe("normalizeCreateProjectInput", () => {
 describe("normalizeUpdateProjectInput", () => {
   it("requires at least one supported mutation field", () => {
     expect(() => normalizeUpdateProjectInput({ projectId: "proj-1" })).toThrow(
-      "project_update requires at least one supported field: name, description, status, or priority"
+      "project_update requires at least one supported field: name, description, status, priority, or authorizedAssigneeActorIds"
     );
   });
 
@@ -142,6 +144,58 @@ describe("createProjectCreateToolDefinition", () => {
 });
 
 describe("createProjectUpdateToolDefinition", () => {
+  it("supports incremental authorized-actor updates", async () => {
+    const projectService = {
+      getProject: vi
+        .fn()
+        .mockResolvedValue(createProjectSummary({ authorizedAssigneeActorIds: ["actor-user"] })),
+      updateProject: vi.fn().mockResolvedValue(
+        createProjectSummary({ authorizedAssigneeActorIds: ["actor-user", "actor-reviewer"] })
+      ),
+    } as unknown as ProjectService;
+    const actorService = {
+      listActors: vi.fn().mockResolvedValue([
+        { id: "actor-user", displayName: "Erik", archived: false },
+        { id: "actor-reviewer", displayName: "Reviewer", archived: false },
+      ]),
+    } as unknown as ActorService;
+    const tool = createProjectUpdateToolDefinition({
+      getProjectService: vi.fn().mockResolvedValue(projectService),
+      getActorService: vi.fn().mockResolvedValue(actorService),
+    });
+
+    await tool.execute("tool-call-1", {
+      projectId: "proj-1",
+      addAuthorizedAssigneeActorIds: ["actor-reviewer"],
+    });
+
+    expect(projectService.updateProject).toHaveBeenCalledWith({
+      projectId: "proj-1",
+      status: undefined,
+      priority: undefined,
+      authorizedAssigneeActorIds: ["actor-user", "actor-reviewer"],
+    });
+  });
+
+  it("fails when authorizing an unknown actor", async () => {
+    const projectService = {
+      updateProject: vi.fn(),
+    } as unknown as ProjectService;
+    const actorService = {
+      listActors: vi.fn().mockResolvedValue([{ id: "actor-user", displayName: "Erik", archived: false }]),
+    } as unknown as ActorService;
+    const tool = createProjectUpdateToolDefinition({
+      getProjectService: vi.fn().mockResolvedValue(projectService),
+      getActorService: vi.fn().mockResolvedValue(actorService),
+    });
+
+    await expect(
+      tool.execute("tool-call-1", {
+        projectId: "proj-1",
+        authorizedAssigneeActorIds: ["actor-missing"],
+      })
+    ).rejects.toThrow("project_update failed: actor not found: actor-missing");
+  });
   it("updates supported fields and returns structured details", async () => {
     const project = createProjectSummary({
       name: "Updated Project",
@@ -194,7 +248,7 @@ describe("createProjectUpdateToolDefinition", () => {
     });
 
     await expect(tool.execute("tool-call-1", { projectId: "proj-1" })).rejects.toThrow(
-      "project_update failed: project_update requires at least one supported field: name, description, status, or priority"
+      "project_update failed: project_update requires at least one supported field: name, description, status, priority, or authorizedAssigneeActorIds"
     );
   });
 

--- a/src/__tests__/project-read-tools.test.ts
+++ b/src/__tests__/project-read-tools.test.ts
@@ -18,6 +18,7 @@ const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectS
   status: "active",
   priority: "medium",
   description: "Primary project",
+  authorizedAssigneeActorIds: [],
   ...overrides,
 });
 
@@ -67,6 +68,31 @@ describe("formatProjectShowContent", () => {
     expect(formatProjectShowContent(createProjectSummary())).toContain(
       "Project proj-1: Todu Pi Extensions"
     );
+  });
+
+  it("shows authorized actors and stale unauthorized assignees", () => {
+    const content = formatProjectShowContent(
+      createProjectSummary({ authorizedAssigneeActorIds: ["actor-user"] }),
+      [{ id: "actor-user", displayName: "Erik", archived: false }],
+      [
+        {
+          id: "task-1",
+          title: "Follow up",
+          status: "active",
+          priority: "medium",
+          projectId: "proj-1",
+          projectName: "Todu Pi Extensions",
+          labels: [],
+          assigneeActorIds: ["actor-user", "actor-reviewer"],
+          assigneeDisplayNames: ["Erik", "Reviewer (unauthorized)"],
+          assignees: ["Erik", "Reviewer"],
+        },
+      ]
+    );
+
+    expect(content).toContain("Authorized assignees: Erik");
+    expect(content).toContain("Stale unauthorized assignees:");
+    expect(content).toContain("task-1 • Follow up • Erik, Reviewer (unauthorized)");
   });
 });
 

--- a/src/__tests__/project-service.test.ts
+++ b/src/__tests__/project-service.test.ts
@@ -18,6 +18,7 @@ const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectS
   status: "active",
   priority: "medium",
   description: "Primary project",
+  authorizedAssigneeActorIds: [],
   ...overrides,
 });
 

--- a/src/__tests__/recurring-mutation-tools.test.ts
+++ b/src/__tests__/recurring-mutation-tools.test.ts
@@ -23,6 +23,7 @@ const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectS
   status: "active",
   priority: "medium",
   description: "Primary project",
+  authorizedAssigneeActorIds: [],
   ...overrides,
 });
 

--- a/src/__tests__/recurring-service.test.ts
+++ b/src/__tests__/recurring-service.test.ts
@@ -56,6 +56,7 @@ describe("createToduRecurringService", () => {
       getProject: vi.fn().mockResolvedValue({
         id: "proj-1",
         name: "Todu Pi Extensions",
+        authorizedAssigneeActorIds: [],
         status: "active",
         priority: "medium",
         description: null,

--- a/src/__tests__/task-mutation-tools.test.ts
+++ b/src/__tests__/task-mutation-tools.test.ts
@@ -51,6 +51,7 @@ const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectS
   status: "active",
   priority: "medium",
   description: "Primary project",
+  authorizedAssigneeActorIds: [],
   ...overrides,
 });
 
@@ -398,6 +399,71 @@ describe("createTaskCreateToolDefinition", () => {
 });
 
 describe("createTaskUpdateToolDefinition", () => {
+  it("rejects adding unauthorized or archived actors for new assignment", async () => {
+    const taskService = {
+      getTask: vi.fn().mockResolvedValue(createTaskDetail({ assigneeActorIds: ["actor-user"] })),
+      updateTask: vi.fn(),
+    } as unknown as TaskService;
+    const actorService = {
+      listActors: vi.fn().mockResolvedValue([
+        { id: "actor-user", displayName: "Erik", archived: false },
+        { id: "actor-archived", displayName: "Archived", archived: true },
+      ]),
+    } as never;
+    const projectService = {
+      getProject: vi.fn().mockResolvedValue(
+        createProjectSummary({ authorizedAssigneeActorIds: ["actor-user"] })
+      ),
+    } as never;
+    const tool = createTaskUpdateToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+      getActorService: vi.fn().mockResolvedValue(actorService),
+      getProjectService: vi.fn().mockResolvedValue(projectService),
+    });
+
+    await expect(
+      tool.execute("tool-call-1", {
+        taskId: "task-123",
+        addAssigneeActorIds: ["actor-archived"],
+      })
+    ).rejects.toThrow(
+      "task_update failed: actor is archived and unavailable for new assignment: actor-archived"
+    );
+  });
+
+  it("preserves existing stale unauthorized assignees during non-additive updates", async () => {
+    const task = createTaskDetail({ assigneeActorIds: ["actor-user", "actor-stale"] });
+    const taskService = {
+      getTask: vi.fn().mockResolvedValue(task),
+      updateTask: vi.fn().mockResolvedValue({ ...task, title: "Updated title" }),
+    } as unknown as TaskService;
+    const actorService = {
+      listActors: vi.fn().mockResolvedValue([
+        { id: "actor-user", displayName: "Erik", archived: false },
+        { id: "actor-stale", displayName: "Stale", archived: false },
+      ]),
+    } as never;
+    const projectService = {
+      getProject: vi.fn().mockResolvedValue(
+        createProjectSummary({ authorizedAssigneeActorIds: ["actor-user"] })
+      ),
+    } as never;
+    const tool = createTaskUpdateToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+      getActorService: vi.fn().mockResolvedValue(actorService),
+      getProjectService: vi.fn().mockResolvedValue(projectService),
+    });
+
+    await tool.execute("tool-call-1", {
+      taskId: "task-123",
+      title: "Updated title",
+      assigneeActorIds: ["actor-user", "actor-stale"],
+    });
+
+    expect(taskService.updateTask).toHaveBeenCalledWith(
+      expect.objectContaining({ assigneeActorIds: ["actor-user", "actor-stale"] })
+    );
+  });
   it("updates supported fields and returns structured details", async () => {
     const task = createTaskDetail({
       title: "Updated task title",

--- a/src/__tests__/tasks-command.test.ts
+++ b/src/__tests__/tasks-command.test.ts
@@ -44,6 +44,7 @@ const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectS
   status: "active",
   priority: "medium",
   description: "Primary project",
+  authorizedAssigneeActorIds: [],
   ...overrides,
 });
 

--- a/src/__tests__/todu-task-service.test.ts
+++ b/src/__tests__/todu-task-service.test.ts
@@ -26,6 +26,7 @@ describe("createToduTaskService", () => {
       status: "active",
       priority: "high",
       description: null,
+      authorizedAssigneeActorIds: ["actor-user"],
     };
     const filter: TaskFilter = { statuses: ["active"] };
     const client = {
@@ -60,6 +61,10 @@ describe("createToduTaskService", () => {
       listNotes: vi.fn().mockResolvedValue([]),
       getNote: vi.fn().mockResolvedValue(null),
       listActors: vi.fn().mockResolvedValue([]),
+      createActor: vi.fn(),
+      renameActor: vi.fn(),
+      archiveActor: vi.fn(),
+      unarchiveActor: vi.fn(),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -95,6 +100,7 @@ describe("createToduTaskService", () => {
       status: "active",
       priority: "high",
       description: null,
+      authorizedAssigneeActorIds: ["actor-user"],
     };
     const client = {
       listTasks: vi.fn(),
@@ -128,6 +134,10 @@ describe("createToduTaskService", () => {
       listNotes: vi.fn().mockResolvedValue([]),
       getNote: vi.fn().mockResolvedValue(null),
       listActors: vi.fn().mockResolvedValue([]),
+      createActor: vi.fn(),
+      renameActor: vi.fn(),
+      archiveActor: vi.fn(),
+      unarchiveActor: vi.fn(),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -197,6 +207,10 @@ describe("createToduTaskService", () => {
       listNotes: vi.fn().mockResolvedValue([]),
       getNote: vi.fn().mockResolvedValue(null),
       listActors: vi.fn().mockResolvedValue([]),
+      createActor: vi.fn(),
+      renameActor: vi.fn(),
+      archiveActor: vi.fn(),
+      unarchiveActor: vi.fn(),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -230,6 +244,7 @@ describe("createToduTaskService", () => {
       status: "active",
       priority: "high",
       description: null,
+      authorizedAssigneeActorIds: ["actor-user"],
     };
     const client = {
       listTasks: vi.fn().mockResolvedValue([taskSummary]),
@@ -273,6 +288,10 @@ describe("createToduTaskService", () => {
       listNotes: vi.fn().mockResolvedValue([]),
       getNote: vi.fn().mockResolvedValue(null),
       listActors: vi.fn().mockResolvedValue([]),
+      createActor: vi.fn(),
+      renameActor: vi.fn(),
+      archiveActor: vi.fn(),
+      unarchiveActor: vi.fn(),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -317,6 +336,7 @@ describe("createToduTaskService", () => {
       status: "active",
       priority: "high",
       description: null,
+      authorizedAssigneeActorIds: ["actor-user"],
     };
     const client = {
       listTasks: vi.fn(),
@@ -360,6 +380,10 @@ describe("createToduTaskService", () => {
       listNotes: vi.fn().mockResolvedValue([]),
       getNote: vi.fn().mockResolvedValue(null),
       listActors: vi.fn().mockResolvedValue([]),
+      createActor: vi.fn(),
+      renameActor: vi.fn(),
+      archiveActor: vi.fn(),
+      unarchiveActor: vi.fn(),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });

--- a/src/domain/task.ts
+++ b/src/domain/task.ts
@@ -13,6 +13,7 @@ export interface ProjectSummary {
   status: "active" | "done" | "cancelled";
   priority: TaskPriority;
   description: string | null;
+  authorizedAssigneeActorIds: ActorId[];
 }
 
 export interface TaskComment {

--- a/src/extension/register-tools.ts
+++ b/src/extension/register-tools.ts
@@ -58,7 +58,7 @@ const registerTools = (pi: ExtensionAPI, dependencies: RegisterToolDependencies 
   registerActorReadTools(pi, { getActorService });
   registerProjectReadTools(pi, { getProjectService, getActorService, getTaskService });
   registerProjectIntegrationTools(pi, { getProjectIntegrationService, getProjectService });
-  registerProjectMutationTools(pi, { getProjectService });
+  registerProjectMutationTools(pi, { getProjectService, getActorService });
   registerRecurringReadTools(pi, { getRecurringService });
   registerRecurringMutationTools(pi, { getRecurringService, getProjectService });
   registerHabitReadTools(pi, { getHabitService });

--- a/src/extension/register-tools.ts
+++ b/src/extension/register-tools.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
+import type { ActorService } from "../services/actor-service";
 import type { HabitService } from "../services/habit-service";
 import type { NoteService } from "../services/note-service";
 import type { ProjectIntegrationService } from "../services/project-integration-service";
@@ -10,6 +11,8 @@ import {
 import type { RecurringService } from "../services/recurring-service";
 import type { TaskService } from "../services/task-service";
 import { getDefaultToduTaskServiceRuntime } from "../services/todu/default-task-service";
+import { registerActorMutationTools } from "../tools/actor-mutation-tools";
+import { registerActorReadTools } from "../tools/actor-read-tools";
 import { registerHabitMutationTools } from "../tools/habit-mutation-tools";
 import { registerHabitReadTools } from "../tools/habit-read-tools";
 import { registerNoteReadTools } from "../tools/note-read-tools";
@@ -23,6 +26,7 @@ import { registerTaskReadTools } from "../tools/task-read-tools";
 
 export interface RegisterToolDependencies {
   getTaskService?: () => Promise<TaskService>;
+  getActorService?: () => Promise<ActorService>;
   getProjectService?: () => Promise<ProjectService>;
   getRecurringService?: () => Promise<RecurringService>;
   getHabitService?: () => Promise<HabitService>;
@@ -33,6 +37,8 @@ export interface RegisterToolDependencies {
 const registerTools = (pi: ExtensionAPI, dependencies: RegisterToolDependencies = {}): void => {
   const runtime = getDefaultToduTaskServiceRuntime();
   const getTaskService = dependencies.getTaskService ?? (() => runtime.ensureConnected());
+  const getActorService =
+    dependencies.getActorService ?? (() => runtime.ensureActorServiceConnected());
   const getProjectService =
     dependencies.getProjectService ??
     (dependencies.getTaskService
@@ -49,7 +55,8 @@ const registerTools = (pi: ExtensionAPI, dependencies: RegisterToolDependencies 
     (() => runtime.ensureProjectIntegrationServiceConnected());
 
   registerTaskReadTools(pi, { getTaskService });
-  registerProjectReadTools(pi, { getProjectService });
+  registerActorReadTools(pi, { getActorService });
+  registerProjectReadTools(pi, { getProjectService, getActorService, getTaskService });
   registerProjectIntegrationTools(pi, { getProjectIntegrationService, getProjectService });
   registerProjectMutationTools(pi, { getProjectService });
   registerRecurringReadTools(pi, { getRecurringService });
@@ -57,7 +64,8 @@ const registerTools = (pi: ExtensionAPI, dependencies: RegisterToolDependencies 
   registerHabitReadTools(pi, { getHabitService });
   registerHabitMutationTools(pi, { getHabitService, getProjectService });
   registerNoteReadTools(pi, { getNoteService });
-  registerTaskMutationTools(pi, { getTaskService });
+  registerActorMutationTools(pi, { getActorService });
+  registerTaskMutationTools(pi, { getTaskService, getActorService, getProjectService });
 };
 
 export { registerTools };

--- a/src/services/actor-service.ts
+++ b/src/services/actor-service.ts
@@ -1,0 +1,19 @@
+import type { ActorSummary } from "../domain/actor";
+
+export interface CreateActorInput {
+  id: string;
+  displayName: string;
+}
+
+export interface RenameActorInput {
+  actorId: string;
+  displayName: string;
+}
+
+export interface ActorService {
+  listActors(): Promise<ActorSummary[]>;
+  createActor(input: CreateActorInput): Promise<ActorSummary>;
+  renameActor(input: RenameActorInput): Promise<ActorSummary>;
+  archiveActor(actorId: string): Promise<ActorSummary>;
+  unarchiveActor(actorId: string): Promise<ActorSummary>;
+}

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -5,6 +5,7 @@ export interface CreateProjectInput {
   name: string;
   description?: string | null;
   priority?: TaskPriority;
+  authorizedAssigneeActorIds?: string[];
 }
 
 export interface UpdateProjectInput {
@@ -13,6 +14,7 @@ export interface UpdateProjectInput {
   description?: string | null;
   status?: ProjectSummary["status"];
   priority?: TaskPriority;
+  authorizedAssigneeActorIds?: string[];
 }
 
 export interface DeleteProjectResult {

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -111,12 +111,17 @@ export interface ToduProjectSummary {
   status: "active" | "done" | "cancelled";
   priority: TaskPriority;
   description: string | null;
+  authorizedAssigneeActorIds: string[];
 }
 
 export interface ToduDaemonClient {
   listTasks(filter?: TaskFilter): Promise<TaskSummary[]>;
   getTask(taskId: TaskId): Promise<TaskDetail | null>;
   listActors(): Promise<ActorSummary[]>;
+  createActor(input: { id: string; displayName: string }): Promise<ActorSummary>;
+  renameActor(input: { actorId: string; displayName: string }): Promise<ActorSummary>;
+  archiveActor(actorId: string): Promise<ActorSummary>;
+  unarchiveActor(actorId: string): Promise<ActorSummary>;
   createTask(input: CreateTaskInput): Promise<TaskDetail>;
   updateTask(input: UpdateTaskInput): Promise<TaskDetail>;
   addTaskComment(input: AddTaskCommentInput): Promise<TaskComment>;
@@ -161,6 +166,7 @@ type ToduActorLike = {
   archived?: boolean;
 };
 
+type ToduProjectWithActorFields = ToduProject & { authorizedAssigneeActorIds?: string[] };
 type ToduTaskWithActorFields = ToduTask & { assigneeActorIds?: string[] };
 type ToduTaskWithDetailWithActorFields = ToduTaskWithDetail & { assigneeActorIds?: string[] };
 type ToduNoteWithActorFields = ToduNote & { authorActorId?: string };
@@ -277,8 +283,47 @@ const createToduDaemonClient = ({
     return listActors(connection);
   },
 
+  async createActor(input: { id: string; displayName: string }): Promise<ActorSummary> {
+    const result = await connection.request<ToduActorLike>("actor.create", { input });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("actor.create", result.error);
+    }
+
+    return mapActorSummary(result.value);
+  },
+
+  async renameActor(input: { actorId: string; displayName: string }): Promise<ActorSummary> {
+    const result = await connection.request<ToduActorLike>("actor.rename", {
+      id: input.actorId,
+      displayName: input.displayName,
+    });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("actor.rename", result.error);
+    }
+
+    return mapActorSummary(result.value);
+  },
+
+  async archiveActor(actorId: string): Promise<ActorSummary> {
+    const result = await connection.request<ToduActorLike>("actor.archive", { id: actorId });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("actor.archive", result.error);
+    }
+
+    return mapActorSummary(result.value);
+  },
+
+  async unarchiveActor(actorId: string): Promise<ActorSummary> {
+    const result = await connection.request<ToduActorLike>("actor.unarchive", { id: actorId });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("actor.unarchive", result.error);
+    }
+
+    return mapActorSummary(result.value);
+  },
+
   async listProjects(): Promise<ToduProjectSummary[]> {
-    const result = await connection.request<ToduProject[]>("project.list", {});
+    const result = await connection.request<ToduProjectWithActorFields[]>("project.list", {});
     if (!result.ok) {
       throw mapDaemonErrorToClientError("project.list", result.error);
     }
@@ -287,7 +332,7 @@ const createToduDaemonClient = ({
   },
 
   async getProject(projectId: string): Promise<ToduProjectSummary | null> {
-    const result = await connection.request<ToduProject>("project.get", { id: projectId });
+    const result = await connection.request<ToduProjectWithActorFields>("project.get", { id: projectId });
     if (!result.ok) {
       if (result.error.code === "NOT_FOUND") {
         return null;
@@ -300,7 +345,7 @@ const createToduDaemonClient = ({
   },
 
   async createProject(input: CreateProjectInput): Promise<ToduProjectSummary> {
-    const result = await connection.request<ToduProject>("project.create", {
+    const result = await connection.request<ToduProjectWithActorFields>("project.create", {
       input: mapCreateProjectInput(input),
     });
     if (!result.ok) {
@@ -311,7 +356,7 @@ const createToduDaemonClient = ({
   },
 
   async updateProject(input: UpdateLocalProjectInput): Promise<ToduProjectSummary> {
-    const result = await connection.request<ToduProject>("project.update", {
+    const result = await connection.request<ToduProjectWithActorFields>("project.update", {
       id: input.projectId,
       input: mapUpdateProjectInput(input),
     });
@@ -643,6 +688,12 @@ const getTaskSortValue = (task: ToduTask, field: string): string | number => {
   }
 };
 
+const mapActorSummary = (actor: ToduActorLike): ActorSummary => ({
+  id: actor.id,
+  displayName: actor.displayName,
+  archived: actor.archived ?? false,
+});
+
 const listActors = async (
   connection: Pick<ToduDaemonConnection, "request">
 ): Promise<ActorSummary[]> => {
@@ -651,11 +702,7 @@ const listActors = async (
     throw mapDaemonErrorToClientError("actor.list", result.error);
   }
 
-  return result.value.map((actor) => ({
-    id: actor.id,
-    displayName: actor.displayName,
-    archived: actor.archived ?? false,
-  }));
+  return result.value.map(mapActorSummary);
 };
 
 const listActorsBestEffort = async (
@@ -798,12 +845,13 @@ const mapNoteFilter = (filter: NoteFilter): ToduNoteFilterWithActorFields => ({
   timezone: filter.timezone,
 });
 
-const mapProjectSummary = (project: ToduProject): ToduProjectSummary => ({
+const mapProjectSummary = (project: ToduProjectWithActorFields): ToduProjectSummary => ({
   id: project.id,
   name: project.name,
   status: toLocalProjectStatus(project.status),
   priority: toLocalTaskPriority(project.priority),
   description: project.description ?? null,
+  authorizedAssigneeActorIds: [...(project.authorizedAssigneeActorIds ?? [])],
 });
 
 const mapIntegrationBinding = (binding: ToduIntegrationBinding): IntegrationBinding => ({
@@ -906,18 +954,6 @@ const mapHabitFilter = (filter: HabitFilter): ToduHabitFilter => ({
   search: filter.query,
 });
 
-const mapCreateProjectInput = (input: CreateProjectInput): Record<string, unknown> => ({
-  name: input.name,
-  description: input.description ?? undefined,
-  priority: input.priority ?? undefined,
-});
-
-const mapUpdateProjectInput = (input: UpdateLocalProjectInput): Record<string, unknown> => ({
-  name: input.name ?? undefined,
-  description: input.description ?? undefined,
-  status: input.status ? toRemoteProjectStatus(input.status) : undefined,
-  priority: input.priority ?? undefined,
-});
 
 const mapCreateRecurringInput = (input: CreateRecurringInput): Record<string, unknown> => ({
   title: input.title,
@@ -1000,6 +1036,22 @@ const mapCreateTaskInput = (input: CreateTaskInput): Record<string, unknown> => 
   description: input.description ?? undefined,
   projectId: input.projectId ?? undefined,
   labels: input.labels,
+});
+
+const mapCreateProjectInput = (input: CreateProjectInput): Record<string, unknown> => ({
+  name: input.name,
+  description: input.description ?? undefined,
+  priority: input.priority ? toRemoteTaskPriority(input.priority) : undefined,
+  authorizedAssigneeActorIds: (input as CreateProjectInput & { authorizedAssigneeActorIds?: string[] })
+    .authorizedAssigneeActorIds,
+});
+
+const mapUpdateProjectInput = (input: UpdateLocalProjectInput): Record<string, unknown> => ({
+  name: input.name ?? undefined,
+  description: input.description ?? undefined,
+  status: input.status ? toRemoteProjectStatus(input.status) : undefined,
+  priority: input.priority ? toRemoteTaskPriority(input.priority) : undefined,
+  authorizedAssigneeActorIds: input.authorizedAssigneeActorIds,
 });
 
 const mapUpdateTaskInput = (input: UpdateTaskInput): Record<string, unknown> => ({

--- a/src/services/todu/default-task-service.ts
+++ b/src/services/todu/default-task-service.ts
@@ -1,3 +1,4 @@
+import type { ActorService } from "../actor-service";
 import type { HabitService } from "../habit-service";
 import type { NoteService } from "../note-service";
 import type { ProjectIntegrationService } from "../project-integration-service";
@@ -11,6 +12,7 @@ import {
   type CreateToduDaemonConnectionOptions,
   type ToduDaemonConnection,
 } from "./daemon-connection";
+import { createToduActorService } from "./todu-actor-service";
 import { createToduProjectIntegrationService } from "./todu-project-integration-service";
 import { createToduProjectService } from "./todu-project-service";
 import { createToduHabitService } from "./todu-habit-service";
@@ -24,12 +26,14 @@ export interface ToduTaskServiceRuntime {
   connection: ToduDaemonConnection;
   client: ToduDaemonClient;
   taskService: TaskService;
+  actorService: ActorService;
   projectService: ProjectService;
   recurringService: RecurringService;
   habitService: HabitService;
   noteService: NoteService;
   projectIntegrationService: ProjectIntegrationService;
   ensureConnected(): Promise<TaskService>;
+  ensureActorServiceConnected(): Promise<ActorService>;
   ensureProjectServiceConnected(): Promise<ProjectService>;
   ensureRecurringServiceConnected(): Promise<RecurringService>;
   ensureHabitServiceConnected(): Promise<HabitService>;
@@ -48,6 +52,7 @@ const createToduTaskServiceRuntime = (
   const connection = createToduDaemonConnection(options);
   const client = createToduDaemonClient({ connection });
   const taskService = createToduTaskService({ client });
+  const actorService = createToduActorService({ client });
   const projectService = createToduProjectService({ client });
   const recurringService = createToduRecurringService({ client });
   const habitService = createToduHabitService({ client });
@@ -66,6 +71,7 @@ const createToduTaskServiceRuntime = (
     connection,
     client,
     taskService,
+    actorService,
     projectService,
     recurringService,
     habitService,
@@ -77,6 +83,13 @@ const createToduTaskServiceRuntime = (
       }
 
       return taskService;
+    },
+    ensureActorServiceConnected: async () => {
+      if (connection.getState().status !== "connected") {
+        await connectWithinTimeout(connection, initialConnectTimeoutMs);
+      }
+
+      return actorService;
     },
     ensureProjectServiceConnected: async () => {
       if (connection.getState().status !== "connected") {

--- a/src/services/todu/todu-actor-service.ts
+++ b/src/services/todu/todu-actor-service.ts
@@ -1,0 +1,59 @@
+import type { ActorService } from "../actor-service";
+import { ToduDaemonClientError, type ToduDaemonClient } from "./daemon-client";
+
+export class ToduActorServiceError extends Error {
+  readonly operation: string;
+  readonly causeCode: string;
+  readonly details?: Record<string, unknown>;
+
+  constructor(options: {
+    operation: string;
+    causeCode: string;
+    message: string;
+    details?: Record<string, unknown>;
+    cause?: unknown;
+  }) {
+    super(options.message, options.cause ? { cause: options.cause } : undefined);
+    this.name = "ToduActorServiceError";
+    this.operation = options.operation;
+    this.causeCode = options.causeCode;
+    this.details = options.details;
+  }
+}
+
+export interface ToduActorServiceDependencies {
+  client: ToduDaemonClient;
+}
+
+const createToduActorService = ({ client }: ToduActorServiceDependencies): ActorService => ({
+  listActors: () => runActorServiceOperation("listActors", () => client.listActors()),
+  createActor: (input) => runActorServiceOperation("createActor", () => client.createActor(input)),
+  renameActor: (input) => runActorServiceOperation("renameActor", () => client.renameActor(input)),
+  archiveActor: (actorId) =>
+    runActorServiceOperation("archiveActor", () => client.archiveActor(actorId)),
+  unarchiveActor: (actorId) =>
+    runActorServiceOperation("unarchiveActor", () => client.unarchiveActor(actorId)),
+});
+
+const runActorServiceOperation = async <TResult>(
+  operation: string,
+  action: () => Promise<TResult>
+): Promise<TResult> => {
+  try {
+    return await action();
+  } catch (error) {
+    if (error instanceof ToduDaemonClientError) {
+      throw new ToduActorServiceError({
+        operation,
+        causeCode: error.code,
+        message: `${operation} failed: ${error.message}`,
+        details: error.details,
+        cause: error,
+      });
+    }
+
+    throw error;
+  }
+};
+
+export { createToduActorService, runActorServiceOperation };

--- a/src/services/todu/todu-task-service.ts
+++ b/src/services/todu/todu-task-service.ts
@@ -68,31 +68,80 @@ const listTasksWithProjectNames = async (
   client: ToduDaemonClient,
   filter?: TaskFilter
 ): Promise<TaskSummary[]> => {
-  const [tasks, projects] = await Promise.all([client.listTasks(filter), client.listProjects()]);
-  const projectNames = new Map(projects.map((project) => [project.id, project.name]));
+  const [tasks, projects, actors] = await Promise.all([
+    client.listTasks(filter),
+    client.listProjects(),
+    listActorsBestEffort(client),
+  ]);
+  const projectMap = new Map(projects.map((project) => [project.id, project]));
+  const actorMap = new Map(actors.map((actor) => [actor.id, actor]));
 
-  return tasks.map((task) => ({
-    ...task,
-    projectName: task.projectId ? (projectNames.get(task.projectId) ?? null) : null,
-  }));
+  return tasks.map((task) => hydrateTaskSummaryMetadata(task, projectMap.get(task.projectId ?? "") ?? null, actorMap));
 };
 
 const hydrateTaskDetailProjectName = async (
   client: ToduDaemonClient,
   task: TaskDetail
 ): Promise<TaskDetail> => {
-  if (!task.projectId) {
-    return {
-      ...task,
-      projectName: null,
-    };
-  }
+  const [project, actors] = await Promise.all([
+    task.projectId ? client.getProject(task.projectId) : Promise.resolve(null),
+    listActorsBestEffort(client),
+  ]);
 
-  const project = await client.getProject(task.projectId);
-  return {
-    ...task,
-    projectName: project?.name ?? null,
-  };
+  return hydrateTaskDetailMetadata(
+    task,
+    project,
+    new Map(actors.map((actor) => [actor.id, actor]))
+  );
+};
+
+const listActorsBestEffort = async (client: ToduDaemonClient) => {
+  try {
+    return await client.listActors();
+  } catch {
+    return [];
+  }
+};
+
+const hydrateTaskSummaryMetadata = (
+  task: TaskSummary,
+  project: { name: string; authorizedAssigneeActorIds: string[] } | null,
+  actorMap: Map<string, { displayName: string; archived: boolean }>
+): TaskSummary => ({
+  ...task,
+  projectName: project?.name ?? null,
+  assigneeDisplayNames: annotateAssigneeDisplayNames(task, project, actorMap),
+});
+
+const hydrateTaskDetailMetadata = (
+  task: TaskDetail,
+  project: { name: string; authorizedAssigneeActorIds: string[] } | null,
+  actorMap: Map<string, { displayName: string; archived: boolean }>
+): TaskDetail => ({
+  ...task,
+  projectName: project?.name ?? null,
+  assigneeDisplayNames: annotateAssigneeDisplayNames(task, project, actorMap),
+});
+
+const annotateAssigneeDisplayNames = (
+  task: Pick<TaskSummary, "assigneeActorIds" | "assigneeDisplayNames" | "assignees">,
+  project: { authorizedAssigneeActorIds: string[] } | null,
+  actorMap: Map<string, { displayName: string; archived: boolean }>
+): string[] => {
+  const authorizedActorIds = new Set(project?.authorizedAssigneeActorIds ?? []);
+  return task.assigneeActorIds.map((actorId, index) => {
+    const actor = actorMap.get(actorId);
+    const baseLabel = task.assigneeDisplayNames[index] ?? task.assignees[index] ?? actor?.displayName ?? actorId;
+    const suffixes: string[] = [];
+    if (actor?.archived) {
+      suffixes.push("archived");
+    }
+    if (project && !authorizedActorIds.has(actorId)) {
+      suffixes.push("unauthorized");
+    }
+
+    return suffixes.length > 0 ? `${baseLabel} (${suffixes.join(", ")})` : baseLabel;
+  });
 };
 
 const runTaskServiceOperation = async <T>(

--- a/src/tools/actor-mutation-tools.ts
+++ b/src/tools/actor-mutation-tools.ts
@@ -1,0 +1,196 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+
+import type { ActorSummary } from "../domain/actor";
+import type { ActorService, CreateActorInput, RenameActorInput } from "../services/actor-service";
+
+const ActorCreateParams = Type.Object({
+  id: Type.String({ description: "Actor ID" }),
+  displayName: Type.String({ description: "Actor display name" }),
+});
+
+const ActorRenameParams = Type.Object({
+  actorId: Type.String({ description: "Actor ID" }),
+  displayName: Type.String({ description: "Actor display name" }),
+});
+
+const ActorArchiveParams = Type.Object({
+  actorId: Type.String({ description: "Actor ID" }),
+});
+
+interface ActorCreateToolDetails {
+  kind: "actor_create";
+  input: CreateActorInput;
+  actor: ActorSummary;
+}
+
+interface ActorRenameToolDetails {
+  kind: "actor_rename";
+  input: RenameActorInput;
+  actor: ActorSummary;
+}
+
+interface ActorArchiveToolDetails {
+  kind: "actor_archive" | "actor_unarchive";
+  actorId: string;
+  actor: ActorSummary;
+}
+
+interface ActorMutationToolDependencies {
+  getActorService: () => Promise<ActorService>;
+}
+
+const createActorCreateToolDefinition = ({ getActorService }: ActorMutationToolDependencies) => ({
+  name: "actor_create",
+  label: "Actor Create",
+  description: "Create an actor.",
+  promptSnippet: "Create an actor through the native backend tool.",
+  promptGuidelines: ["Use this tool for lightweight actor management in normal chat."],
+  parameters: ActorCreateParams,
+  async execute(_toolCallId: string, params: { id: string; displayName: string }) {
+    try {
+      const input = normalizeCreateActorInput(params);
+      const actorService = await getActorService();
+      const actor = await actorService.createActor(input);
+      const details: ActorCreateToolDetails = { kind: "actor_create", input, actor };
+
+      return {
+        content: [{ type: "text" as const, text: formatActorResult("Created", actor) }],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "actor_create failed"), { cause: error });
+    }
+  },
+});
+
+const createActorRenameToolDefinition = ({ getActorService }: ActorMutationToolDependencies) => ({
+  name: "actor_rename",
+  label: "Actor Rename",
+  description: "Rename an actor.",
+  promptSnippet: "Rename an actor through the native backend tool.",
+  promptGuidelines: ["Use this tool for lightweight actor management in normal chat."],
+  parameters: ActorRenameParams,
+  async execute(_toolCallId: string, params: { actorId: string; displayName: string }) {
+    try {
+      const input = normalizeRenameActorInput(params);
+      const actorService = await getActorService();
+      const actor = await actorService.renameActor(input);
+      const details: ActorRenameToolDetails = { kind: "actor_rename", input, actor };
+
+      return {
+        content: [{ type: "text" as const, text: formatActorResult("Renamed", actor) }],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "actor_rename failed"), { cause: error });
+    }
+  },
+});
+
+const createActorArchiveToolDefinition = ({ getActorService }: ActorMutationToolDependencies) => ({
+  name: "actor_archive",
+  label: "Actor Archive",
+  description: "Archive an actor.",
+  promptSnippet: "Archive an actor through the native backend tool.",
+  promptGuidelines: ["Use this tool for lightweight actor management in normal chat."],
+  parameters: ActorArchiveParams,
+  async execute(_toolCallId: string, params: { actorId: string }) {
+    try {
+      const actorId = normalizeRequiredText(params.actorId, "actorId");
+      const actorService = await getActorService();
+      const actor = await actorService.archiveActor(actorId);
+      const details: ActorArchiveToolDetails = { kind: "actor_archive", actorId, actor };
+
+      return {
+        content: [{ type: "text" as const, text: formatActorResult("Archived", actor) }],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "actor_archive failed"), { cause: error });
+    }
+  },
+});
+
+const createActorUnarchiveToolDefinition = ({
+  getActorService,
+}: ActorMutationToolDependencies) => ({
+  name: "actor_unarchive",
+  label: "Actor Unarchive",
+  description: "Unarchive an actor.",
+  promptSnippet: "Unarchive an actor through the native backend tool.",
+  promptGuidelines: ["Use this tool for lightweight actor management in normal chat."],
+  parameters: ActorArchiveParams,
+  async execute(_toolCallId: string, params: { actorId: string }) {
+    try {
+      const actorId = normalizeRequiredText(params.actorId, "actorId");
+      const actorService = await getActorService();
+      const actor = await actorService.unarchiveActor(actorId);
+      const details: ActorArchiveToolDetails = { kind: "actor_unarchive", actorId, actor };
+
+      return {
+        content: [{ type: "text" as const, text: formatActorResult("Unarchived", actor) }],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "actor_unarchive failed"), { cause: error });
+    }
+  },
+});
+
+const registerActorMutationTools = (
+  pi: Pick<ExtensionAPI, "registerTool">,
+  dependencies: ActorMutationToolDependencies
+): void => {
+  pi.registerTool(createActorCreateToolDefinition(dependencies));
+  pi.registerTool(createActorRenameToolDefinition(dependencies));
+  pi.registerTool(createActorArchiveToolDefinition(dependencies));
+  pi.registerTool(createActorUnarchiveToolDefinition(dependencies));
+};
+
+const normalizeCreateActorInput = (params: { id: string; displayName: string }): CreateActorInput => ({
+  id: normalizeRequiredText(params.id, "id"),
+  displayName: normalizeRequiredText(params.displayName, "displayName"),
+});
+
+const normalizeRenameActorInput = (params: {
+  actorId: string;
+  displayName: string;
+}): RenameActorInput => ({
+  actorId: normalizeRequiredText(params.actorId, "actorId"),
+  displayName: normalizeRequiredText(params.displayName, "displayName"),
+});
+
+const normalizeRequiredText = (value: string, fieldName: string): string => {
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) {
+    throw new Error(`${fieldName} is required`);
+  }
+
+  return trimmedValue;
+};
+
+const formatActorResult = (verb: string, actor: ActorSummary): string =>
+  `${verb} actor ${actor.id}: ${actor.displayName} (${actor.archived ? "archived" : "active"}).`;
+
+const formatToolError = (error: unknown, prefix: string): string => {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return `${prefix}: ${error.message}`;
+  }
+
+  return prefix;
+};
+
+export type {
+  ActorArchiveToolDetails,
+  ActorCreateToolDetails,
+  ActorMutationToolDependencies,
+  ActorRenameToolDetails,
+};
+export {
+  createActorArchiveToolDefinition,
+  createActorCreateToolDefinition,
+  createActorRenameToolDefinition,
+  createActorUnarchiveToolDefinition,
+  registerActorMutationTools,
+};

--- a/src/tools/actor-read-tools.ts
+++ b/src/tools/actor-read-tools.ts
@@ -1,0 +1,78 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+
+import type { ActorSummary } from "../domain/actor";
+import type { ActorService } from "../services/actor-service";
+
+const ActorListParams = Type.Object({});
+
+interface ActorListToolDetails {
+  kind: "actor_list";
+  actors: ActorSummary[];
+  total: number;
+  empty: boolean;
+}
+
+interface ActorReadToolDependencies {
+  getActorService: () => Promise<ActorService>;
+}
+
+const createActorListToolDefinition = ({ getActorService }: ActorReadToolDependencies) => ({
+  name: "actor_list",
+  label: "Actor List",
+  description: "List actors.",
+  promptSnippet: "List actors through the native backend tool.",
+  promptGuidelines: ["Use this tool for lightweight actor-management lookups in normal chat."],
+  parameters: ActorListParams,
+  async execute(_toolCallId: string, _params: Record<string, never>) {
+    try {
+      const actorService = await getActorService();
+      const actors = await actorService.listActors();
+      const details: ActorListToolDetails = {
+        kind: "actor_list",
+        actors,
+        total: actors.length,
+        empty: actors.length === 0,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: formatActorListContent(details) }],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "actor_list failed"), { cause: error });
+    }
+  },
+});
+
+const registerActorReadTools = (
+  pi: Pick<ExtensionAPI, "registerTool">,
+  dependencies: ActorReadToolDependencies
+): void => {
+  pi.registerTool(createActorListToolDefinition(dependencies));
+};
+
+const formatActorListContent = (details: ActorListToolDetails): string => {
+  if (details.empty) {
+    return "No actors found.";
+  }
+
+  return [
+    `Actors (${details.total}):`,
+    ...details.actors.map(
+      (actor) =>
+        `- ${actor.id} • ${actor.displayName} • ${actor.archived ? "archived" : "active"}`
+    ),
+  ].join("\n");
+};
+
+const formatToolError = (error: unknown, prefix: string): string => {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return `${prefix}: ${error.message}`;
+  }
+
+  return prefix;
+};
+
+export type { ActorListToolDetails, ActorReadToolDependencies };
+export { createActorListToolDefinition, formatActorListContent, registerActorReadTools };

--- a/src/tools/project-mutation-tools.ts
+++ b/src/tools/project-mutation-tools.ts
@@ -3,6 +3,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
 import type { ProjectSummary, TaskPriority } from "../domain/task";
+import type { ActorService } from "../services/actor-service";
 import type {
   CreateProjectInput,
   DeleteProjectResult,
@@ -36,6 +37,21 @@ const ProjectUpdateParams = Type.Object({
   priority: Type.Optional(
     StringEnum(PROJECT_PRIORITY_VALUES, { description: "Optional next project priority" })
   ),
+  authorizedAssigneeActorIds: Type.Optional(
+    Type.Array(Type.String({ description: "Actor ID" }), {
+      description: "Optional full replacement authorized assignee actor ID list",
+    })
+  ),
+  addAuthorizedAssigneeActorIds: Type.Optional(
+    Type.Array(Type.String({ description: "Actor ID" }), {
+      description: "Optional actor IDs to add to the authorized assignee list",
+    })
+  ),
+  removeAuthorizedAssigneeActorIds: Type.Optional(
+    Type.Array(Type.String({ description: "Actor ID" }), {
+      description: "Optional actor IDs to remove from the authorized assignee list",
+    })
+  ),
 });
 
 const ProjectDeleteParams = Type.Object({
@@ -54,6 +70,9 @@ interface ProjectUpdateToolParams {
   description?: string;
   status?: ProjectSummary["status"];
   priority?: TaskPriority;
+  authorizedAssigneeActorIds?: string[];
+  addAuthorizedAssigneeActorIds?: string[];
+  removeAuthorizedAssigneeActorIds?: string[];
 }
 
 interface ProjectDeleteToolParams {
@@ -82,6 +101,7 @@ interface ProjectDeleteToolDetails {
 
 interface ProjectMutationToolDependencies {
   getProjectService: () => Promise<ProjectService>;
+  getActorService?: () => Promise<ActorService>;
 }
 
 const createProjectCreateToolDefinition = ({
@@ -119,6 +139,7 @@ const createProjectCreateToolDefinition = ({
 
 const createProjectUpdateToolDefinition = ({
   getProjectService,
+  getActorService,
 }: ProjectMutationToolDependencies) => ({
   name: "project_update",
   label: "Project Update",
@@ -126,14 +147,15 @@ const createProjectUpdateToolDefinition = ({
   promptSnippet: "Update a plain project record by explicit project ID.",
   promptGuidelines: [
     "Use this tool for plain project-record updates in normal chat.",
-    "Supported fields are name, description, status, and priority.",
+    "Supported fields are name, description, status, priority, and authorized assignee actor IDs.",
     "Do not use it for repo inspection or integration-binding changes.",
   ],
   parameters: ProjectUpdateParams,
   async execute(_toolCallId: string, params: ProjectUpdateToolParams) {
     try {
-      const input = normalizeUpdateProjectInput(params);
       const projectService = await getProjectService();
+      const actorService = await getActorService?.();
+      const input = await resolveUpdateProjectInput(projectService, params, actorService);
       const project = await projectService.updateProject(input);
       const details: ProjectUpdateToolDetails = {
         kind: "project_update",
@@ -231,18 +253,89 @@ const normalizeUpdateProjectInput = (params: ProjectUpdateToolParams): UpdatePro
     input.description = normalizeNullableText(params.description);
   }
 
+  if (hasOwn(params, "authorizedAssigneeActorIds")) {
+    input.authorizedAssigneeActorIds = normalizeActorIdList(
+      params.authorizedAssigneeActorIds,
+      "authorizedAssigneeActorIds"
+    );
+  }
+
   if (
     input.name === undefined &&
     input.status === undefined &&
     input.priority === undefined &&
-    !hasOwn(input, "description")
+    !hasOwn(input, "description") &&
+    !hasOwn(input, "authorizedAssigneeActorIds")
   ) {
     throw new Error(
-      "project_update requires at least one supported field: name, description, status, or priority"
+      "project_update requires at least one supported field: name, description, status, priority, or authorizedAssigneeActorIds"
     );
   }
 
   return input;
+};
+
+const resolveUpdateProjectInput = async (
+  projectService: ProjectService,
+  params: ProjectUpdateToolParams,
+  actorService?: ActorService
+): Promise<UpdateProjectInput> => {
+  if (params.authorizedAssigneeActorIds !== undefined) {
+    if (
+      params.addAuthorizedAssigneeActorIds !== undefined ||
+      params.removeAuthorizedAssigneeActorIds !== undefined
+    ) {
+      throw new Error(
+        "project_update cannot combine authorizedAssigneeActorIds with addAuthorizedAssigneeActorIds or removeAuthorizedAssigneeActorIds"
+      );
+    }
+
+    const input = normalizeUpdateProjectInput(params);
+    return validateAuthorizedActorIds(input, actorService);
+  }
+
+  const addAuthorizedActorIds = hasOwn(params, "addAuthorizedAssigneeActorIds")
+    ? normalizeActorIdList(params.addAuthorizedAssigneeActorIds, "addAuthorizedAssigneeActorIds")
+    : undefined;
+  const removeAuthorizedActorIds = hasOwn(params, "removeAuthorizedAssigneeActorIds")
+    ? normalizeActorIdList(
+        params.removeAuthorizedAssigneeActorIds,
+        "removeAuthorizedAssigneeActorIds"
+      )
+    : undefined;
+  const hasIncrementalUpdate =
+    addAuthorizedActorIds !== undefined || removeAuthorizedActorIds !== undefined;
+
+  if (!hasIncrementalUpdate) {
+    const input = normalizeUpdateProjectInput(params);
+    return validateAuthorizedActorIds(input, actorService);
+  }
+
+  const projectId = normalizeRequiredText(params.projectId, "projectId");
+  const project = await projectService.getProject(projectId);
+  if (!project) {
+    throw new Error(`project not found: ${projectId}`);
+  }
+
+  const nextAuthorizedActorIds = new Set(project.authorizedAssigneeActorIds);
+  for (const actorId of addAuthorizedActorIds ?? []) {
+    nextAuthorizedActorIds.add(actorId);
+  }
+  for (const actorId of removeAuthorizedActorIds ?? []) {
+    nextAuthorizedActorIds.delete(actorId);
+  }
+
+  return validateAuthorizedActorIds(
+    {
+      projectId,
+      name: hasOwn(params, "name") ? normalizeRequiredText(params.name ?? "", "name") : undefined,
+      description: hasOwn(params, "description") ? normalizeNullableText(params.description) : undefined,
+      status: params.status,
+      priority: params.priority,
+      authorizedAssigneeActorIds: [...nextAuthorizedActorIds],
+    },
+    actorService
+  );
 };
 
 const normalizeOptionalDescription = <TValue extends { description?: string }>(
@@ -270,6 +363,36 @@ const normalizeNullableText = (value: string | null | undefined): string | null 
   return trimmedValue.length > 0 ? trimmedValue : null;
 };
 
+const normalizeActorIdList = (values: string[] | undefined, fieldName: string): string[] => {
+  if (values === undefined) {
+    throw new Error(`${fieldName} is required`);
+  }
+
+  return [
+    ...new Set(values.map((value, index) => normalizeRequiredText(value ?? "", `${fieldName}[${index}]`))),
+  ];
+};
+
+const validateAuthorizedActorIds = async (
+  input: UpdateProjectInput,
+  actorService?: ActorService
+): Promise<UpdateProjectInput> => {
+  if (!actorService || input.authorizedAssigneeActorIds === undefined) {
+    return input;
+  }
+
+  const actors = await actorService.listActors();
+  const actorMap = new Map(actors.map((actor) => [actor.id, actor]));
+  for (const actorId of input.authorizedAssigneeActorIds) {
+    const actor = actorMap.get(actorId);
+    if (!actor) {
+      throw new Error(`actor not found: ${actorId}`);
+    }
+  }
+
+  return input;
+};
+
 const hasOwn = <TObject extends object>(value: TObject, property: keyof TObject): boolean =>
   Object.prototype.hasOwnProperty.call(value, property);
 
@@ -290,6 +413,9 @@ const formatProjectUpdateContent = (project: ProjectSummary, input: UpdateProjec
     input.priority !== undefined ? `priority=${input.priority}` : null,
     hasOwn(input, "description")
       ? `description=${input.description === null ? "cleared" : "updated"}`
+      : null,
+    hasOwn(input, "authorizedAssigneeActorIds")
+      ? `authorizedAssigneeActorIds=${JSON.stringify(input.authorizedAssigneeActorIds ?? [])}`
       : null,
   ].filter((value): value is string => value !== null);
 

--- a/src/tools/project-read-tools.ts
+++ b/src/tools/project-read-tools.ts
@@ -1,8 +1,11 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
-import type { ProjectSummary } from "../domain/task";
+import type { ActorSummary } from "../domain/actor";
+import type { ProjectSummary, TaskSummary } from "../domain/task";
+import type { ActorService } from "../services/actor-service";
 import type { ProjectService } from "../services/project-service";
+import type { TaskService } from "../services/task-service";
 
 const ProjectListParams = Type.Object({});
 const ProjectShowParams = Type.Object({
@@ -29,6 +32,8 @@ interface ProjectShowToolParams {
 
 interface ProjectReadToolDependencies {
   getProjectService: () => Promise<ProjectService>;
+  getActorService?: () => Promise<ActorService>;
+  getTaskService?: () => Promise<TaskService>;
 }
 
 const createProjectListToolDefinition = ({ getProjectService }: ProjectReadToolDependencies) => ({
@@ -62,7 +67,11 @@ const createProjectListToolDefinition = ({ getProjectService }: ProjectReadToolD
   },
 });
 
-const createProjectShowToolDefinition = ({ getProjectService }: ProjectReadToolDependencies) => ({
+const createProjectShowToolDefinition = ({
+  getProjectService,
+  getActorService,
+  getTaskService,
+}: ProjectReadToolDependencies) => ({
   name: "project_show",
   label: "Project Show",
   description: "Show project details by ID or unique name.",
@@ -99,8 +108,13 @@ const createProjectShowToolDefinition = ({ getProjectService }: ProjectReadToolD
         project,
       };
 
+      const [actors, tasks] = await Promise.all([
+        getActorService ? getActorService().then((service) => service.listActors()) : Promise.resolve([]),
+        getTaskService ? getTaskService().then((service) => service.listTasks({ projectId: project.id })) : Promise.resolve([]),
+      ]);
+
       return {
-        content: [{ type: "text" as const, text: formatProjectShowContent(project) }],
+        content: [{ type: "text" as const, text: formatProjectShowContent(project, actors, tasks) }],
         details,
       };
     } catch (error) {
@@ -153,16 +167,43 @@ const formatProjectListContent = (details: ProjectListToolDetails): string => {
   return lines.join("\n");
 };
 
-const formatProjectShowContent = (project: ProjectSummary): string =>
-  [
+const formatProjectShowContent = (
+  project: ProjectSummary,
+  actors: ActorSummary[] = [],
+  tasks: TaskSummary[] = []
+): string => {
+  const actorMap = new Map(actors.map((actor) => [actor.id, actor]));
+  const authorizedActors =
+    project.authorizedAssigneeActorIds.length > 0
+      ? project.authorizedAssigneeActorIds.map((actorId) => {
+          const actor = actorMap.get(actorId);
+          return actor ? `${actor.displayName}${actor.archived ? " (archived)" : ""}` : actorId;
+        })
+      : ["(none)"];
+  const staleUnauthorizedTasks = tasks.filter((task) =>
+    task.assigneeActorIds.some((actorId) => !project.authorizedAssigneeActorIds.includes(actorId))
+  );
+
+  const lines = [
     `Project ${project.id}: ${project.name}`,
     "",
     `Status: ${project.status}`,
     `Priority: ${project.priority}`,
+    `Authorized assignees: ${authorizedActors.join(", ")}`,
     "",
     "Description:",
     project.description?.trim().length ? project.description : "(none)",
-  ].join("\n");
+  ];
+
+  if (staleUnauthorizedTasks.length > 0) {
+    lines.push("", "Stale unauthorized assignees:");
+    for (const task of staleUnauthorizedTasks) {
+      lines.push(`- ${task.id} • ${task.title} • ${task.assigneeDisplayNames.join(", ")}`);
+    }
+  }
+
+  return lines.join("\n");
+};
 
 const formatProjectSummaryLine = (project: ProjectSummary): string =>
   `${project.id} • ${project.name} • ${project.status} • ${project.priority}`;

--- a/src/tools/task-mutation-tools.ts
+++ b/src/tools/task-mutation-tools.ts
@@ -13,6 +13,7 @@ import type {
 import { commentOnTask } from "../flows/comment-on-task";
 import { createTask } from "../flows/create-task";
 import { updateTask } from "../flows/update-task";
+import type { ActorService } from "../services/actor-service";
 import type {
   AddTaskCommentInput,
   CreateTaskInput,
@@ -21,6 +22,7 @@ import type {
   TaskService,
   UpdateTaskInput,
 } from "../services/task-service";
+import type { ProjectService } from "../services/project-service";
 import { ToduTaskServiceError } from "../services/todu/todu-task-service";
 
 const TASK_STATUS_VALUES = ["active", "inprogress", "waiting", "done", "cancelled"] as const;
@@ -144,6 +146,8 @@ interface TaskMoveToolDetails {
 
 interface TaskMutationToolDependencies {
   getTaskService: () => Promise<TaskService>;
+  getActorService?: () => Promise<ActorService>;
+  getProjectService?: () => Promise<ProjectService>;
 }
 
 const createTaskCreateToolDefinition = ({ getTaskService }: TaskMutationToolDependencies) => ({
@@ -179,7 +183,11 @@ const createTaskCreateToolDefinition = ({ getTaskService }: TaskMutationToolDepe
   },
 });
 
-const createTaskUpdateToolDefinition = ({ getTaskService }: TaskMutationToolDependencies) => ({
+const createTaskUpdateToolDefinition = ({
+  getTaskService,
+  getActorService,
+  getProjectService,
+}: TaskMutationToolDependencies) => ({
   name: "task_update",
   label: "Task Update",
   description: "Update a task's title, status, priority, description, or assignees.",
@@ -194,7 +202,12 @@ const createTaskUpdateToolDefinition = ({ getTaskService }: TaskMutationToolDepe
   async execute(_toolCallId: string, params: TaskUpdateToolParams) {
     try {
       const taskService = await getTaskService();
-      const input = await resolveUpdateTaskInput(taskService, params);
+      const actorService = await getActorService?.();
+      const projectService = await getProjectService?.();
+      const input = await resolveUpdateTaskInput(taskService, params, {
+        actorService,
+        projectService,
+      });
       const task = await updateTask({ taskService }, input);
       const details: TaskUpdateToolDetails = {
         kind: "task_update",
@@ -442,9 +455,15 @@ const normalizeUpdateTaskInput = (params: TaskUpdateToolParams): UpdateTaskInput
   return input;
 };
 
+interface ResolveUpdateTaskInputDependencies {
+  actorService?: ActorService;
+  projectService?: ProjectService;
+}
+
 const resolveUpdateTaskInput = async (
   taskService: TaskService,
-  params: TaskUpdateToolParams
+  params: TaskUpdateToolParams,
+  dependencies: ResolveUpdateTaskInputDependencies = {}
 ): Promise<UpdateTaskInput> => {
   if (params.assigneeActorIds !== undefined) {
     if (params.addAssigneeActorIds !== undefined || params.removeAssigneeActorIds !== undefined) {
@@ -453,7 +472,8 @@ const resolveUpdateTaskInput = async (
       );
     }
 
-    return normalizeUpdateTaskInput(params);
+    const input = normalizeUpdateTaskInput(params);
+    return validateNextAssigneeActorIds(taskService, input, dependencies);
   }
 
   const addAssigneeActorIds = hasOwn(params, "addAssigneeActorIds")
@@ -481,7 +501,8 @@ const resolveUpdateTaskInput = async (
   }
 
   if (!hasIncrementalAssigneeUpdate) {
-    return normalizeUpdateTaskInput(params);
+    const input = normalizeUpdateTaskInput(params);
+    return validateNextAssigneeActorIds(taskService, input, dependencies);
   }
 
   const task = await taskService.getTask(baseInput.taskId);
@@ -497,10 +518,60 @@ const resolveUpdateTaskInput = async (
     nextAssigneeActorIds.delete(actorId);
   }
 
-  return {
-    ...baseInput,
-    assigneeActorIds: [...nextAssigneeActorIds],
-  };
+  return validateNextAssigneeActorIds(
+    taskService,
+    {
+      ...baseInput,
+      assigneeActorIds: [...nextAssigneeActorIds],
+    },
+    dependencies,
+  );
+};
+
+const validateNextAssigneeActorIds = async (
+  taskService: TaskService,
+  input: UpdateTaskInput,
+  dependencies: ResolveUpdateTaskInputDependencies
+): Promise<UpdateTaskInput> => {
+  if (input.assigneeActorIds === undefined) {
+    return input;
+  }
+
+  if (!dependencies.actorService || !dependencies.projectService) {
+    return input;
+  }
+
+  const task = await taskService.getTask(input.taskId);
+  if (!task) {
+    throw new Error(`task not found: ${input.taskId}`);
+  }
+
+  const project = task.projectId ? await dependencies.projectService.getProject(task.projectId) : null;
+  if (!project) {
+    return input;
+  }
+
+  const currentAssignees = new Set(task.assigneeActorIds);
+  const actors = await dependencies.actorService.listActors();
+  const actorMap = new Map(actors.map((actor) => [actor.id, actor]));
+  const authorizedActorIds = new Set(project.authorizedAssigneeActorIds);
+
+  for (const actorId of input.assigneeActorIds) {
+    const actor = actorMap.get(actorId);
+    if (!actor) {
+      throw new Error(`actor not found: ${actorId}`);
+    }
+
+    if (!currentAssignees.has(actorId) && actor.archived) {
+      throw new Error(`actor is archived and unavailable for new assignment: ${actorId}`);
+    }
+
+    if (!currentAssignees.has(actorId) && !authorizedActorIds.has(actorId)) {
+      throw new Error(`actor is not authorized for project ${project.id}: ${actorId}`);
+    }
+  }
+
+  return input;
 };
 
 const normalizeTaskCommentInput = (params: TaskCommentCreateToolParams): AddTaskCommentInput => ({


### PR DESCRIPTION
## Summary
- add actor management tools and services for list/create/rename/archive/unarchive
- extend project read/update flows to manage authorized assignee actor IDs and show stale unauthorized assignees
- enforce authorized non-archived actor assignment for new task assignees while preserving existing stale assignees

## Testing
- npm run lint
- npm run typecheck
- npm test

Task: #task-2b66df66