### PR TITLE
Add label support to task_create and task_update

### DIFF
--- a/src/__tests__/task-mutation-tools.test.ts
+++ b/src/__tests__/task-mutation-tools.test.ts
@@ -82,11 +82,13 @@ describe("normalizeCreateTaskInput", () => {
         title: "  Implement mutation tools  ",
         projectId: "  proj-1  ",
         description: "   ",
+        labels: ["  Foundation  ", "foundation", "UI"],
       })
     ).toEqual({
       title: "Implement mutation tools",
       projectId: "proj-1",
       description: null,
+      labels: ["foundation", "ui"],
     });
   });
 
@@ -103,7 +105,7 @@ describe("normalizeCreateTaskInput", () => {
 describe("normalizeUpdateTaskInput", () => {
   it("requires at least one supported mutation field", () => {
     expect(() => normalizeUpdateTaskInput({ taskId: "task-123" })).toThrow(
-      "task_update requires at least one supported field: title, status, priority, description, or assigneeActorIds"
+      "task_update requires at least one supported field: title, status, priority, description, labels, or assigneeActorIds"
     );
   });
 
@@ -132,6 +134,20 @@ describe("normalizeUpdateTaskInput", () => {
       status: undefined,
       priority: undefined,
       description: null,
+    });
+  });
+
+  it("normalizes labels for additive updates", () => {
+    expect(
+      normalizeUpdateTaskInput({
+        taskId: " task-123 ",
+        labels: ["  Foundation  ", "foundation", "UI"],
+      })
+    ).toEqual({
+      taskId: "task-123",
+      status: undefined,
+      priority: undefined,
+      labels: ["foundation", "ui"],
     });
   });
 });
@@ -171,6 +187,45 @@ describe("resolveUpdateTaskInput", () => {
       status: undefined,
       priority: undefined,
       assigneeActorIds: ["actor-reviewer"],
+    });
+  });
+
+  it("adds labels to the existing label list by default", async () => {
+    const taskService = {
+      getTask: vi.fn().mockResolvedValue(createTaskDetail({ labels: ["foundation"] })),
+    } as unknown as TaskService;
+
+    await expect(
+      resolveUpdateTaskInput(taskService, {
+        taskId: "task-123",
+        labels: ["UI", "foundation"],
+      })
+    ).resolves.toEqual({
+      taskId: "task-123",
+      status: undefined,
+      priority: undefined,
+      labels: ["foundation", "ui"],
+    });
+  });
+
+  it("removes labels when removeLabels is provided", async () => {
+    const taskService = {
+      getTask: vi
+        .fn()
+        .mockResolvedValue(createTaskDetail({ labels: ["foundation", "ui", "urgent"] })),
+    } as unknown as TaskService;
+
+    await expect(
+      resolveUpdateTaskInput(taskService, {
+        taskId: "task-123",
+        labels: ["backend"],
+        removeLabels: ["ui", "missing"],
+      })
+    ).resolves.toEqual({
+      taskId: "task-123",
+      status: undefined,
+      priority: undefined,
+      labels: ["foundation", "urgent", "backend"],
     });
   });
 
@@ -296,12 +351,14 @@ describe("createTaskCreateToolDefinition", () => {
       title: "  Implement mutation tools  ",
       projectId: " proj-1 ",
       description: "  Add create, update, and comment tools.  ",
+      labels: [" Foundation ", "ui"],
     });
 
     expect(taskService.createTask).toHaveBeenCalledWith({
       title: "Implement mutation tools",
       projectId: "proj-1",
       description: "Add create, update, and comment tools.",
+      labels: ["foundation", "ui"],
     });
     expect(result.content[0]?.text).toContain(`Created task ${task.id}: ${task.title}`);
     expect(result.details).toEqual({
@@ -310,6 +367,7 @@ describe("createTaskCreateToolDefinition", () => {
         title: "Implement mutation tools",
         projectId: "proj-1",
         description: "Add create, update, and comment tools.",
+        labels: ["foundation", "ui"],
       },
       task,
     });
@@ -475,8 +533,10 @@ describe("createTaskUpdateToolDefinition", () => {
       status: "inprogress",
       priority: "medium",
       description: null,
+      labels: ["foundation", "ui"],
     });
     const taskService = {
+      getTask: vi.fn().mockResolvedValue(createTaskDetail({ labels: ["foundation"] })),
       updateTask: vi.fn().mockResolvedValue(task),
     } as unknown as TaskService;
     const tool = createTaskUpdateToolDefinition({
@@ -489,6 +549,7 @@ describe("createTaskUpdateToolDefinition", () => {
       status: "inprogress",
       priority: "medium",
       description: "   ",
+      labels: ["UI"],
     });
 
     expect(taskService.updateTask).toHaveBeenCalledWith({
@@ -497,10 +558,11 @@ describe("createTaskUpdateToolDefinition", () => {
       status: "inprogress",
       priority: "medium",
       description: null,
+      labels: ["foundation", "ui"],
     });
     expect(result.content[0]?.text).toContain(`Updated task ${task.id}: ${task.title}`);
     expect(result.content[0]?.text).toContain(
-      'Changes: title="Updated task title", status=inprogress, priority=medium, description=cleared'
+      'Changes: title="Updated task title", status=inprogress, priority=medium, description=cleared, labels=["foundation","ui"]'
     );
     expect(result.details).toEqual({
       kind: "task_update",
@@ -510,6 +572,7 @@ describe("createTaskUpdateToolDefinition", () => {
         status: "inprogress",
         priority: "medium",
         description: null,
+        labels: ["foundation", "ui"],
       },
       task,
     });
@@ -521,7 +584,7 @@ describe("createTaskUpdateToolDefinition", () => {
     });
 
     await expect(tool.execute("tool-call-1", { taskId: "task-123" })).rejects.toThrow(
-      "task_update failed: task_update requires at least one supported field: title, status, priority, description, or assigneeActorIds"
+      "task_update failed: task_update requires at least one supported field: title, status, priority, description, labels, or assigneeActorIds"
     );
   });
 

--- a/src/services/task-service.ts
+++ b/src/services/task-service.ts
@@ -22,6 +22,7 @@ export interface UpdateTaskInput {
   status?: TaskStatus;
   priority?: TaskPriority;
   description?: string | null;
+  labels?: string[];
   assigneeActorIds?: string[];
 }
 

--- a/src/services/todu/daemon-client.ts
+++ b/src/services/todu/daemon-client.ts
@@ -1216,6 +1216,7 @@ const mapUpdateTaskInput = (input: UpdateTaskInput): Record<string, unknown> => 
   status: input.status ? toRemoteTaskStatus(input.status) : undefined,
   priority: input.priority ? toRemoteTaskPriority(input.priority) : undefined,
   description: input.description ?? undefined,
+  labels: input.labels,
   assigneeActorIds: input.assigneeActorIds,
 });
 

--- a/src/tools/task-mutation-tools.ts
+++ b/src/tools/task-mutation-tools.ts
@@ -32,6 +32,11 @@ const TaskCreateParams = Type.Object({
   title: Type.String({ description: "Task title" }),
   projectId: Type.String({ description: "Project ID or unique project name for the new task" }),
   description: Type.Optional(Type.String({ description: "Optional task description" })),
+  labels: Type.Optional(
+    Type.Array(Type.String({ description: "Task label" }), {
+      description: "Optional labels to apply to the new task",
+    })
+  ),
 });
 
 const TaskUpdateParams = Type.Object({
@@ -46,6 +51,16 @@ const TaskUpdateParams = Type.Object({
   description: Type.Optional(
     Type.String({
       description: "Optional replacement description. Use an empty string to clear it.",
+    })
+  ),
+  labels: Type.Optional(
+    Type.Array(Type.String({ description: "Task label" }), {
+      description: "Optional labels to add to the existing task labels",
+    })
+  ),
+  removeLabels: Type.Optional(
+    Type.Array(Type.String({ description: "Task label" }), {
+      description: "Optional labels to remove from the existing task labels",
     })
   ),
   assigneeActorIds: Type.Optional(
@@ -83,6 +98,7 @@ interface TaskCreateToolParams {
   title: string;
   projectId: string;
   description?: string;
+  labels?: string[];
 }
 
 interface TaskUpdateToolParams {
@@ -91,6 +107,8 @@ interface TaskUpdateToolParams {
   status?: TaskStatus;
   priority?: TaskPriority;
   description?: string;
+  labels?: string[];
+  removeLabels?: string[];
   assigneeActorIds?: string[];
   addAssigneeActorIds?: string[];
   removeAssigneeActorIds?: string[];
@@ -153,12 +171,13 @@ interface TaskMutationToolDependencies {
 const createTaskCreateToolDefinition = ({ getTaskService }: TaskMutationToolDependencies) => ({
   name: "task_create",
   label: "Task Create",
-  description: "Create a task with a title, project reference, and optional description.",
+  description: "Create a task with a title, project reference, and optional description or labels.",
   promptSnippet: "Create a task when the title and project reference are known.",
   promptGuidelines: [
     "Use this tool for backend task creation in normal chat instead of interactive slash-command flows.",
     "Provide an explicit project ID when known.",
     "If only a project name is available, pass the exact unique project name so the tool can resolve it.",
+    "Use labels to tag the task during creation when needed.",
     "Do not guess project identity.",
   ],
   parameters: TaskCreateParams,
@@ -190,11 +209,13 @@ const createTaskUpdateToolDefinition = ({
 }: TaskMutationToolDependencies) => ({
   name: "task_update",
   label: "Task Update",
-  description: "Update a task's title, status, priority, description, or assignees.",
-  promptSnippet: "Update a task's supported metadata and assignee fields by task ID.",
+  description: "Update a task's title, status, priority, description, labels, or assignees.",
+  promptSnippet: "Update a task's supported metadata, label, and assignee fields by task ID.",
   promptGuidelines: [
     "Use this tool for backend task updates in normal chat.",
-    "Supported fields are title, status, priority, description, and actor-based assignee updates.",
+    "Supported fields are title, status, priority, description, labels, and actor-based assignee updates.",
+    "Use labels to add labels to the existing task labels.",
+    "Use removeLabels when labels should be removed from the existing task labels.",
     "Use assigneeActorIds to replace the full assignee list.",
     "Use addAssigneeActorIds or removeAssigneeActorIds for incremental multi-actor assignment changes.",
   ],
@@ -376,6 +397,7 @@ const normalizeCreateTaskInput = (params: TaskCreateToolParams): CreateTaskInput
   title: normalizeRequiredText(params.title, "title"),
   projectId: normalizeRequiredText(params.projectId, "projectId"),
   description: normalizeOptionalDescription(params, "description"),
+  labels: hasOwn(params, "labels") ? normalizeLabelList(params.labels, "labels") : undefined,
 });
 
 const resolveCreateTaskInput = async (
@@ -436,6 +458,10 @@ const normalizeUpdateTaskInput = (params: TaskUpdateToolParams): UpdateTaskInput
     input.description = normalizeNullableText(params.description);
   }
 
+  if (hasOwn(params, "labels")) {
+    input.labels = normalizeLabelList(params.labels, "labels");
+  }
+
   if (hasOwn(params, "assigneeActorIds")) {
     input.assigneeActorIds = normalizeActorIdList(params.assigneeActorIds, "assigneeActorIds");
   }
@@ -445,10 +471,11 @@ const normalizeUpdateTaskInput = (params: TaskUpdateToolParams): UpdateTaskInput
     input.status === undefined &&
     input.priority === undefined &&
     !hasOwn(input, "description") &&
+    !hasOwn(input, "labels") &&
     !hasOwn(input, "assigneeActorIds")
   ) {
     throw new Error(
-      "task_update requires at least one supported field: title, status, priority, description, or assigneeActorIds"
+      "task_update requires at least one supported field: title, status, priority, description, labels, or assigneeActorIds"
     );
   }
 
@@ -482,9 +509,16 @@ const resolveUpdateTaskInput = async (
   const removeAssigneeActorIds = hasOwn(params, "removeAssigneeActorIds")
     ? normalizeActorIdList(params.removeAssigneeActorIds, "removeAssigneeActorIds")
     : undefined;
+  const addLabels = hasOwn(params, "labels")
+    ? normalizeLabelList(params.labels, "labels")
+    : undefined;
+  const removeLabels = hasOwn(params, "removeLabels")
+    ? normalizeLabelList(params.removeLabels, "removeLabels")
+    : undefined;
 
   const hasIncrementalAssigneeUpdate =
     addAssigneeActorIds !== undefined || removeAssigneeActorIds !== undefined;
+  const hasIncrementalLabelUpdate = addLabels !== undefined || removeLabels !== undefined;
 
   const baseInput: UpdateTaskInput = {
     taskId: normalizeRequiredText(params.taskId, "taskId") as TaskId,
@@ -500,7 +534,7 @@ const resolveUpdateTaskInput = async (
     baseInput.description = normalizeNullableText(params.description);
   }
 
-  if (!hasIncrementalAssigneeUpdate) {
+  if (!hasIncrementalAssigneeUpdate && !hasIncrementalLabelUpdate) {
     const input = normalizeUpdateTaskInput(params);
     return validateNextAssigneeActorIds(taskService, input, dependencies);
   }
@@ -518,11 +552,20 @@ const resolveUpdateTaskInput = async (
     nextAssigneeActorIds.delete(actorId);
   }
 
+  const nextLabels = new Set(task.labels);
+  for (const label of addLabels ?? []) {
+    nextLabels.add(label);
+  }
+  for (const label of removeLabels ?? []) {
+    nextLabels.delete(label);
+  }
+
   return validateNextAssigneeActorIds(
     taskService,
     {
       ...baseInput,
-      assigneeActorIds: [...nextAssigneeActorIds],
+      ...(hasIncrementalLabelUpdate ? { labels: [...nextLabels] } : {}),
+      ...(hasIncrementalAssigneeUpdate ? { assigneeActorIds: [...nextAssigneeActorIds] } : {}),
     },
     dependencies
   );
@@ -594,6 +637,18 @@ const normalizeActorIdList = (values: string[] | undefined, fieldName: string): 
   return [...new Set(normalizedValues)];
 };
 
+const normalizeLabelList = (values: string[] | undefined, fieldName: string): string[] => {
+  if (values === undefined) {
+    throw new Error(`${fieldName} is required`);
+  }
+
+  const normalizedValues = values.map((value, index) =>
+    normalizeRequiredText(value ?? "", `${fieldName}[${index}]`).toLowerCase()
+  );
+
+  return [...new Set(normalizedValues)];
+};
+
 const normalizeRequiredText = (value: string, fieldName: string): string => {
   const trimmedValue = value.trim();
   if (trimmedValue.length === 0) {
@@ -638,6 +693,7 @@ const formatTaskUpdateContent = (task: TaskDetail, input: UpdateTaskInput): stri
     hasOwn(input, "description")
       ? `description=${input.description === null ? "cleared" : "updated"}`
       : null,
+    hasOwn(input, "labels") ? `labels=${JSON.stringify(input.labels ?? [])}` : null,
     hasOwn(input, "assigneeActorIds")
       ? `assigneeActorIds=${JSON.stringify(input.assigneeActorIds ?? [])}`
       : null,


### PR DESCRIPTION
## Summary

Add label support to the pi task mutation tools so agents can tag tasks at creation time and add or remove labels during task updates.

## Task

- task-3e899c8e

## Changes

- add `labels` support to `task_create`
- add additive `labels` and explicit `removeLabels` support to `task_update`
- thread updated labels through the task service and daemon client
- document the new label arguments in the tool definitions and prompt guidelines
- add tests covering create labels, additive updates, removals, and backward compatibility

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- `make check`
- `./scripts/pre-pr.sh`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
