### PR TITLE
feat: add mapping, trust, and approval tools

### DIFF
--- a/src/__tests__/actor-tools.test.ts
+++ b/src/__tests__/actor-tools.test.ts
@@ -43,7 +43,9 @@ describe("registerTools", () => {
 
 describe("actor tools", () => {
   it("lists actors", async () => {
-    const actorService = { listActors: vi.fn().mockResolvedValue([createActor()]) } as unknown as ActorService;
+    const actorService = {
+      listActors: vi.fn().mockResolvedValue([createActor()]),
+    } as unknown as ActorService;
     const tool = createActorListToolDefinition({
       getActorService: vi.fn().mockResolvedValue(actorService),
     });
@@ -77,14 +79,22 @@ describe("actor tools", () => {
 
     await expect(
       createTool.execute("tool-call-1", { id: " actor-user ", displayName: " Erik " })
-    ).resolves.toMatchObject({ content: [{ text: expect.stringContaining("Created actor actor-user") }] });
+    ).resolves.toMatchObject({
+      content: [{ text: expect.stringContaining("Created actor actor-user") }],
+    });
     await expect(
       renameTool.execute("tool-call-2", { actorId: " actor-user ", displayName: " Updated Erik " })
-    ).resolves.toMatchObject({ content: [{ text: expect.stringContaining("Renamed actor actor-user") }] });
-    await expect(archiveTool.execute("tool-call-3", { actorId: " actor-user " })).resolves.toMatchObject({
+    ).resolves.toMatchObject({
+      content: [{ text: expect.stringContaining("Renamed actor actor-user") }],
+    });
+    await expect(
+      archiveTool.execute("tool-call-3", { actorId: " actor-user " })
+    ).resolves.toMatchObject({
       content: [{ text: expect.stringContaining("Archived actor actor-user") }],
     });
-    await expect(unarchiveTool.execute("tool-call-4", { actorId: " actor-user " })).resolves.toMatchObject({
+    await expect(
+      unarchiveTool.execute("tool-call-4", { actorId: " actor-user " })
+    ).resolves.toMatchObject({
       content: [{ text: expect.stringContaining("Unarchived actor actor-user") }],
     });
   });

--- a/src/__tests__/approval-tools.test.ts
+++ b/src/__tests__/approval-tools.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ApprovalItem } from "@/domain/approval";
+import { registerTools } from "@/extension/register-tools";
+import type { ActorService } from "@/services/actor-service";
+import type { ApprovalService } from "@/services/approval-service";
+import {
+  createApprovalListToolDefinition,
+  createApproveNoteContentToolDefinition,
+  createApproveTaskDescriptionToolDefinition,
+} from "@/tools/approval-tools";
+
+const createApprovalItem = (overrides: Partial<ApprovalItem> = {}): ApprovalItem => ({
+  kind: "taskDescription",
+  state: "pendingApproval",
+  taskId: "task-123",
+  projectId: "proj-1",
+  taskTitle: "Review imported task",
+  contentPreview: "Imported content preview",
+  sourceBindingId: "ibind-1",
+  sourceActorId: "actor-reviewer",
+  ...overrides,
+});
+
+describe("registerTools", () => {
+  it("registers approval tools", () => {
+    const pi = { registerTool: vi.fn() };
+
+    registerTools(pi as never, {
+      getApprovalService: vi.fn().mockResolvedValue({} as ApprovalService),
+    });
+
+    const registeredToolNames = pi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(registeredToolNames).toEqual(
+      expect.arrayContaining([
+        "approval_list",
+        "approval_approve_task_description",
+        "approval_approve_note_content",
+      ])
+    );
+  });
+});
+
+describe("approval tools", () => {
+  it("lists approval-needed items", async () => {
+    const approvalService = {
+      listApprovals: vi.fn().mockResolvedValue([createApprovalItem()]),
+    } as unknown as ApprovalService;
+    const actorService = {
+      listActors: vi
+        .fn()
+        .mockResolvedValue([{ id: "actor-reviewer", displayName: "Reviewer", archived: false }]),
+    } as unknown as ActorService;
+    const tool = createApprovalListToolDefinition({
+      getApprovalService: vi.fn().mockResolvedValue(approvalService),
+      getActorService: vi.fn().mockResolvedValue(actorService),
+    });
+
+    const result = await tool.execute("tool-call-1", {});
+
+    expect(result.content[0]?.text).toContain("Approval-needed items (1):");
+    expect(result.content[0]?.text).toContain("task description • Review imported task");
+    expect(result.content[0]?.text).toContain("Reviewer (actor-reviewer)");
+  });
+
+  it("approves task descriptions and note content explicitly", async () => {
+    const approvalService = {
+      approveTaskDescription: vi.fn().mockResolvedValue(createApprovalItem({ state: "approved" })),
+      approveNoteContent: vi.fn().mockResolvedValue(
+        createApprovalItem({
+          kind: "noteContent",
+          noteId: "note-1",
+          taskId: undefined,
+          taskTitle: undefined,
+          state: "approved",
+        })
+      ),
+    } as unknown as ApprovalService;
+    const toolTask = createApproveTaskDescriptionToolDefinition({
+      getApprovalService: vi.fn().mockResolvedValue(approvalService),
+    });
+    const toolNote = createApproveNoteContentToolDefinition({
+      getApprovalService: vi.fn().mockResolvedValue(approvalService),
+    });
+
+    await expect(toolTask.execute("tool-call-1", { taskId: "task-123" })).resolves.toMatchObject({
+      content: [{ text: expect.stringContaining("Approval updated:") }],
+    });
+    await expect(toolNote.execute("tool-call-2", { noteId: "note-1" })).resolves.toMatchObject({
+      content: [{ text: expect.stringContaining("Approval updated:") }],
+    });
+  });
+});

--- a/src/__tests__/current-task-context.test.ts
+++ b/src/__tests__/current-task-context.test.ts
@@ -20,7 +20,9 @@ const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
   assigneeDisplayNames: overrides.assigneeDisplayNames ?? ["Erik"],
   assignees: overrides.assignees ?? ["Erik"],
   description: overrides.description ?? "Persist and restore current task context",
+  descriptionApproval: overrides.descriptionApproval ?? null,
   comments: overrides.comments ?? [],
+  outboundAssigneeWarnings: overrides.outboundAssigneeWarnings ?? [],
 });
 
 const createContext = (

--- a/src/__tests__/daemon-client-habit.test.ts
+++ b/src/__tests__/daemon-client-habit.test.ts
@@ -349,6 +349,7 @@ describe("createToduDaemonClient habit support", () => {
       authorActorId: null,
       authorDisplayName: "user",
       author: "user",
+      contentApproval: null,
       entityType: "habit",
       entityId: "habit-1",
       tags: [],

--- a/src/__tests__/daemon-client.test.ts
+++ b/src/__tests__/daemon-client.test.ts
@@ -293,6 +293,7 @@ describe("createToduDaemonClient", () => {
       assigneeDisplayNames: [],
       assignees: [],
       description: "Implement the typed client wrapper",
+      descriptionApproval: null,
       comments: [
         {
           id: "note-1",
@@ -301,9 +302,11 @@ describe("createToduDaemonClient", () => {
           authorActorId: null,
           authorDisplayName: "user",
           author: "user",
+          contentApproval: null,
           createdAt: "2026-03-19T01:00:00.000Z",
         },
       ],
+      outboundAssigneeWarnings: [],
     });
   });
 
@@ -439,6 +442,7 @@ describe("createToduDaemonClient", () => {
       authorActorId: null,
       authorDisplayName: "user",
       author: "user",
+      contentApproval: null,
       createdAt: "2026-03-19T02:00:00.000Z",
     });
     expect(connection.request).toHaveBeenCalledWith("note.create", {
@@ -938,6 +942,7 @@ describe("createToduDaemonClient", () => {
         authorActorId: null,
         authorDisplayName: "user",
         author: "user",
+        contentApproval: null,
         entityType: null,
         entityId: null,
         tags: ["daily"],

--- a/src/__tests__/integration-tools.test.ts
+++ b/src/__tests__/integration-tools.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ActorSummary } from "@/domain/actor";
+import type { TaskSummary } from "@/domain/task";
+import { registerTools } from "@/extension/register-tools";
+import type { ActorService } from "@/services/actor-service";
+import type {
+  IntegrationBinding,
+  IntegrationBindingStatus,
+  ProjectIntegrationService,
+} from "@/services/project-integration-service";
+import type { ProjectService } from "@/services/project-service";
+import type { TaskService } from "@/services/task-service";
+import {
+  createIntegrationShowToolDefinition,
+  createIntegrationUpdateToolDefinition,
+} from "@/tools/integration-tools";
+
+const createBinding = (overrides: Partial<IntegrationBinding> = {}): IntegrationBinding => ({
+  id: "ibind-1",
+  provider: "github",
+  projectId: "proj-1",
+  targetKind: "repository",
+  targetRef: "owner/repo",
+  strategy: "bidirectional",
+  enabled: true,
+  options: {
+    actorMappings: [
+      {
+        actorId: "actor-user",
+        externalLogin: "erik",
+        trusted: true,
+      },
+    ],
+  },
+  createdAt: "2026-03-19T00:00:00.000Z",
+  updatedAt: "2026-03-19T00:00:00.000Z",
+  ...overrides,
+});
+
+const createStatus = (
+  overrides: Partial<IntegrationBindingStatus> = {}
+): IntegrationBindingStatus => ({
+  bindingId: "ibind-1",
+  state: "idle",
+  authorityId: null,
+  lastSuccessfulSyncAt: null,
+  lastAttemptedSyncAt: null,
+  lastErrorSummary: null,
+  updatedAt: "2026-03-19T00:00:00.000Z",
+  ...overrides,
+});
+
+const createTaskSummary = (overrides: Partial<TaskSummary> = {}): TaskSummary => ({
+  id: "task-123",
+  title: "Review mapping",
+  status: "active",
+  priority: "medium",
+  projectId: "proj-1",
+  projectName: "Todu Pi Extensions",
+  labels: [],
+  assigneeActorIds: ["actor-user", "actor-reviewer"],
+  assigneeDisplayNames: ["Erik", "Reviewer"],
+  assignees: ["Erik", "Reviewer"],
+  ...overrides,
+});
+
+const actors: ActorSummary[] = [
+  { id: "actor-user", displayName: "Erik", archived: false },
+  { id: "actor-reviewer", displayName: "Reviewer", archived: false },
+];
+
+describe("registerTools", () => {
+  it("registers integration tools", () => {
+    const pi = { registerTool: vi.fn() };
+
+    registerTools(pi as never, {
+      getProjectIntegrationService: vi.fn().mockResolvedValue({} as ProjectIntegrationService),
+    });
+
+    const registeredToolNames = pi.registerTool.mock.calls.map(([tool]) => tool.name);
+    expect(registeredToolNames).toEqual(
+      expect.arrayContaining(["integration_list", "integration_show", "integration_update"])
+    );
+  });
+});
+
+describe("integration tools", () => {
+  it("shows mappings, trust state, and unmapped assignee warnings", async () => {
+    const integrationService = {
+      getIntegrationBinding: vi.fn().mockResolvedValue(createBinding()),
+      getIntegrationBindingStatus: vi.fn().mockResolvedValue(createStatus()),
+    } as unknown as ProjectIntegrationService;
+    const projectService = {
+      listProjects: vi
+        .fn()
+        .mockResolvedValue([
+          {
+            id: "proj-1",
+            name: "Todu Pi Extensions",
+            status: "active",
+            priority: "medium",
+            description: null,
+            authorizedAssigneeActorIds: [],
+          },
+        ]),
+    } as unknown as ProjectService;
+    const taskService = {
+      listTasks: vi.fn().mockResolvedValue([createTaskSummary()]),
+    } as unknown as TaskService;
+    const actorService = {
+      listActors: vi.fn().mockResolvedValue(actors),
+    } as unknown as ActorService;
+    const tool = createIntegrationShowToolDefinition({
+      getProjectIntegrationService: vi.fn().mockResolvedValue(integrationService),
+      getProjectService: vi.fn().mockResolvedValue(projectService),
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+      getActorService: vi.fn().mockResolvedValue(actorService),
+    });
+
+    const result = await tool.execute("tool-call-1", { bindingId: "ibind-1" });
+
+    expect(result.content[0]?.text).toContain("Actor mappings (1):");
+    expect(result.content[0]?.text).toContain("trust: trusted");
+    expect(result.content[0]?.text).toContain("Skipped unmapped outbound assignee warnings:");
+    expect(result.content[0]?.text).toContain("task-123 • Review mapping • Reviewer");
+  });
+
+  it("updates trust state for mapped actors", async () => {
+    const integrationService = {
+      getIntegrationBinding: vi.fn().mockResolvedValue(createBinding()),
+      updateIntegrationBinding: vi.fn().mockResolvedValue(
+        createBinding({
+          options: {
+            actorMappings: [{ actorId: "actor-user", externalLogin: "erik", trusted: false }],
+          },
+        })
+      ),
+    } as unknown as ProjectIntegrationService;
+    const actorService = {
+      listActors: vi.fn().mockResolvedValue(actors),
+    } as unknown as ActorService;
+    const tool = createIntegrationUpdateToolDefinition({
+      getProjectIntegrationService: vi.fn().mockResolvedValue(integrationService),
+      getActorService: vi.fn().mockResolvedValue(actorService),
+    });
+
+    const result = await tool.execute("tool-call-1", {
+      bindingId: "ibind-1",
+      untrustActorIds: ["actor-user"],
+    });
+
+    expect(integrationService.updateIntegrationBinding).toHaveBeenCalledWith(
+      expect.objectContaining({ bindingId: "ibind-1" })
+    );
+    expect(result.content[0]?.text).toContain("Updated integration ibind-1");
+  });
+});

--- a/src/__tests__/note-read-tools.test.ts
+++ b/src/__tests__/note-read-tools.test.ts
@@ -26,6 +26,7 @@ const createNoteSummary = (overrides: Partial<NoteSummary> = {}): NoteSummary =>
   tags: ["review"],
   createdAt: "2026-03-20T00:00:00.000Z",
   ...overrides,
+  contentApproval: overrides.contentApproval ?? null,
 });
 
 describe("registerTools", () => {
@@ -218,6 +219,7 @@ describe("createNoteShowToolDefinition", () => {
     expect(result.content[0]?.text).toContain("review");
     expect(result.content[0]?.text).toContain("task:task-123");
     expect(result.content[0]?.text).toContain("This is a test note.");
+    expect(result.content[0]?.text).toContain("Approval: none");
     expect(result.details).toEqual({
       kind: "note_show",
       noteId: "note-1",
@@ -266,7 +268,18 @@ describe("formatNoteShowContent", () => {
     expect(content).toContain("Author: Erik");
     expect(content).toContain("Entity: task:task-123");
     expect(content).toContain("Tags: review");
+    expect(content).toContain("Approval: none");
     expect(content).toContain("This is a test note.");
+  });
+
+  it("shows pending approval metadata when present", () => {
+    const content = formatNoteShowContent(
+      createNoteSummary({
+        contentApproval: { state: "pendingApproval", sourceBindingId: "ibind-1" },
+      })
+    );
+
+    expect(content).toContain("pendingApproval • binding ibind-1");
   });
 
   it("formats journal entries without entity binding", () => {

--- a/src/__tests__/note-service.test.ts
+++ b/src/__tests__/note-service.test.ts
@@ -19,6 +19,7 @@ describe("createToduNoteService", () => {
         authorActorId: "actor-user",
         authorDisplayName: "Erik",
         author: "user",
+        contentApproval: null,
         entityType: null,
         entityId: null,
         tags: [],

--- a/src/__tests__/project-integration-service.test.ts
+++ b/src/__tests__/project-integration-service.test.ts
@@ -58,6 +58,9 @@ describe("createProjectIntegrationService", () => {
       gateway: {
         listIntegrationBindings: vi.fn().mockResolvedValue([createBinding()]),
         createIntegrationBinding: vi.fn(),
+        getIntegrationBinding: vi.fn(),
+        updateIntegrationBinding: vi.fn(),
+        getIntegrationBindingStatus: vi.fn(),
       },
     });
 
@@ -95,6 +98,9 @@ describe("createProjectIntegrationService", () => {
           .fn()
           .mockResolvedValue([createBinding(), createBinding({ id: "ibind-2" })]),
         createIntegrationBinding: vi.fn(),
+        getIntegrationBinding: vi.fn(),
+        updateIntegrationBinding: vi.fn(),
+        getIntegrationBindingStatus: vi.fn(),
       },
     });
 
@@ -130,6 +136,9 @@ describe("createProjectIntegrationService", () => {
       gateway: {
         listIntegrationBindings: vi.fn().mockResolvedValue([]),
         createIntegrationBinding: vi.fn(),
+        getIntegrationBinding: vi.fn(),
+        updateIntegrationBinding: vi.fn(),
+        getIntegrationBindingStatus: vi.fn(),
       },
     });
 
@@ -167,6 +176,9 @@ describe("createProjectIntegrationService", () => {
       gateway: {
         listIntegrationBindings: vi.fn().mockResolvedValue([]),
         createIntegrationBinding,
+        getIntegrationBinding: vi.fn(),
+        updateIntegrationBinding: vi.fn(),
+        getIntegrationBindingStatus: vi.fn(),
       },
     });
 
@@ -217,6 +229,9 @@ describe("createProjectIntegrationService", () => {
         createIntegrationBinding: vi
           .fn()
           .mockResolvedValue(createBinding({ provider: "forgejo", targetRef: "team/custom" })),
+        getIntegrationBinding: vi.fn(),
+        updateIntegrationBinding: vi.fn(),
+        getIntegrationBindingStatus: vi.fn(),
       },
     });
 

--- a/src/__tests__/project-mutation-tools.test.ts
+++ b/src/__tests__/project-mutation-tools.test.ts
@@ -149,9 +149,11 @@ describe("createProjectUpdateToolDefinition", () => {
       getProject: vi
         .fn()
         .mockResolvedValue(createProjectSummary({ authorizedAssigneeActorIds: ["actor-user"] })),
-      updateProject: vi.fn().mockResolvedValue(
-        createProjectSummary({ authorizedAssigneeActorIds: ["actor-user", "actor-reviewer"] })
-      ),
+      updateProject: vi
+        .fn()
+        .mockResolvedValue(
+          createProjectSummary({ authorizedAssigneeActorIds: ["actor-user", "actor-reviewer"] })
+        ),
     } as unknown as ProjectService;
     const actorService = {
       listActors: vi.fn().mockResolvedValue([
@@ -182,7 +184,9 @@ describe("createProjectUpdateToolDefinition", () => {
       updateProject: vi.fn(),
     } as unknown as ProjectService;
     const actorService = {
-      listActors: vi.fn().mockResolvedValue([{ id: "actor-user", displayName: "Erik", archived: false }]),
+      listActors: vi
+        .fn()
+        .mockResolvedValue([{ id: "actor-user", displayName: "Erik", archived: false }]),
     } as unknown as ActorService;
     const tool = createProjectUpdateToolDefinition({
       getProjectService: vi.fn().mockResolvedValue(projectService),

--- a/src/__tests__/task-detail-view.test.ts
+++ b/src/__tests__/task-detail-view.test.ts
@@ -18,6 +18,8 @@ const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
   assigneeDisplayNames: ["Erik", "Reviewer"],
   assignees: ["Erik", "Reviewer"],
   description: "Show metadata, description, and comments inside pi.",
+  descriptionApproval: null,
+  outboundAssigneeWarnings: [],
   comments: [
     {
       id: "comment-1",
@@ -26,6 +28,7 @@ const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
       authorActorId: "actor-user",
       authorDisplayName: "Erik",
       author: "user",
+      contentApproval: null,
       createdAt: "2026-03-19T00:00:00.000Z",
     },
     {
@@ -35,6 +38,7 @@ const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
       authorActorId: "actor-user",
       authorDisplayName: "Erik",
       author: "user",
+      contentApproval: null,
       createdAt: "2026-03-19T01:00:00.000Z",
     },
   ],
@@ -52,11 +56,33 @@ describe("task detail view model", () => {
     expect(viewModel.body).toContain("Priority: high");
     expect(viewModel.body).toContain("Project: Todu Pi Extensions");
     expect(viewModel.body).toContain("Assignees: Erik, Reviewer");
+    expect(viewModel.body).toContain("Description approval: None");
     expect(viewModel.body).toContain("Labels: ui, detail");
     expect(viewModel.body).toContain("Description");
     expect(viewModel.body).toContain("Show metadata, description, and comments inside pi.");
     expect(viewModel.body).toContain("Recent comments (2)");
     expect(viewModel.body).toContain("Second note");
+  });
+
+  it("shows approval and unmapped assignee warnings when present", () => {
+    const viewModel = createTaskDetailViewModel(
+      createTaskDetail({
+        descriptionApproval: { state: "pendingApproval", sourceBindingId: "ibind-1" },
+        outboundAssigneeWarnings: [
+          {
+            bindingId: "ibind-1",
+            provider: "github",
+            targetRef: "owner/repo",
+            unmappedActorIds: ["actor-reviewer"],
+            unmappedAssigneeDisplayNames: ["Reviewer"],
+          },
+        ],
+      })
+    );
+
+    expect(viewModel.body).toContain("pendingApproval • binding ibind-1");
+    expect(viewModel.body).toContain("Skipped unmapped outbound assignee warnings");
+    expect(viewModel.body).toContain("github:owner/repo (ibind-1) • Reviewer");
   });
 
   it("creates quick action items for the detail hub", () => {

--- a/src/__tests__/task-mutation-tools.test.ts
+++ b/src/__tests__/task-mutation-tools.test.ts
@@ -32,6 +32,8 @@ const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
   description: "Add create, update, and comment tools.",
   comments: [],
   ...overrides,
+  descriptionApproval: overrides.descriptionApproval ?? null,
+  outboundAssigneeWarnings: overrides.outboundAssigneeWarnings ?? [],
 });
 
 const createTaskComment = (overrides: Partial<TaskComment> = {}): TaskComment => ({
@@ -43,6 +45,7 @@ const createTaskComment = (overrides: Partial<TaskComment> = {}): TaskComment =>
   createdAt: "2026-03-19T00:00:00.000Z",
   content: "Looks good",
   ...overrides,
+  contentApproval: overrides.contentApproval ?? null,
 });
 
 const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectSummary => ({
@@ -150,9 +153,11 @@ describe("resolveUpdateTaskInput", () => {
 
   it("supports incremental assignee updates", async () => {
     const taskService = {
-      getTask: vi.fn().mockResolvedValue(
-        createTaskDetail({ assigneeActorIds: ["actor-user"], assigneeDisplayNames: ["Erik"] })
-      ),
+      getTask: vi
+        .fn()
+        .mockResolvedValue(
+          createTaskDetail({ assigneeActorIds: ["actor-user"], assigneeDisplayNames: ["Erik"] })
+        ),
     } as unknown as TaskService;
 
     await expect(
@@ -411,9 +416,9 @@ describe("createTaskUpdateToolDefinition", () => {
       ]),
     } as never;
     const projectService = {
-      getProject: vi.fn().mockResolvedValue(
-        createProjectSummary({ authorizedAssigneeActorIds: ["actor-user"] })
-      ),
+      getProject: vi
+        .fn()
+        .mockResolvedValue(createProjectSummary({ authorizedAssigneeActorIds: ["actor-user"] })),
     } as never;
     const tool = createTaskUpdateToolDefinition({
       getTaskService: vi.fn().mockResolvedValue(taskService),
@@ -444,9 +449,9 @@ describe("createTaskUpdateToolDefinition", () => {
       ]),
     } as never;
     const projectService = {
-      getProject: vi.fn().mockResolvedValue(
-        createProjectSummary({ authorizedAssigneeActorIds: ["actor-user"] })
-      ),
+      getProject: vi
+        .fn()
+        .mockResolvedValue(createProjectSummary({ authorizedAssigneeActorIds: ["actor-user"] })),
     } as never;
     const tool = createTaskUpdateToolDefinition({
       getTaskService: vi.fn().mockResolvedValue(taskService),

--- a/src/__tests__/task-read-tools.test.ts
+++ b/src/__tests__/task-read-tools.test.ts
@@ -37,11 +37,14 @@ const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
       authorActorId: "actor-user",
       authorDisplayName: "Erik",
       author: "user",
+      contentApproval: null,
       createdAt: "2026-03-19T00:00:00.000Z",
       content: "Looks good",
     },
   ],
   ...overrides,
+  descriptionApproval: overrides.descriptionApproval ?? null,
+  outboundAssigneeWarnings: overrides.outboundAssigneeWarnings ?? [],
 });
 
 describe("registerTools", () => {
@@ -265,6 +268,7 @@ describe("createTaskShowToolDefinition", () => {
     expect(result.content[0]?.text).toContain(`Task ${task.id}: ${task.title}`);
     expect(result.content[0]?.text).toContain("Description:");
     expect(result.content[0]?.text).toContain("Assignees: Erik, Reviewer");
+    expect(result.content[0]?.text).toContain("Description approval: none");
     expect(result.content[0]?.text).toContain("Recent comments (1):");
     expect(result.details).toEqual({
       kind: "task_show",
@@ -290,6 +294,33 @@ describe("createTaskShowToolDefinition", () => {
       taskId: "task-missing",
       found: false,
     });
+  });
+
+  it("shows pending approval and outbound assignee warnings", async () => {
+    const task = createTaskDetail({
+      descriptionApproval: { state: "pendingApproval", sourceBindingId: "ibind-1" },
+      outboundAssigneeWarnings: [
+        {
+          bindingId: "ibind-1",
+          provider: "github",
+          targetRef: "owner/repo",
+          unmappedActorIds: ["actor-reviewer"],
+          unmappedAssigneeDisplayNames: ["Reviewer"],
+        },
+      ],
+    });
+    const taskService = {
+      getTask: vi.fn().mockResolvedValue(task),
+    } as unknown as TaskService;
+    const tool = createTaskShowToolDefinition({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+    });
+
+    const result = await tool.execute("tool-call-1", { taskId: task.id });
+
+    expect(result.content[0]?.text).toContain("pendingApproval • binding ibind-1");
+    expect(result.content[0]?.text).toContain("Skipped unmapped outbound assignee warnings:");
+    expect(result.content[0]?.text).toContain("ibind-1 • github:owner/repo • Reviewer");
   });
 
   it("surfaces service failures with tool-specific context", async () => {

--- a/src/__tests__/tasks-command.test.ts
+++ b/src/__tests__/tasks-command.test.ts
@@ -36,6 +36,8 @@ const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
   description: "Build the first task browse flow",
   comments: [],
   ...overrides,
+  descriptionApproval: overrides.descriptionApproval ?? null,
+  outboundAssigneeWarnings: overrides.outboundAssigneeWarnings ?? [],
 });
 
 const createProjectSummary = (overrides: Partial<ProjectSummary> = {}): ProjectSummary => ({
@@ -878,6 +880,7 @@ describe("openTaskDetailHub", () => {
           authorActorId: "actor-user",
           authorDisplayName: "Erik",
           author: "user",
+          contentApproval: null,
           createdAt: "2026-03-19T00:00:00.000Z",
         },
       ],

--- a/src/__tests__/todu-task-service.test.ts
+++ b/src/__tests__/todu-task-service.test.ts
@@ -65,6 +65,12 @@ describe("createToduTaskService", () => {
       renameActor: vi.fn(),
       archiveActor: vi.fn(),
       unarchiveActor: vi.fn(),
+      getIntegrationBinding: vi.fn(),
+      updateIntegrationBinding: vi.fn(),
+      getIntegrationBindingStatus: vi.fn(),
+      listApprovals: vi.fn(),
+      approveTaskDescription: vi.fn(),
+      approveNoteContent: vi.fn(),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -92,7 +98,9 @@ describe("createToduTaskService", () => {
       assigneeDisplayNames: ["Erik"],
       assignees: ["Erik"],
       description: "Create the initial module layout",
+      descriptionApproval: null,
       comments: [],
+      outboundAssigneeWarnings: [],
     };
     const project: ProjectSummary = {
       id: "proj-1",
@@ -138,6 +146,12 @@ describe("createToduTaskService", () => {
       renameActor: vi.fn(),
       archiveActor: vi.fn(),
       unarchiveActor: vi.fn(),
+      getIntegrationBinding: vi.fn(),
+      updateIntegrationBinding: vi.fn(),
+      getIntegrationBindingStatus: vi.fn(),
+      listApprovals: vi.fn(),
+      approveTaskDescription: vi.fn(),
+      approveNoteContent: vi.fn(),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -155,6 +169,7 @@ describe("createToduTaskService", () => {
         "Priority: high",
         "Project: Foundation",
         "Assignees: Erik",
+        "Description approval: None",
         "Labels: foundation",
         "",
         "Description",
@@ -211,6 +226,12 @@ describe("createToduTaskService", () => {
       renameActor: vi.fn(),
       archiveActor: vi.fn(),
       unarchiveActor: vi.fn(),
+      getIntegrationBinding: vi.fn(),
+      updateIntegrationBinding: vi.fn(),
+      getIntegrationBindingStatus: vi.fn(),
+      listApprovals: vi.fn(),
+      approveTaskDescription: vi.fn(),
+      approveNoteContent: vi.fn(),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -292,6 +313,12 @@ describe("createToduTaskService", () => {
       renameActor: vi.fn(),
       archiveActor: vi.fn(),
       unarchiveActor: vi.fn(),
+      getIntegrationBinding: vi.fn(),
+      updateIntegrationBinding: vi.fn(),
+      getIntegrationBindingStatus: vi.fn(),
+      listApprovals: vi.fn(),
+      approveTaskDescription: vi.fn(),
+      approveNoteContent: vi.fn(),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -328,7 +355,9 @@ describe("createToduTaskService", () => {
       assigneeDisplayNames: ["Erik"],
       assignees: ["Erik"],
       description: "Create the initial module layout",
+      descriptionApproval: null,
       comments: [],
+      outboundAssigneeWarnings: [],
     };
     const project: ProjectSummary = {
       id: "proj-1",
@@ -384,6 +413,12 @@ describe("createToduTaskService", () => {
       renameActor: vi.fn(),
       archiveActor: vi.fn(),
       unarchiveActor: vi.fn(),
+      getIntegrationBinding: vi.fn(),
+      updateIntegrationBinding: vi.fn(),
+      getIntegrationBindingStatus: vi.fn(),
+      listApprovals: vi.fn(),
+      approveTaskDescription: vi.fn(),
+      approveNoteContent: vi.fn(),
       on: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
     };
     const taskService = createToduTaskService({ client });
@@ -449,6 +484,8 @@ describe("createToduTaskService", () => {
       assigneeDisplayNames: ["Reviewer"],
       assignees: ["Reviewer"],
       description: null,
+      descriptionApproval: null,
+      outboundAssigneeWarnings: [],
       comments: [],
     };
     const client = {

--- a/src/domain/approval.ts
+++ b/src/domain/approval.ts
@@ -1,0 +1,33 @@
+export type ContentApprovalState = "notRequired" | "pendingApproval" | "approved";
+
+export interface ImportedContentApproval {
+  state: ContentApprovalState;
+  sourceBindingId?: string;
+  sourceActorId?: string;
+  sourceFingerprint?: string;
+  reviewedAt?: string;
+  reviewedByActorId?: string;
+}
+
+export type ApprovalItemKind = "taskDescription" | "noteContent";
+
+export interface ApprovalItem {
+  kind: ApprovalItemKind;
+  state: ContentApprovalState;
+  taskId?: string;
+  noteId?: string;
+  projectId?: string;
+  taskTitle?: string;
+  entityType?: "task" | "project" | "habit";
+  entityId?: string;
+  contentPreview: string;
+  sourceBindingId?: string;
+  sourceActorId?: string;
+  sourceFingerprint?: string;
+  reviewedAt?: string;
+  reviewedByActorId?: string;
+}
+
+export interface ApprovalListFilter {
+  kind?: ApprovalItemKind;
+}

--- a/src/domain/note.ts
+++ b/src/domain/note.ts
@@ -1,3 +1,5 @@
+import type { ImportedContentApproval } from "./approval";
+
 export type NoteId = string;
 
 export type NoteEntityType = "task" | "project" | "habit";
@@ -8,6 +10,7 @@ export interface NoteSummary {
   authorActorId: string | null;
   authorDisplayName: string;
   author: string | null;
+  contentApproval: ImportedContentApproval | null;
   entityType: NoteEntityType | null;
   entityId: string | null;
   tags: string[];

--- a/src/domain/task.ts
+++ b/src/domain/task.ts
@@ -1,3 +1,5 @@
+import type { ImportedContentApproval } from "./approval";
+
 export type TaskId = string;
 export type ProjectId = string;
 export type ActorId = string;
@@ -23,7 +25,16 @@ export interface TaskComment {
   authorActorId: ActorId | null;
   authorDisplayName: string;
   author: string | null;
+  contentApproval: ImportedContentApproval | null;
   createdAt: string;
+}
+
+export interface OutboundAssigneeWarning {
+  bindingId: string;
+  provider: string;
+  targetRef: string;
+  unmappedActorIds: ActorId[];
+  unmappedAssigneeDisplayNames: string[];
 }
 
 export interface TaskSummary {
@@ -41,7 +52,9 @@ export interface TaskSummary {
 
 export interface TaskDetail extends TaskSummary {
   description: string | null;
+  descriptionApproval: ImportedContentApproval | null;
   comments: TaskComment[];
+  outboundAssigneeWarnings: OutboundAssigneeWarning[];
 }
 
 export type TaskSortField = "priority" | "dueDate" | "createdAt" | "updatedAt" | "title";

--- a/src/extension/register-tools.ts
+++ b/src/extension/register-tools.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 import type { ActorService } from "../services/actor-service";
+import type { ApprovalService } from "../services/approval-service";
 import type { HabitService } from "../services/habit-service";
 import type { NoteService } from "../services/note-service";
 import type { ProjectIntegrationService } from "../services/project-integration-service";
@@ -15,6 +16,8 @@ import { registerActorMutationTools } from "../tools/actor-mutation-tools";
 import { registerActorReadTools } from "../tools/actor-read-tools";
 import { registerHabitMutationTools } from "../tools/habit-mutation-tools";
 import { registerHabitReadTools } from "../tools/habit-read-tools";
+import { registerApprovalTools } from "../tools/approval-tools";
+import { registerIntegrationTools } from "../tools/integration-tools";
 import { registerNoteReadTools } from "../tools/note-read-tools";
 import { registerProjectIntegrationTools } from "../tools/project-integration-tools";
 import { registerProjectMutationTools } from "../tools/project-mutation-tools";
@@ -31,6 +34,7 @@ export interface RegisterToolDependencies {
   getRecurringService?: () => Promise<RecurringService>;
   getHabitService?: () => Promise<HabitService>;
   getNoteService?: () => Promise<NoteService>;
+  getApprovalService?: () => Promise<ApprovalService>;
   getProjectIntegrationService?: () => Promise<ProjectIntegrationService>;
 }
 
@@ -53,17 +57,26 @@ const registerTools = (pi: ExtensionAPI, dependencies: RegisterToolDependencies 
   const getProjectIntegrationService =
     dependencies.getProjectIntegrationService ??
     (() => runtime.ensureProjectIntegrationServiceConnected());
+  const getApprovalService =
+    dependencies.getApprovalService ?? (() => runtime.ensureApprovalServiceConnected());
 
   registerTaskReadTools(pi, { getTaskService });
   registerActorReadTools(pi, { getActorService });
   registerProjectReadTools(pi, { getProjectService, getActorService, getTaskService });
   registerProjectIntegrationTools(pi, { getProjectIntegrationService, getProjectService });
+  registerIntegrationTools(pi, {
+    getProjectIntegrationService,
+    getProjectService,
+    getTaskService,
+    getActorService,
+  });
   registerProjectMutationTools(pi, { getProjectService, getActorService });
   registerRecurringReadTools(pi, { getRecurringService });
   registerRecurringMutationTools(pi, { getRecurringService, getProjectService });
   registerHabitReadTools(pi, { getHabitService });
   registerHabitMutationTools(pi, { getHabitService, getProjectService });
   registerNoteReadTools(pi, { getNoteService });
+  registerApprovalTools(pi, { getApprovalService, getActorService });
   registerActorMutationTools(pi, { getActorService });
   registerTaskMutationTools(pi, { getTaskService, getActorService, getProjectService });
 };

--- a/src/services/approval-service.ts
+++ b/src/services/approval-service.ts
@@ -1,0 +1,7 @@
+import type { ApprovalItem, ApprovalListFilter } from "../domain/approval";
+
+export interface ApprovalService {
+  listApprovals(filter?: ApprovalListFilter): Promise<ApprovalItem[]>;
+  approveTaskDescription(taskId: string): Promise<ApprovalItem>;
+  approveNoteContent(noteId: string): Promise<ApprovalItem>;
+}

--- a/src/services/project-integration-service.ts
+++ b/src/services/project-integration-service.ts
@@ -1,4 +1,27 @@
 import type { ProjectSummary, TaskPriority } from "../domain/task";
+
+export interface IntegrationBindingActorMapping {
+  actorId: string;
+  externalAccountId?: string;
+  externalLogin?: string;
+  displayName?: string;
+  trusted?: boolean;
+}
+
+export interface IntegrationBindingOptions {
+  actorMappings?: IntegrationBindingActorMapping[];
+  [key: string]: unknown;
+}
+
+export interface IntegrationBindingStatus {
+  bindingId: string;
+  state: "running" | "idle" | "blocked" | "error";
+  authorityId: string | null;
+  lastSuccessfulSyncAt: string | null;
+  lastAttemptedSyncAt: string | null;
+  lastErrorSummary: string | null;
+  updatedAt: string;
+}
 import type { ProjectService } from "./project-service";
 import type { RepoContextService, ResolvedRepositoryContext } from "./repo-context";
 
@@ -12,7 +35,7 @@ export interface IntegrationBinding {
   targetRef: string;
   strategy: IntegrationSyncStrategy;
   enabled: boolean;
-  options?: Record<string, unknown>;
+  options?: IntegrationBindingOptions;
   createdAt: string;
   updatedAt: string;
 }
@@ -24,7 +47,18 @@ export interface CreateIntegrationBindingInput {
   targetRef: string;
   strategy?: IntegrationSyncStrategy;
   enabled?: boolean;
-  options?: Record<string, unknown>;
+  options?: IntegrationBindingOptions;
+}
+
+export interface UpdateIntegrationBindingInput {
+  bindingId: string;
+  provider?: string;
+  projectId?: string;
+  targetKind?: string;
+  targetRef?: string;
+  strategy?: IntegrationSyncStrategy;
+  enabled?: boolean;
+  options?: IntegrationBindingOptions;
 }
 
 export interface IntegrationBindingFilter {
@@ -95,6 +129,9 @@ export interface RegisterRepositoryProjectInput {
 
 export interface ProjectIntegrationService {
   listIntegrationBindings(filter?: IntegrationBindingFilter): Promise<IntegrationBinding[]>;
+  getIntegrationBinding(bindingId: string): Promise<IntegrationBinding | null>;
+  updateIntegrationBinding(input: UpdateIntegrationBindingInput): Promise<IntegrationBinding>;
+  getIntegrationBindingStatus(bindingId: string): Promise<IntegrationBindingStatus | null>;
   checkRepositoryBinding(input?: {
     repositoryPath?: string;
     provider?: string;
@@ -108,6 +145,9 @@ export interface ProjectIntegrationService {
 export interface ProjectIntegrationGateway {
   listIntegrationBindings(filter?: IntegrationBindingFilter): Promise<IntegrationBinding[]>;
   createIntegrationBinding(input: CreateIntegrationBindingInput): Promise<IntegrationBinding>;
+  getIntegrationBinding(bindingId: string): Promise<IntegrationBinding | null>;
+  updateIntegrationBinding(input: UpdateIntegrationBindingInput): Promise<IntegrationBinding>;
+  getIntegrationBindingStatus(bindingId: string): Promise<IntegrationBindingStatus | null>;
 }
 
 export interface ProjectIntegrationServiceDependencies {
@@ -122,6 +162,9 @@ const createProjectIntegrationService = ({
   gateway,
 }: ProjectIntegrationServiceDependencies): ProjectIntegrationService => ({
   listIntegrationBindings: (filter) => gateway.listIntegrationBindings(filter),
+  getIntegrationBinding: (bindingId) => gateway.getIntegrationBinding(bindingId),
+  updateIntegrationBinding: (input) => gateway.updateIntegrationBinding(input),
+  getIntegrationBindingStatus: (bindingId) => gateway.getIntegrationBindingStatus(bindingId),
   checkRepositoryBinding: async (input = {}) => {
     const repositoryResolution = await resolveRepositoryInput(repoContextService, input);
     if (repositoryResolution.kind !== "resolved") {

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -4,6 +4,7 @@ import type {
   HabitStreak as ToduHabitStreak,
   IntegrationBinding as ToduIntegrationBinding,
   IntegrationBindingFilter as ToduIntegrationBindingFilter,
+  IntegrationBindingStatus as ToduIntegrationBindingStatus,
   Note as ToduNote,
   NoteFilter as ToduNoteFilter,
   Project as ToduProject,
@@ -14,6 +15,7 @@ import type {
   TaskPriority as ToduTaskPriority,
   TaskStatus as ToduTaskStatus,
   TaskWithDetail as ToduTaskWithDetail,
+  UpdateIntegrationBindingInput as ToduUpdateIntegrationBindingInput,
 } from "@todu/core";
 
 import type {
@@ -23,6 +25,11 @@ import type {
   HabitStreak,
   HabitSummary,
 } from "../../domain/habit";
+import type {
+  ApprovalItem,
+  ApprovalListFilter,
+  ImportedContentApproval,
+} from "../../domain/approval";
 import type { NoteEntityType, NoteFilter, NoteSummary } from "../../domain/note";
 import type {
   RecurringFilter,
@@ -50,6 +57,8 @@ import type {
   CreateIntegrationBindingInput,
   IntegrationBinding,
   IntegrationBindingFilter,
+  IntegrationBindingStatus,
+  UpdateIntegrationBindingInput,
 } from "../project-integration-service";
 import type {
   CreateProjectInput,
@@ -136,7 +145,13 @@ export interface ToduDaemonClient {
   updateRecurring(input: UpdateRecurringInput): Promise<RecurringTemplateDetail>;
   deleteRecurring(recurringId: string): Promise<DeleteRecurringResult>;
   listIntegrationBindings(filter?: IntegrationBindingFilter): Promise<IntegrationBinding[]>;
+  getIntegrationBinding(bindingId: string): Promise<IntegrationBinding | null>;
   createIntegrationBinding(input: CreateIntegrationBindingInput): Promise<IntegrationBinding>;
+  updateIntegrationBinding(input: UpdateIntegrationBindingInput): Promise<IntegrationBinding>;
+  getIntegrationBindingStatus(bindingId: string): Promise<IntegrationBindingStatus | null>;
+  listApprovals(filter?: ApprovalListFilter): Promise<ApprovalItem[]>;
+  approveTaskDescription(taskId: string): Promise<ApprovalItem>;
+  approveNoteContent(noteId: string): Promise<ApprovalItem>;
   deleteTask(taskId: TaskId): Promise<DeleteTaskResult>;
   moveTask(input: MoveTaskInput): Promise<MoveTaskResult>;
   listHabits(filter?: HabitFilter): Promise<HabitSummary[]>;
@@ -166,10 +181,19 @@ type ToduActorLike = {
   archived?: boolean;
 };
 
+type ToduApprovalItem = ApprovalItem;
+type ToduApprovalListFilter = ApprovalListFilter;
+
 type ToduProjectWithActorFields = ToduProject & { authorizedAssigneeActorIds?: string[] };
 type ToduTaskWithActorFields = ToduTask & { assigneeActorIds?: string[] };
-type ToduTaskWithDetailWithActorFields = ToduTaskWithDetail & { assigneeActorIds?: string[] };
-type ToduNoteWithActorFields = ToduNote & { authorActorId?: string };
+type ToduTaskWithDetailWithActorFields = ToduTaskWithDetail & {
+  assigneeActorIds?: string[];
+  descriptionApproval?: ImportedContentApproval;
+};
+type ToduNoteWithActorFields = ToduNote & {
+  authorActorId?: string;
+  contentApproval?: ImportedContentApproval;
+};
 type ToduNoteFilterWithActorFields = ToduNoteFilter & { authorActorId?: string };
 
 const createToduDaemonClient = ({
@@ -184,7 +208,9 @@ const createToduDaemonClient = ({
   },
 
   async getTask(taskId: TaskId): Promise<TaskDetail | null> {
-    const taskResult = await connection.request<ToduTaskWithDetailWithActorFields>("task.get", { id: taskId });
+    const taskResult = await connection.request<ToduTaskWithDetailWithActorFields>("task.get", {
+      id: taskId,
+    });
     if (!taskResult.ok) {
       if (taskResult.error.code === "NOT_FOUND") {
         return null;
@@ -332,7 +358,9 @@ const createToduDaemonClient = ({
   },
 
   async getProject(projectId: string): Promise<ToduProjectSummary | null> {
-    const result = await connection.request<ToduProjectWithActorFields>("project.get", { id: projectId });
+    const result = await connection.request<ToduProjectWithActorFields>("project.get", {
+      id: projectId,
+    });
     if (!result.ok) {
       if (result.error.code === "NOT_FOUND") {
         return null;
@@ -453,6 +481,21 @@ const createToduDaemonClient = ({
     return result.value.map(mapIntegrationBinding);
   },
 
+  async getIntegrationBinding(bindingId: string): Promise<IntegrationBinding | null> {
+    const result = await connection.request<ToduIntegrationBinding>("integration.get", {
+      id: bindingId,
+    });
+    if (!result.ok) {
+      if (result.error.code === "NOT_FOUND") {
+        return null;
+      }
+
+      throw mapDaemonErrorToClientError("integration.get", result.error);
+    }
+
+    return mapIntegrationBinding(result.value);
+  },
+
   async createIntegrationBinding(
     input: CreateIntegrationBindingInput
   ): Promise<IntegrationBinding> {
@@ -464,6 +507,68 @@ const createToduDaemonClient = ({
     }
 
     return mapIntegrationBinding(result.value);
+  },
+
+  async updateIntegrationBinding(
+    input: UpdateIntegrationBindingInput
+  ): Promise<IntegrationBinding> {
+    const result = await connection.request<ToduIntegrationBinding>("integration.update", {
+      id: input.bindingId,
+      input: mapUpdateIntegrationBindingInput(input),
+    });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("integration.update", result.error);
+    }
+
+    return mapIntegrationBinding(result.value);
+  },
+
+  async getIntegrationBindingStatus(bindingId: string): Promise<IntegrationBindingStatus | null> {
+    const result = await connection.request<ToduIntegrationBindingStatus>("integration.status", {
+      id: bindingId,
+    });
+    if (!result.ok) {
+      if (result.error.code === "NOT_FOUND") {
+        return null;
+      }
+
+      throw mapDaemonErrorToClientError("integration.status", result.error);
+    }
+
+    return mapIntegrationBindingStatus(result.value);
+  },
+
+  async listApprovals(filter: ApprovalListFilter = {}): Promise<ApprovalItem[]> {
+    const result = await connection.request<ToduApprovalItem[]>("approval.list", {
+      filter: mapApprovalListFilter(filter),
+    });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("approval.list", result.error);
+    }
+
+    return result.value.map(mapApprovalItem);
+  },
+
+  async approveTaskDescription(taskId: string): Promise<ApprovalItem> {
+    const result = await connection.request<ToduApprovalItem>("approval.approveTaskDescription", {
+      taskId,
+    });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("approval.approveTaskDescription", result.error);
+    }
+
+    return mapApprovalItem(result.value);
+  },
+
+  async approveNoteContent(noteId: string): Promise<ApprovalItem> {
+    const result = await connection.request<ToduApprovalItem>("approval.approveNoteContent", {
+      noteId,
+    });
+    if (!result.ok) {
+      throw mapDaemonErrorToClientError("approval.approveNoteContent", result.error);
+    }
+
+    return mapApprovalItem(result.value);
   },
 
   async listHabits(filter: HabitFilter = {}): Promise<HabitSummary[]> {
@@ -746,8 +851,7 @@ const resolveActorDisplayNames = (
 
 const hasActorBackedTaskAssignments = (
   tasks: ReadonlyArray<{ assigneeActorIds?: string[] }>
-): boolean =>
-  tasks.some((task) => (task.assigneeActorIds ?? []).length > 0);
+): boolean => tasks.some((task) => (task.assigneeActorIds ?? []).length > 0);
 
 const shouldLoadTaskActors = (
   task: { assigneeActorIds?: string[] },
@@ -802,7 +906,9 @@ const mapTaskDetail = (
 ): TaskDetail => ({
   ...mapTaskSummary(task, actorMap),
   description: task.description ?? null,
+  descriptionApproval: mapImportedContentApproval(task.descriptionApproval),
   comments,
+  outboundAssigneeWarnings: [],
 });
 
 const mapTaskComment = (
@@ -815,6 +921,7 @@ const mapTaskComment = (
   authorActorId: note.authorActorId ?? null,
   authorDisplayName: resolveActorDisplayName(note.authorActorId, actorMap, note.author),
   author: note.author ?? null,
+  contentApproval: mapImportedContentApproval(note.contentApproval),
   createdAt: note.createdAt,
 });
 
@@ -827,6 +934,7 @@ const mapNoteSummary = (
   authorActorId: note.authorActorId ?? null,
   authorDisplayName: resolveActorDisplayName(note.authorActorId, actorMap, note.author),
   author: note.author ?? null,
+  contentApproval: mapImportedContentApproval(note.contentApproval),
   entityType: (note.entityType as NoteEntityType) ?? null,
   entityId: note.entityId ?? null,
   tags: [...note.tags],
@@ -865,6 +973,39 @@ const mapIntegrationBinding = (binding: ToduIntegrationBinding): IntegrationBind
   options: binding.options,
   createdAt: binding.createdAt,
   updatedAt: binding.updatedAt,
+});
+
+const mapIntegrationBindingStatus = (
+  status: ToduIntegrationBindingStatus
+): IntegrationBindingStatus => ({
+  bindingId: status.bindingId,
+  state: status.state,
+  authorityId: status.authorityId,
+  lastSuccessfulSyncAt: status.lastSuccessfulSyncAt,
+  lastAttemptedSyncAt: status.lastAttemptedSyncAt,
+  lastErrorSummary: status.lastErrorSummary,
+  updatedAt: status.updatedAt,
+});
+
+const mapImportedContentApproval = (
+  approval: ImportedContentApproval | null | undefined
+): ImportedContentApproval | null => (approval ? { ...approval } : null);
+
+const mapApprovalItem = (item: ToduApprovalItem): ApprovalItem => ({
+  kind: item.kind,
+  state: item.state,
+  taskId: item.taskId,
+  noteId: item.noteId,
+  projectId: item.projectId,
+  taskTitle: item.taskTitle,
+  entityType: item.entityType,
+  entityId: item.entityId,
+  contentPreview: item.contentPreview,
+  sourceBindingId: item.sourceBindingId,
+  sourceActorId: item.sourceActorId,
+  sourceFingerprint: item.sourceFingerprint,
+  reviewedAt: item.reviewedAt,
+  reviewedByActorId: item.reviewedByActorId,
 });
 
 const mapRecurringTemplateSummary = (
@@ -954,7 +1095,6 @@ const mapHabitFilter = (filter: HabitFilter): ToduHabitFilter => ({
   search: filter.query,
 });
 
-
 const mapCreateRecurringInput = (input: CreateRecurringInput): Record<string, unknown> => ({
   title: input.title,
   projectId: input.projectId,
@@ -1006,6 +1146,22 @@ const mapCreateIntegrationBindingInput = (
   options: input.options,
 });
 
+const mapUpdateIntegrationBindingInput = (
+  input: UpdateIntegrationBindingInput
+): ToduUpdateIntegrationBindingInput => ({
+  provider: input.provider,
+  projectId: input.projectId as ToduUpdateIntegrationBindingInput["projectId"],
+  targetKind: input.targetKind,
+  targetRef: input.targetRef,
+  strategy: input.strategy,
+  enabled: input.enabled,
+  options: input.options,
+});
+
+const mapApprovalListFilter = (filter: ApprovalListFilter): ToduApprovalListFilter => ({
+  kind: filter.kind,
+});
+
 const mapTaskFilter = (filter: TaskFilter): Record<string, unknown> => {
   const status =
     filter.statuses && filter.statuses.length > 0
@@ -1042,8 +1198,9 @@ const mapCreateProjectInput = (input: CreateProjectInput): Record<string, unknow
   name: input.name,
   description: input.description ?? undefined,
   priority: input.priority ? toRemoteTaskPriority(input.priority) : undefined,
-  authorizedAssigneeActorIds: (input as CreateProjectInput & { authorizedAssigneeActorIds?: string[] })
-    .authorizedAssigneeActorIds,
+  authorizedAssigneeActorIds: (
+    input as CreateProjectInput & { authorizedAssigneeActorIds?: string[] }
+  ).authorizedAssigneeActorIds,
 });
 
 const mapUpdateProjectInput = (input: UpdateLocalProjectInput): Record<string, unknown> => ({

--- a/src/services/todu/default-task-service.ts
+++ b/src/services/todu/default-task-service.ts
@@ -1,4 +1,5 @@
 import type { ActorService } from "../actor-service";
+import type { ApprovalService } from "../approval-service";
 import type { HabitService } from "../habit-service";
 import type { NoteService } from "../note-service";
 import type { ProjectIntegrationService } from "../project-integration-service";
@@ -15,6 +16,7 @@ import {
 import { createToduActorService } from "./todu-actor-service";
 import { createToduProjectIntegrationService } from "./todu-project-integration-service";
 import { createToduProjectService } from "./todu-project-service";
+import { createToduApprovalService } from "./todu-approval-service";
 import { createToduHabitService } from "./todu-habit-service";
 import { createToduNoteService } from "./todu-note-service";
 import { createToduRecurringService } from "./todu-recurring-service";
@@ -31,6 +33,7 @@ export interface ToduTaskServiceRuntime {
   recurringService: RecurringService;
   habitService: HabitService;
   noteService: NoteService;
+  approvalService: ApprovalService;
   projectIntegrationService: ProjectIntegrationService;
   ensureConnected(): Promise<TaskService>;
   ensureActorServiceConnected(): Promise<ActorService>;
@@ -38,6 +41,7 @@ export interface ToduTaskServiceRuntime {
   ensureRecurringServiceConnected(): Promise<RecurringService>;
   ensureHabitServiceConnected(): Promise<HabitService>;
   ensureNoteServiceConnected(): Promise<NoteService>;
+  ensureApprovalServiceConnected(): Promise<ApprovalService>;
   ensureProjectIntegrationServiceConnected(): Promise<ProjectIntegrationService>;
   disconnect(): Promise<void>;
 }
@@ -57,6 +61,7 @@ const createToduTaskServiceRuntime = (
   const recurringService = createToduRecurringService({ client });
   const habitService = createToduHabitService({ client });
   const noteService = createToduNoteService({ client });
+  const approvalService = createToduApprovalService({ client });
   const projectIntegrationService = createToduProjectIntegrationService({
     client,
     projectService,
@@ -76,6 +81,7 @@ const createToduTaskServiceRuntime = (
     recurringService,
     habitService,
     noteService,
+    approvalService,
     projectIntegrationService,
     ensureConnected: async () => {
       if (connection.getState().status !== "connected") {
@@ -118,6 +124,13 @@ const createToduTaskServiceRuntime = (
       }
 
       return noteService;
+    },
+    ensureApprovalServiceConnected: async () => {
+      if (connection.getState().status !== "connected") {
+        await connectWithinTimeout(connection, initialConnectTimeoutMs);
+      }
+
+      return approvalService;
     },
     ensureProjectIntegrationServiceConnected: async () => {
       if (connection.getState().status !== "connected") {

--- a/src/services/todu/todu-approval-service.ts
+++ b/src/services/todu/todu-approval-service.ts
@@ -1,0 +1,64 @@
+import type { ApprovalItem } from "../../domain/approval";
+import type { ApprovalService } from "../approval-service";
+import { ToduDaemonClientError, type ToduDaemonClient } from "./daemon-client";
+
+export class ToduApprovalServiceError extends Error {
+  readonly operation: string;
+  readonly causeCode: string;
+  readonly details?: Record<string, unknown>;
+
+  constructor(options: {
+    operation: string;
+    causeCode: string;
+    message: string;
+    details?: Record<string, unknown>;
+    cause?: unknown;
+  }) {
+    super(options.message, options.cause ? { cause: options.cause } : undefined);
+    this.name = "ToduApprovalServiceError";
+    this.operation = options.operation;
+    this.causeCode = options.causeCode;
+    this.details = options.details;
+  }
+}
+
+export interface ToduApprovalServiceDependencies {
+  client: ToduDaemonClient;
+}
+
+const createToduApprovalService = ({
+  client,
+}: ToduApprovalServiceDependencies): ApprovalService => ({
+  listApprovals: (filter) =>
+    runApprovalServiceOperation("listApprovals", () => client.listApprovals(filter)),
+  approveTaskDescription: (taskId) =>
+    runApprovalServiceOperation("approveTaskDescription", () =>
+      client.approveTaskDescription(taskId)
+    ),
+  approveNoteContent: (noteId) =>
+    runApprovalServiceOperation("approveNoteContent", () => client.approveNoteContent(noteId)),
+});
+
+const runApprovalServiceOperation = async <TResult>(
+  operation: string,
+  action: () => Promise<TResult>
+): Promise<TResult> => {
+  try {
+    return await action();
+  } catch (error) {
+    if (error instanceof ToduDaemonClientError) {
+      throw new ToduApprovalServiceError({
+        operation,
+        causeCode: error.code,
+        message: `${operation} failed: ${error.message}`,
+        details: error.details,
+        cause: error,
+      });
+    }
+
+    throw error;
+  }
+};
+
+export { createToduApprovalService, runApprovalServiceOperation };
+export type { ApprovalItem };

--- a/src/services/todu/todu-project-integration-service.ts
+++ b/src/services/todu/todu-project-integration-service.ts
@@ -2,11 +2,13 @@ import type {
   CreateIntegrationBindingInput,
   IntegrationBinding,
   IntegrationBindingFilter,
+  IntegrationBindingStatus,
   ProjectIntegrationGateway,
   ProjectIntegrationService,
   RegisterRepositoryProjectInput,
   RepositoryBindingCheckResult,
   RepositoryProjectRegistrationResult,
+  UpdateIntegrationBindingInput,
 } from "../project-integration-service";
 import { createProjectIntegrationService } from "../project-integration-service";
 import type { ProjectService } from "../project-service";
@@ -44,6 +46,12 @@ const createToduProjectIntegrationGateway = ({
     client.listIntegrationBindings(filter),
   createIntegrationBinding: (input: CreateIntegrationBindingInput): Promise<IntegrationBinding> =>
     client.createIntegrationBinding(input),
+  getIntegrationBinding: (bindingId: string): Promise<IntegrationBinding | null> =>
+    client.getIntegrationBinding(bindingId),
+  updateIntegrationBinding: (input: UpdateIntegrationBindingInput): Promise<IntegrationBinding> =>
+    client.updateIntegrationBinding(input),
+  getIntegrationBindingStatus: (bindingId: string): Promise<IntegrationBindingStatus | null> =>
+    client.getIntegrationBindingStatus(bindingId),
 });
 
 const createToduProjectIntegrationService = ({
@@ -62,6 +70,18 @@ const createToduProjectIntegrationService = ({
     listIntegrationBindings: (filter) =>
       runProjectIntegrationServiceOperation("listIntegrationBindings", () =>
         service.listIntegrationBindings(filter)
+      ),
+    getIntegrationBinding: (bindingId) =>
+      runProjectIntegrationServiceOperation("getIntegrationBinding", () =>
+        service.getIntegrationBinding(bindingId)
+      ),
+    updateIntegrationBinding: (input) =>
+      runProjectIntegrationServiceOperation("updateIntegrationBinding", () =>
+        service.updateIntegrationBinding(input)
+      ),
+    getIntegrationBindingStatus: (bindingId) =>
+      runProjectIntegrationServiceOperation("getIntegrationBindingStatus", () =>
+        service.getIntegrationBindingStatus(bindingId)
       ),
     checkRepositoryBinding: (input): Promise<RepositoryBindingCheckResult> =>
       runProjectIntegrationServiceOperation("checkRepositoryBinding", () =>

--- a/src/services/todu/todu-task-service.ts
+++ b/src/services/todu/todu-task-service.ts
@@ -1,4 +1,9 @@
-import type { TaskDetail, TaskFilter, TaskSummary } from "../../domain/task";
+import type {
+  OutboundAssigneeWarning,
+  TaskDetail,
+  TaskFilter,
+  TaskSummary,
+} from "../../domain/task";
 import type { TaskService } from "../task-service";
 import { ToduDaemonClientError, type ToduDaemonClient } from "./daemon-client";
 
@@ -76,7 +81,9 @@ const listTasksWithProjectNames = async (
   const projectMap = new Map(projects.map((project) => [project.id, project]));
   const actorMap = new Map(actors.map((actor) => [actor.id, actor]));
 
-  return tasks.map((task) => hydrateTaskSummaryMetadata(task, projectMap.get(task.projectId ?? "") ?? null, actorMap));
+  return tasks.map((task) =>
+    hydrateTaskSummaryMetadata(task, projectMap.get(task.projectId ?? "") ?? null, actorMap)
+  );
 };
 
 const hydrateTaskDetailProjectName = async (
@@ -88,11 +95,12 @@ const hydrateTaskDetailProjectName = async (
     listActorsBestEffort(client),
   ]);
 
-  return hydrateTaskDetailMetadata(
-    task,
-    project,
-    new Map(actors.map((actor) => [actor.id, actor]))
-  );
+  const actorMap = new Map(actors.map((actor) => [actor.id, actor]));
+  const outboundAssigneeWarnings = task.projectId
+    ? await buildOutboundAssigneeWarnings(client, task.projectId, task.assigneeActorIds, actorMap)
+    : [];
+
+  return hydrateTaskDetailMetadata(task, project, actorMap, outboundAssigneeWarnings);
 };
 
 const listActorsBestEffort = async (client: ToduDaemonClient) => {
@@ -116,11 +124,13 @@ const hydrateTaskSummaryMetadata = (
 const hydrateTaskDetailMetadata = (
   task: TaskDetail,
   project: { name: string; authorizedAssigneeActorIds: string[] } | null,
-  actorMap: Map<string, { displayName: string; archived: boolean }>
+  actorMap: Map<string, { displayName: string; archived: boolean }>,
+  outboundAssigneeWarnings: OutboundAssigneeWarning[] = []
 ): TaskDetail => ({
   ...task,
   projectName: project?.name ?? null,
   assigneeDisplayNames: annotateAssigneeDisplayNames(task, project, actorMap),
+  outboundAssigneeWarnings,
 });
 
 const annotateAssigneeDisplayNames = (
@@ -131,7 +141,8 @@ const annotateAssigneeDisplayNames = (
   const authorizedActorIds = new Set(project?.authorizedAssigneeActorIds ?? []);
   return task.assigneeActorIds.map((actorId, index) => {
     const actor = actorMap.get(actorId);
-    const baseLabel = task.assigneeDisplayNames[index] ?? task.assignees[index] ?? actor?.displayName ?? actorId;
+    const baseLabel =
+      task.assigneeDisplayNames[index] ?? task.assignees[index] ?? actor?.displayName ?? actorId;
     const suffixes: string[] = [];
     if (actor?.archived) {
       suffixes.push("archived");
@@ -141,6 +152,46 @@ const annotateAssigneeDisplayNames = (
     }
 
     return suffixes.length > 0 ? `${baseLabel} (${suffixes.join(", ")})` : baseLabel;
+  });
+};
+
+const buildOutboundAssigneeWarnings = async (
+  client: ToduDaemonClient,
+  projectId: string,
+  assigneeActorIds: string[],
+  actorMap: Map<string, { displayName: string; archived: boolean }>
+): Promise<OutboundAssigneeWarning[]> => {
+  let bindings: Awaited<ReturnType<ToduDaemonClient["listIntegrationBindings"]>> = [];
+  try {
+    if (typeof client.listIntegrationBindings === "function") {
+      bindings = (await client.listIntegrationBindings({ projectId, enabled: true })) ?? [];
+    }
+  } catch {
+    bindings = [];
+  }
+
+  return bindings.flatMap((binding) => {
+    const mappedActorIds = new Set(
+      Array.isArray(binding.options?.actorMappings)
+        ? binding.options.actorMappings.map((mapping) => mapping.actorId)
+        : []
+    );
+    const unmappedActorIds = assigneeActorIds.filter((actorId) => !mappedActorIds.has(actorId));
+    if (unmappedActorIds.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        bindingId: binding.id,
+        provider: binding.provider,
+        targetRef: binding.targetRef,
+        unmappedActorIds,
+        unmappedAssigneeDisplayNames: unmappedActorIds.map(
+          (actorId) => actorMap.get(actorId)?.displayName ?? actorId
+        ),
+      },
+    ];
   });
 };
 

--- a/src/tools/actor-mutation-tools.ts
+++ b/src/tools/actor-mutation-tools.ts
@@ -148,7 +148,10 @@ const registerActorMutationTools = (
   pi.registerTool(createActorUnarchiveToolDefinition(dependencies));
 };
 
-const normalizeCreateActorInput = (params: { id: string; displayName: string }): CreateActorInput => ({
+const normalizeCreateActorInput = (params: {
+  id: string;
+  displayName: string;
+}): CreateActorInput => ({
   id: normalizeRequiredText(params.id, "id"),
   displayName: normalizeRequiredText(params.displayName, "displayName"),
 });

--- a/src/tools/actor-read-tools.ts
+++ b/src/tools/actor-read-tools.ts
@@ -60,8 +60,7 @@ const formatActorListContent = (details: ActorListToolDetails): string => {
   return [
     `Actors (${details.total}):`,
     ...details.actors.map(
-      (actor) =>
-        `- ${actor.id} • ${actor.displayName} • ${actor.archived ? "archived" : "active"}`
+      (actor) => `- ${actor.id} • ${actor.displayName} • ${actor.archived ? "archived" : "active"}`
     ),
   ].join("\n");
 };

--- a/src/tools/approval-tools.ts
+++ b/src/tools/approval-tools.ts
@@ -1,0 +1,219 @@
+import { StringEnum } from "@mariozechner/pi-ai";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+
+import type { ApprovalItem, ApprovalItemKind, ApprovalListFilter } from "../domain/approval";
+import type { ActorService } from "../services/actor-service";
+import type { ApprovalService } from "../services/approval-service";
+
+const APPROVAL_KIND_VALUES = ["taskDescription", "noteContent"] as const;
+
+const ApprovalListParams = Type.Object({
+  kind: Type.Optional(
+    StringEnum(APPROVAL_KIND_VALUES, { description: "Optional approval item kind filter" })
+  ),
+});
+
+const ApprovalApproveTaskParams = Type.Object({
+  taskId: Type.String({ description: "Task ID" }),
+});
+
+const ApprovalApproveNoteParams = Type.Object({
+  noteId: Type.String({ description: "Note ID" }),
+});
+
+interface ApprovalListToolParams {
+  kind?: ApprovalItemKind;
+}
+
+interface ApprovalToolDependencies {
+  getApprovalService: () => Promise<ApprovalService>;
+  getActorService?: () => Promise<ActorService>;
+}
+
+const createApprovalListToolDefinition = ({
+  getApprovalService,
+  getActorService,
+}: ApprovalToolDependencies) => ({
+  name: "approval_list",
+  label: "Approval List",
+  description: "List pending imported-content approval items.",
+  promptSnippet: "List approval-needed items for imported content.",
+  promptGuidelines: ["Use this tool for approval-needed list/filter lookups in normal chat."],
+  parameters: ApprovalListParams,
+  async execute(_toolCallId: string, params: ApprovalListToolParams) {
+    try {
+      const approvalService = await getApprovalService();
+      const items = await approvalService.listApprovals(normalizeApprovalListFilter(params));
+      const actorMap = await listActorsBestEffort(getActorService);
+
+      return {
+        content: [{ type: "text" as const, text: formatApprovalListContent(items, actorMap) }],
+        details: {
+          kind: "approval_list",
+          filter: normalizeApprovalListFilter(params),
+          items,
+          total: items.length,
+          empty: items.length === 0,
+        },
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "approval_list failed"), { cause: error });
+    }
+  },
+});
+
+const createApproveTaskDescriptionToolDefinition = ({
+  getApprovalService,
+  getActorService,
+}: ApprovalToolDependencies) => ({
+  name: "approval_approve_task_description",
+  label: "Approve Task Description",
+  description: "Approve pending imported task description content.",
+  promptSnippet: "Approve imported task description content explicitly.",
+  parameters: ApprovalApproveTaskParams,
+  async execute(_toolCallId: string, params: { taskId: string }) {
+    const taskId = normalizeRequiredText(params.taskId, "taskId");
+
+    try {
+      const approvalService = await getApprovalService();
+      const item = await approvalService.approveTaskDescription(taskId);
+      const actorMap = await listActorsBestEffort(getActorService);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Approval updated:\n${formatApprovalItem(item, actorMap)}`,
+          },
+        ],
+        details: { kind: "approval_approve_task_description", taskId, item },
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "approval_approve_task_description failed"), {
+        cause: error,
+      });
+    }
+  },
+});
+
+const createApproveNoteContentToolDefinition = ({
+  getApprovalService,
+  getActorService,
+}: ApprovalToolDependencies) => ({
+  name: "approval_approve_note_content",
+  label: "Approve Note Content",
+  description: "Approve pending imported note or comment content.",
+  promptSnippet: "Approve imported note or comment content explicitly.",
+  parameters: ApprovalApproveNoteParams,
+  async execute(_toolCallId: string, params: { noteId: string }) {
+    const noteId = normalizeRequiredText(params.noteId, "noteId");
+
+    try {
+      const approvalService = await getApprovalService();
+      const item = await approvalService.approveNoteContent(noteId);
+      const actorMap = await listActorsBestEffort(getActorService);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Approval updated:\n${formatApprovalItem(item, actorMap)}`,
+          },
+        ],
+        details: { kind: "approval_approve_note_content", noteId, item },
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "approval_approve_note_content failed"), {
+        cause: error,
+      });
+    }
+  },
+});
+
+const registerApprovalTools = (
+  pi: Pick<ExtensionAPI, "registerTool">,
+  dependencies: ApprovalToolDependencies
+): void => {
+  pi.registerTool(createApprovalListToolDefinition(dependencies));
+  pi.registerTool(createApproveTaskDescriptionToolDefinition(dependencies));
+  pi.registerTool(createApproveNoteContentToolDefinition(dependencies));
+};
+
+const normalizeApprovalListFilter = (params: ApprovalListToolParams): ApprovalListFilter => ({
+  kind: params.kind,
+});
+
+const listActorsBestEffort = async (
+  getActorService: (() => Promise<ActorService>) | undefined
+): Promise<Map<string, string>> => {
+  if (!getActorService) {
+    return new Map();
+  }
+
+  try {
+    const actors = await (await getActorService()).listActors();
+    return new Map(actors.map((actor) => [actor.id, actor.displayName]));
+  } catch {
+    return new Map();
+  }
+};
+
+const formatApprovalListContent = (
+  items: ApprovalItem[],
+  actorMap: Map<string, string>
+): string => {
+  if (items.length === 0) {
+    return "No approval-needed items found.";
+  }
+
+  return [
+    `Approval-needed items (${items.length}):`,
+    ...items.map((item) => `- ${formatApprovalLine(item, actorMap)}`),
+  ].join("\n");
+};
+
+const formatApprovalItem = (item: ApprovalItem, actorMap: Map<string, string>): string =>
+  [
+    `Kind: ${formatApprovalKind(item.kind)}`,
+    `State: ${item.state}`,
+    `Target: ${item.taskId ?? item.noteId ?? "-"}`,
+    `Source: ${formatActorRef(item.sourceActorId, actorMap) ?? item.sourceBindingId ?? "-"}`,
+    `Preview: ${item.contentPreview}`,
+  ].join("\n");
+
+const formatApprovalLine = (item: ApprovalItem, actorMap: Map<string, string>): string =>
+  `${formatApprovalKind(item.kind)} • ${item.taskTitle ?? item.taskId ?? item.noteId ?? "-"} • ${item.state} • ${formatActorRef(item.sourceActorId, actorMap) ?? item.sourceBindingId ?? "-"} • ${item.contentPreview}`;
+
+const formatApprovalKind = (kind: ApprovalItemKind): string =>
+  kind === "taskDescription" ? "task description" : "note content";
+
+const formatActorRef = (
+  actorId: string | undefined,
+  actorMap: Map<string, string>
+): string | null => (actorId ? `${actorMap.get(actorId) ?? actorId} (${actorId})` : null);
+
+const normalizeRequiredText = (value: string, fieldName: string): string => {
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) {
+    throw new Error(`${fieldName} is required`);
+  }
+
+  return trimmedValue;
+};
+
+const formatToolError = (error: unknown, prefix: string): string => {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return `${prefix}: ${error.message}`;
+  }
+
+  return prefix;
+};
+
+export {
+  createApprovalListToolDefinition,
+  createApproveNoteContentToolDefinition,
+  createApproveTaskDescriptionToolDefinition,
+  formatApprovalListContent,
+  registerApprovalTools,
+};

--- a/src/tools/integration-tools.ts
+++ b/src/tools/integration-tools.ts
@@ -1,0 +1,503 @@
+import { StringEnum } from "@mariozechner/pi-ai";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+
+import type { ActorSummary } from "../domain/actor";
+import type { TaskSummary } from "../domain/task";
+import type { ActorService } from "../services/actor-service";
+import type {
+  IntegrationBinding,
+  IntegrationBindingActorMapping,
+  IntegrationBindingFilter,
+  IntegrationBindingStatus,
+  ProjectIntegrationService,
+} from "../services/project-integration-service";
+import type { ProjectService } from "../services/project-service";
+import type { TaskService } from "../services/task-service";
+
+const INTEGRATION_STRATEGY_VALUES = ["bidirectional", "pull", "push", "none"] as const;
+
+const IntegrationListParams = Type.Object({
+  provider: Type.Optional(Type.String({ description: "Optional provider filter" })),
+  projectId: Type.Optional(Type.String({ description: "Optional project ID filter" })),
+  enabled: Type.Optional(Type.Boolean({ description: "Optional enabled-state filter" })),
+});
+
+const IntegrationShowParams = Type.Object({
+  bindingId: Type.String({ description: "Integration binding ID" }),
+});
+
+const IntegrationUpdateParams = Type.Object({
+  bindingId: Type.String({ description: "Integration binding ID" }),
+  strategy: Type.Optional(
+    StringEnum(INTEGRATION_STRATEGY_VALUES, { description: "Optional integration strategy" })
+  ),
+  enabled: Type.Optional(Type.Boolean({ description: "Optional enabled state" })),
+  actorMappings: Type.Optional(
+    Type.Array(
+      Type.Object({
+        actorId: Type.String(),
+        externalAccountId: Type.Optional(Type.String()),
+        externalLogin: Type.Optional(Type.String()),
+        displayName: Type.Optional(Type.String()),
+        trusted: Type.Optional(Type.Boolean()),
+      })
+    )
+  ),
+  trustActorIds: Type.Optional(Type.Array(Type.String())),
+  untrustActorIds: Type.Optional(Type.Array(Type.String())),
+});
+
+interface IntegrationToolDependencies {
+  getProjectIntegrationService: () => Promise<ProjectIntegrationService>;
+  getProjectService?: () => Promise<ProjectService>;
+  getTaskService?: () => Promise<TaskService>;
+  getActorService?: () => Promise<ActorService>;
+}
+
+interface IntegrationListToolDetails {
+  kind: "integration_list";
+  filter: IntegrationBindingFilter;
+  bindings: IntegrationBinding[];
+  total: number;
+  empty: boolean;
+}
+
+interface IntegrationShowToolDetails {
+  kind: "integration_show";
+  bindingId: string;
+  found: boolean;
+  binding?: IntegrationBinding;
+  status?: IntegrationBindingStatus | null;
+  taskWarnings?: IntegrationTaskWarning[];
+}
+
+interface IntegrationUpdateToolDetails {
+  kind: "integration_update";
+  bindingId: string;
+  binding: IntegrationBinding;
+}
+
+const createIntegrationListToolDefinition = ({
+  getProjectIntegrationService,
+  getProjectService,
+}: IntegrationToolDependencies) => ({
+  name: "integration_list",
+  label: "Integration List",
+  description: "List integration bindings and their high-level state.",
+  promptSnippet: "List integration bindings and sync state.",
+  parameters: IntegrationListParams,
+  async execute(_toolCallId: string, params: IntegrationBindingFilter) {
+    try {
+      const integrationService = await getProjectIntegrationService();
+      const bindings = await integrationService.listIntegrationBindings(
+        normalizeIntegrationFilter(params)
+      );
+      const projectNameMap = await buildProjectNameMap(getProjectService);
+
+      const details: IntegrationListToolDetails = {
+        kind: "integration_list",
+        filter: normalizeIntegrationFilter(params),
+        bindings,
+        total: bindings.length,
+        empty: bindings.length === 0,
+      };
+
+      return {
+        content: [
+          { type: "text" as const, text: formatIntegrationListContent(bindings, projectNameMap) },
+        ],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "integration_list failed"), { cause: error });
+    }
+  },
+});
+
+const createIntegrationShowToolDefinition = ({
+  getProjectIntegrationService,
+  getProjectService,
+  getTaskService,
+  getActorService,
+}: IntegrationToolDependencies) => ({
+  name: "integration_show",
+  label: "Integration Show",
+  description:
+    "Show integration binding details, mappings, trust state, and unmapped assignee warnings.",
+  promptSnippet: "Inspect binding-local actor mappings, trust state, and warning summaries.",
+  parameters: IntegrationShowParams,
+  async execute(_toolCallId: string, params: { bindingId: string }) {
+    const bindingId = normalizeRequiredText(params.bindingId, "bindingId");
+
+    try {
+      const integrationService = await getProjectIntegrationService();
+      const binding = await integrationService.getIntegrationBinding(bindingId);
+      if (!binding) {
+        const details: IntegrationShowToolDetails = {
+          kind: "integration_show",
+          bindingId,
+          found: false,
+        };
+
+        return {
+          content: [{ type: "text" as const, text: `Integration binding not found: ${bindingId}` }],
+          details,
+        };
+      }
+
+      const [status, projectNameMap, actors, tasks] = await Promise.all([
+        integrationService.getIntegrationBindingStatus(bindingId),
+        buildProjectNameMap(getProjectService),
+        listActorsBestEffort(getActorService),
+        listProjectTasksBestEffort(getTaskService, binding.projectId),
+      ]);
+      const taskWarnings = buildTaskMappingWarnings(binding, tasks, actors);
+
+      const details: IntegrationShowToolDetails = {
+        kind: "integration_show",
+        bindingId,
+        found: true,
+        binding,
+        status,
+        taskWarnings,
+      };
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: formatIntegrationShowContent(
+              binding,
+              status,
+              projectNameMap,
+              actors,
+              taskWarnings
+            ),
+          },
+        ],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "integration_show failed"), { cause: error });
+    }
+  },
+});
+
+const createIntegrationUpdateToolDefinition = ({
+  getProjectIntegrationService,
+  getActorService,
+}: IntegrationToolDependencies) => ({
+  name: "integration_update",
+  label: "Integration Update",
+  description: "Update integration binding trust state and actor mappings.",
+  promptSnippet: "Update binding-local actor mappings or trust state explicitly.",
+  parameters: IntegrationUpdateParams,
+  async execute(
+    _toolCallId: string,
+    params: {
+      bindingId: string;
+      strategy?: "bidirectional" | "pull" | "push" | "none";
+      enabled?: boolean;
+      actorMappings?: IntegrationBindingActorMapping[];
+      trustActorIds?: string[];
+      untrustActorIds?: string[];
+    }
+  ) {
+    const bindingId = normalizeRequiredText(params.bindingId, "bindingId");
+
+    try {
+      const integrationService = await getProjectIntegrationService();
+      const existing = await integrationService.getIntegrationBinding(bindingId);
+      if (!existing) {
+        throw new Error(`integration binding not found: ${bindingId}`);
+      }
+
+      const actorIdsToValidate = [
+        ...(params.actorMappings?.map((mapping) => mapping.actorId) ?? []),
+        ...(params.trustActorIds ?? []),
+        ...(params.untrustActorIds ?? []),
+      ];
+      await validateActorIds(getActorService, actorIdsToValidate);
+
+      const actorMappings = applyMappingUpdates(existing.options?.actorMappings ?? [], params);
+      if (
+        params.strategy === undefined &&
+        params.enabled === undefined &&
+        params.actorMappings === undefined &&
+        params.trustActorIds === undefined &&
+        params.untrustActorIds === undefined
+      ) {
+        throw new Error(
+          "integration_update requires at least one supported field: strategy, enabled, actorMappings, trustActorIds, or untrustActorIds"
+        );
+      }
+
+      const updated = await integrationService.updateIntegrationBinding({
+        bindingId,
+        strategy: params.strategy,
+        enabled: params.enabled,
+        options: {
+          ...(existing.options ?? {}),
+          actorMappings,
+        },
+      });
+
+      const details: IntegrationUpdateToolDetails = {
+        kind: "integration_update",
+        bindingId,
+        binding: updated,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: formatIntegrationUpdateContent(updated) }],
+        details,
+      };
+    } catch (error) {
+      throw new Error(formatToolError(error, "integration_update failed"), { cause: error });
+    }
+  },
+});
+
+const registerIntegrationTools = (
+  pi: Pick<ExtensionAPI, "registerTool">,
+  dependencies: IntegrationToolDependencies
+): void => {
+  pi.registerTool(createIntegrationListToolDefinition(dependencies));
+  pi.registerTool(createIntegrationShowToolDefinition(dependencies));
+  pi.registerTool(createIntegrationUpdateToolDefinition(dependencies));
+};
+
+const normalizeIntegrationFilter = (
+  filter: IntegrationBindingFilter
+): IntegrationBindingFilter => ({
+  provider: normalizeOptionalText(filter.provider),
+  projectId: normalizeOptionalText(filter.projectId),
+  enabled: filter.enabled,
+});
+
+const buildProjectNameMap = async (
+  getProjectService: (() => Promise<ProjectService>) | undefined
+): Promise<Map<string, string>> => {
+  if (!getProjectService) {
+    return new Map();
+  }
+
+  const projectService = await getProjectService();
+  const projects = await projectService.listProjects();
+  return new Map(projects.map((project) => [project.id, project.name]));
+};
+
+const listActorsBestEffort = async (
+  getActorService: (() => Promise<ActorService>) | undefined
+): Promise<ActorSummary[]> => {
+  if (!getActorService) {
+    return [];
+  }
+
+  try {
+    return await (await getActorService()).listActors();
+  } catch {
+    return [];
+  }
+};
+
+const listProjectTasksBestEffort = async (
+  getTaskService: (() => Promise<TaskService>) | undefined,
+  projectId: string
+): Promise<TaskSummary[]> => {
+  if (!getTaskService) {
+    return [];
+  }
+
+  try {
+    return await (await getTaskService()).listTasks({ projectId });
+  } catch {
+    return [];
+  }
+};
+
+interface IntegrationTaskWarning {
+  taskId: string;
+  title: string;
+  unmappedActorIds: string[];
+  unmappedAssigneeDisplayNames: string[];
+}
+
+const buildTaskMappingWarnings = (
+  binding: IntegrationBinding,
+  tasks: TaskSummary[],
+  actors: ActorSummary[]
+): IntegrationTaskWarning[] => {
+  const actorMap = new Map(actors.map((actor) => [actor.id, actor]));
+  const mappedActorIds = new Set(
+    (binding.options?.actorMappings ?? []).map((mapping) => mapping.actorId)
+  );
+
+  return tasks.flatMap((task) => {
+    const unmappedActorIds = task.assigneeActorIds.filter(
+      (actorId) => !mappedActorIds.has(actorId)
+    );
+    if (unmappedActorIds.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        taskId: task.id,
+        title: task.title,
+        unmappedActorIds,
+        unmappedAssigneeDisplayNames: unmappedActorIds.map((actorId) => {
+          const index = task.assigneeActorIds.indexOf(actorId);
+          return task.assigneeDisplayNames[index] ?? actorMap.get(actorId)?.displayName ?? actorId;
+        }),
+      },
+    ];
+  });
+};
+
+const applyMappingUpdates = (
+  existingMappings: IntegrationBindingActorMapping[],
+  params: {
+    actorMappings?: IntegrationBindingActorMapping[];
+    trustActorIds?: string[];
+    untrustActorIds?: string[];
+  }
+): IntegrationBindingActorMapping[] => {
+  const baseMappings = new Map(
+    (params.actorMappings ?? existingMappings).map((mapping) => [mapping.actorId, { ...mapping }])
+  );
+
+  for (const actorId of params.trustActorIds ?? []) {
+    const mapping = baseMappings.get(actorId);
+    if (!mapping) {
+      throw new Error(`cannot trust unmapped actor: ${actorId}`);
+    }
+    mapping.trusted = true;
+  }
+
+  for (const actorId of params.untrustActorIds ?? []) {
+    const mapping = baseMappings.get(actorId);
+    if (!mapping) {
+      throw new Error(`cannot untrust unmapped actor: ${actorId}`);
+    }
+    mapping.trusted = false;
+  }
+
+  return [...baseMappings.values()].sort((left, right) =>
+    left.actorId.localeCompare(right.actorId)
+  );
+};
+
+const validateActorIds = async (
+  getActorService: (() => Promise<ActorService>) | undefined,
+  actorIds: string[]
+): Promise<void> => {
+  if (!getActorService || actorIds.length === 0) {
+    return;
+  }
+
+  const actors = await (await getActorService()).listActors();
+  const knownActorIds = new Set(actors.map((actor) => actor.id));
+  for (const actorId of actorIds) {
+    if (!knownActorIds.has(actorId)) {
+      throw new Error(`actor not found: ${actorId}`);
+    }
+  }
+};
+
+const formatIntegrationListContent = (
+  bindings: IntegrationBinding[],
+  projectNameMap: Map<string, string>
+): string => {
+  if (bindings.length === 0) {
+    return "No integration bindings found.";
+  }
+
+  return [
+    `Integration bindings (${bindings.length}):`,
+    ...bindings.map(
+      (binding) =>
+        `- ${binding.id} • ${binding.provider} • ${projectNameMap.get(binding.projectId) ?? binding.projectId} • ${binding.targetRef} • ${binding.strategy} • ${binding.enabled ? "enabled" : "disabled"}`
+    ),
+  ].join("\n");
+};
+
+const formatIntegrationShowContent = (
+  binding: IntegrationBinding,
+  status: IntegrationBindingStatus | null,
+  projectNameMap: Map<string, string>,
+  actors: ActorSummary[],
+  taskWarnings: IntegrationTaskWarning[]
+): string => {
+  const actorMap = new Map(actors.map((actor) => [actor.id, actor]));
+  const mappings = binding.options?.actorMappings ?? [];
+  const lines = [
+    `Integration ${binding.id}`,
+    "",
+    `Provider: ${binding.provider}`,
+    `Project: ${projectNameMap.get(binding.projectId) ?? binding.projectId}`,
+    `Target: ${binding.targetKind}:${binding.targetRef}`,
+    `Strategy: ${binding.strategy}`,
+    `Enabled: ${binding.enabled ? "yes" : "no"}`,
+    `State: ${status?.state ?? "unknown"}`,
+    `Last error: ${status?.lastErrorSummary ?? "-"}`,
+    "",
+    `Actor mappings (${mappings.length}):`,
+  ];
+
+  if (mappings.length === 0) {
+    lines.push("- (none)");
+  } else {
+    for (const mapping of mappings) {
+      const actor = actorMap.get(mapping.actorId);
+      lines.push(
+        `- ${actor?.displayName ?? mapping.displayName ?? mapping.actorId} (${mapping.actorId}) • ${mapping.externalLogin ?? mapping.externalAccountId ?? "external identity unknown"} • trust: ${mapping.trusted ? "trusted" : "untrusted"}`
+      );
+    }
+  }
+
+  if (taskWarnings.length > 0) {
+    lines.push("", "Skipped unmapped outbound assignee warnings:");
+    for (const warning of taskWarnings) {
+      lines.push(
+        `- ${warning.taskId} • ${warning.title} • ${warning.unmappedAssigneeDisplayNames.join(", ")}`
+      );
+    }
+  }
+
+  return lines.join("\n");
+};
+
+const formatIntegrationUpdateContent = (binding: IntegrationBinding): string =>
+  `Updated integration ${binding.id} • mappings: ${(binding.options?.actorMappings ?? []).length} • strategy: ${binding.strategy} • ${binding.enabled ? "enabled" : "disabled"}`;
+
+const normalizeRequiredText = (value: string, fieldName: string): string => {
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) {
+    throw new Error(`${fieldName} is required`);
+  }
+
+  return trimmedValue;
+};
+
+const normalizeOptionalText = (value: string | undefined): string | undefined => {
+  const trimmedValue = value?.trim();
+  return trimmedValue && trimmedValue.length > 0 ? trimmedValue : undefined;
+};
+
+const formatToolError = (error: unknown, prefix: string): string => {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return `${prefix}: ${error.message}`;
+  }
+
+  return prefix;
+};
+
+export {
+  createIntegrationListToolDefinition,
+  createIntegrationShowToolDefinition,
+  createIntegrationUpdateToolDefinition,
+  formatIntegrationShowContent,
+  registerIntegrationTools,
+};

--- a/src/tools/note-read-tools.ts
+++ b/src/tools/note-read-tools.ts
@@ -4,6 +4,7 @@ import { Type } from "@sinclair/typebox";
 
 import type { NoteEntityType, NoteFilter, NoteSummary } from "../domain/note";
 import type { NoteService } from "../services/note-service";
+import { formatApprovalSummary } from "../utils/approval-format";
 import { getSystemTimezone } from "../utils/timezone";
 
 const NOTE_ENTITY_TYPE_VALUES = ["task", "project", "habit"] as const;
@@ -190,7 +191,8 @@ const formatNoteListContent = (details: NoteListToolDetails): string => {
 const formatNoteSummaryLine = (note: NoteSummary): string => {
   const entityLabel = note.entityType ? `${note.entityType}:${note.entityId ?? "?"}` : "journal";
   const tagLabel = note.tags.length > 0 ? note.tags.join(", ") : "no tags";
-  return `${note.id} • ${entityLabel} • ${note.authorDisplayName} • ${tagLabel} • ${note.createdAt}\n    ${note.content}`;
+  const approvalLabel = formatApprovalSummary(note.contentApproval) ?? "no approval metadata";
+  return `${note.id} • ${entityLabel} • ${note.authorDisplayName} • ${tagLabel} • ${approvalLabel} • ${note.createdAt}\n    ${note.content}`;
 };
 
 const formatNoteShowContent = (note: NoteSummary): string => {
@@ -203,6 +205,7 @@ const formatNoteShowContent = (note: NoteSummary): string => {
     `Author: ${note.authorDisplayName}`,
     `Entity: ${entityLabel}`,
     `Tags: ${tagLabel}`,
+    `Approval: ${formatApprovalSummary(note.contentApproval) ?? "none"}`,
     `Created: ${note.createdAt}`,
     "",
     "Content:",

--- a/src/tools/project-mutation-tools.ts
+++ b/src/tools/project-mutation-tools.ts
@@ -329,7 +329,9 @@ const resolveUpdateProjectInput = async (
     {
       projectId,
       name: hasOwn(params, "name") ? normalizeRequiredText(params.name ?? "", "name") : undefined,
-      description: hasOwn(params, "description") ? normalizeNullableText(params.description) : undefined,
+      description: hasOwn(params, "description")
+        ? normalizeNullableText(params.description)
+        : undefined,
       status: params.status,
       priority: params.priority,
       authorizedAssigneeActorIds: [...nextAuthorizedActorIds],
@@ -369,7 +371,9 @@ const normalizeActorIdList = (values: string[] | undefined, fieldName: string): 
   }
 
   return [
-    ...new Set(values.map((value, index) => normalizeRequiredText(value ?? "", `${fieldName}[${index}]`))),
+    ...new Set(
+      values.map((value, index) => normalizeRequiredText(value ?? "", `${fieldName}[${index}]`))
+    ),
   ];
 };
 

--- a/src/tools/project-read-tools.ts
+++ b/src/tools/project-read-tools.ts
@@ -109,12 +109,18 @@ const createProjectShowToolDefinition = ({
       };
 
       const [actors, tasks] = await Promise.all([
-        getActorService ? getActorService().then((service) => service.listActors()) : Promise.resolve([]),
-        getTaskService ? getTaskService().then((service) => service.listTasks({ projectId: project.id })) : Promise.resolve([]),
+        getActorService
+          ? getActorService().then((service) => service.listActors())
+          : Promise.resolve([]),
+        getTaskService
+          ? getTaskService().then((service) => service.listTasks({ projectId: project.id }))
+          : Promise.resolve([]),
       ]);
 
       return {
-        content: [{ type: "text" as const, text: formatProjectShowContent(project, actors, tasks) }],
+        content: [
+          { type: "text" as const, text: formatProjectShowContent(project, actors, tasks) },
+        ],
         details,
       };
     } catch (error) {

--- a/src/tools/task-mutation-tools.ts
+++ b/src/tools/task-mutation-tools.ts
@@ -524,7 +524,7 @@ const resolveUpdateTaskInput = async (
       ...baseInput,
       assigneeActorIds: [...nextAssigneeActorIds],
     },
-    dependencies,
+    dependencies
   );
 };
 
@@ -546,7 +546,9 @@ const validateNextAssigneeActorIds = async (
     throw new Error(`task not found: ${input.taskId}`);
   }
 
-  const project = task.projectId ? await dependencies.projectService.getProject(task.projectId) : null;
+  const project = task.projectId
+    ? await dependencies.projectService.getProject(task.projectId)
+    : null;
   if (!project) {
     return input;
   }
@@ -579,10 +581,7 @@ const normalizeTaskCommentInput = (params: TaskCommentCreateToolParams): AddTask
   content: normalizeRequiredText(params.content, "content"),
 });
 
-const normalizeActorIdList = (
-  values: string[] | undefined,
-  fieldName: string
-): string[] => {
+const normalizeActorIdList = (values: string[] | undefined, fieldName: string): string[] => {
   if (values === undefined) {
     throw new Error(`${fieldName} is required`);
   }

--- a/src/tools/task-read-tools.ts
+++ b/src/tools/task-read-tools.ts
@@ -12,10 +12,11 @@ import type {
   TaskStatus,
   TaskSummary,
 } from "../domain/task";
-import { getSystemTimezone } from "../utils/timezone";
 import { browseTasks } from "../flows/browse-tasks";
 import { showTaskDetail } from "../flows/show-task-detail";
 import type { TaskService } from "../services/task-service";
+import { formatApprovalSummary } from "../utils/approval-format";
+import { getSystemTimezone } from "../utils/timezone";
 
 const TASK_STATUS_VALUES = ["active", "inprogress", "waiting", "done", "cancelled"] as const;
 const TASK_PRIORITY_VALUES = ["low", "medium", "high"] as const;
@@ -245,6 +246,7 @@ const formatTaskShowContent = (task: TaskDetail): string => {
     `Priority: ${task.priority}`,
     `Project: ${task.projectName ?? task.projectId ?? "No project"}`,
     `Assignees: ${task.assigneeDisplayNames.length > 0 ? task.assigneeDisplayNames.join(", ") : "none"}`,
+    `Description approval: ${formatApprovalSummary(task.descriptionApproval) ?? "none"}`,
     `Labels: ${task.labels.length > 0 ? task.labels.join(", ") : "none"}`,
     "",
     "Description:",
@@ -259,9 +261,20 @@ const formatTaskShowContent = (task: TaskDetail): string => {
   }
 
   for (const comment of task.comments) {
-    lines.push(`- [${comment.createdAt}] ${comment.authorDisplayName}`);
+    lines.push(
+      `- [${comment.createdAt}] ${comment.authorDisplayName}${formatApprovalSummary(comment.contentApproval) ? ` • approval: ${formatApprovalSummary(comment.contentApproval)}` : ""}`
+    );
     lines.push(...indentLines(comment.content || "(empty)", 2));
     lines.push("");
+  }
+
+  if (task.outboundAssigneeWarnings.length > 0) {
+    lines.push("", "Skipped unmapped outbound assignee warnings:");
+    for (const warning of task.outboundAssigneeWarnings) {
+      lines.push(
+        `- ${warning.bindingId} • ${warning.provider}:${warning.targetRef} • ${warning.unmappedAssigneeDisplayNames.join(", ")}`
+      );
+    }
   }
 
   if (lines.at(-1) === "") {

--- a/src/ui/components/task-detail.ts
+++ b/src/ui/components/task-detail.ts
@@ -1,4 +1,5 @@
 import type { TaskDetail, TaskPriority, TaskStatus } from "../../domain/task";
+import { formatApprovalSummary } from "../../utils/approval-format";
 
 export type TaskDetailActionKind =
   | "pickup"
@@ -74,6 +75,7 @@ const createTaskDetailBody = (task: TaskDetail, recentCommentLimit: number): str
     `Priority: ${task.priority}`,
     `Project: ${task.projectName ?? task.projectId ?? "No project"}`,
     `Assignees: ${task.assigneeDisplayNames.length > 0 ? task.assigneeDisplayNames.join(", ") : "None"}`,
+    `Description approval: ${formatApprovalSummary(task.descriptionApproval) ?? "None"}`,
     `Labels: ${task.labels.length > 0 ? task.labels.join(", ") : "None"}`,
     "",
     "Description",
@@ -82,6 +84,17 @@ const createTaskDetailBody = (task: TaskDetail, recentCommentLimit: number): str
     `Recent comments (${task.comments.length})`,
     ...formatRecentComments(task, recentCommentLimit),
   ];
+
+  if (task.outboundAssigneeWarnings.length > 0) {
+    lines.push(
+      "",
+      "Skipped unmapped outbound assignee warnings",
+      ...task.outboundAssigneeWarnings.map(
+        (warning) =>
+          `- ${warning.provider}:${warning.targetRef} (${warning.bindingId}) • ${warning.unmappedAssigneeDisplayNames.join(", ")}`
+      )
+    );
+  }
 
   return lines.join("\n");
 };
@@ -97,7 +110,10 @@ const formatRecentComments = (task: TaskDetail, recentCommentLimit: number): str
       .split("\n")
       .map((line) => (line.trim().length > 0 ? `  ${line}` : "  "));
 
-    return [`- ${comment.authorDisplayName} · ${comment.createdAt}`, ...contentLines];
+    return [
+      `- ${comment.authorDisplayName} · ${comment.createdAt}${formatApprovalSummary(comment.contentApproval) ? ` · ${formatApprovalSummary(comment.contentApproval)}` : ""}`,
+      ...contentLines,
+    ];
   });
 };
 

--- a/src/utils/approval-format.ts
+++ b/src/utils/approval-format.ts
@@ -1,0 +1,24 @@
+import type { ImportedContentApproval } from "../domain/approval";
+
+const formatApprovalSummary = (
+  approval: ImportedContentApproval | null | undefined
+): string | null => {
+  if (!approval) {
+    return null;
+  }
+
+  const parts: string[] = [approval.state];
+  if (approval.sourceBindingId) {
+    parts.push(`binding ${approval.sourceBindingId}`);
+  }
+  if (approval.sourceActorId) {
+    parts.push(`actor ${approval.sourceActorId}`);
+  }
+  if (approval.reviewedAt) {
+    parts.push(`reviewed ${approval.reviewedAt}`);
+  }
+
+  return parts.join(" • ");
+};
+
+export { formatApprovalSummary };

--- a/src/utils/task-format.ts
+++ b/src/utils/task-format.ts
@@ -5,7 +5,9 @@ const formatTaskSummary = (task: TaskSummary): string =>
     task.status,
     task.priority,
     task.projectName ?? task.projectId ?? "no-project",
-    task.assigneeDisplayNames.length > 0 ? `assignees: ${task.assigneeDisplayNames.join(", ")}` : null,
+    task.assigneeDisplayNames.length > 0
+      ? `assignees: ${task.assigneeDisplayNames.join(", ")}`
+      : null,
   ]
     .filter((value): value is string => value !== null)
     .join(" • ");


### PR DESCRIPTION
## Summary
- add approval and integration tools for binding-local mapping, trust management, and explicit approval actions
- surface pending approval metadata and skipped unmapped assignee warnings in task, note, and integration views
- extend daemon-backed services and tests for approval, integration status, and warning hydration

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm test

Task: #task-6d243eb7