### PR TITLE
fix: use note.get for note_show

### DIFF
--- a/src/__tests__/daemon-client.test.ts
+++ b/src/__tests__/daemon-client.test.ts
@@ -905,6 +905,62 @@ describe("createToduDaemonClient", () => {
     ).rejects.toThrow("task.move failed");
   });
 
+  it("gets a note by id", async () => {
+    const connection = createConnectionMock();
+    connection.request.mockResolvedValue({
+      ok: true,
+      value: {
+        id: "note-1",
+        content: "Journal entry",
+        author: "user",
+        tags: ["daily"],
+        createdAt: "2026-03-20T00:00:00.000Z",
+      },
+    });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await expect(client.getNote("note-1")).resolves.toEqual({
+      id: "note-1",
+      content: "Journal entry",
+      authorActorId: null,
+      authorDisplayName: "user",
+      author: "user",
+      contentApproval: null,
+      entityType: null,
+      entityId: null,
+      tags: ["daily"],
+      createdAt: "2026-03-20T00:00:00.000Z",
+    });
+    expect(connection.request).toHaveBeenCalledWith("note.get", { id: "note-1" });
+  });
+
+  it("returns null when note.get returns NOT_FOUND", async () => {
+    const connection = createConnectionMock();
+    connection.request.mockResolvedValue({
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: "missing note",
+      },
+    });
+
+    const client = createToduDaemonClient({
+      connection: connection as unknown as Pick<
+        ToduDaemonConnection,
+        "request" | "subscribeToEvents"
+      >,
+    });
+
+    await expect(client.getNote("note-missing")).resolves.toBeNull();
+    expect(connection.request).toHaveBeenCalledWith("note.get", { id: "note-missing" });
+  });
+
   it("lists notes with filter mapped to daemon NoteFilter", async () => {
     const connection = createConnectionMock();
     connection.request.mockResolvedValue({

--- a/src/__tests__/note-service.test.ts
+++ b/src/__tests__/note-service.test.ts
@@ -7,6 +7,7 @@ import { createToduNoteService, ToduNoteServiceError } from "@/services/todu/tod
 const createClientMock = () =>
   ({
     listNotes: vi.fn().mockResolvedValue([]),
+    getNote: vi.fn().mockResolvedValue(null),
   }) as unknown as ToduDaemonClient;
 
 describe("createToduNoteService", () => {
@@ -35,6 +36,29 @@ describe("createToduNoteService", () => {
     expect(result).toEqual(notes);
   });
 
+  it("delegates getNote to the daemon client", async () => {
+    const client = createClientMock();
+    const note = {
+      id: "note-1",
+      content: "Hello",
+      authorActorId: null,
+      authorDisplayName: "Erik",
+      author: "user",
+      contentApproval: null,
+      entityType: null,
+      entityId: null,
+      tags: [],
+      createdAt: "2026-03-20T00:00:00.000Z",
+    };
+    vi.mocked(client.getNote).mockResolvedValue(note);
+
+    const service = createToduNoteService({ client });
+    const result = await service.getNote("note-1");
+
+    expect(client.getNote).toHaveBeenCalledWith("note-1");
+    expect(result).toEqual(note);
+  });
+
   it("wraps daemon client errors in ToduNoteServiceError", async () => {
     const client = createClientMock();
     vi.mocked(client.listNotes).mockRejectedValue(
@@ -49,6 +73,22 @@ describe("createToduNoteService", () => {
 
     await expect(service.listNotes()).rejects.toThrow(ToduNoteServiceError);
     await expect(service.listNotes()).rejects.toThrow("listNotes failed: connection lost");
+  });
+
+  it("wraps getNote daemon client errors in ToduNoteServiceError", async () => {
+    const client = createClientMock();
+    vi.mocked(client.getNote).mockRejectedValue(
+      new ToduDaemonClientError({
+        code: "unavailable",
+        method: "note.get",
+        message: "connection lost",
+      })
+    );
+
+    const service = createToduNoteService({ client });
+
+    await expect(service.getNote("note-1")).rejects.toThrow(ToduNoteServiceError);
+    await expect(service.getNote("note-1")).rejects.toThrow("getNote failed: connection lost");
   });
 
   it("re-throws non-daemon errors as-is", async () => {


### PR DESCRIPTION
## Summary
- add direct daemon-client coverage for `note.get`
- verify `NOT_FOUND` maps to `null` for note lookup
- keep pi extensions aligned with the upstream `note.get` RPC

## Testing
- make pre-pr

Task: #task-631043e9