### PR TITLE
Select task from typed pickup command

### DIFF
--- a/src/__tests__/pickup-task-input.test.ts
+++ b/src/__tests__/pickup-task-input.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { TaskDetail } from "@/domain/task";
+import {
+  createPickupTaskInputHandler,
+  resolvePickupTaskInputTaskId,
+} from "@/extension/pickup-task-input";
+import type { TaskService } from "@/services/task-service";
+
+const createTaskDetail = (overrides: Partial<TaskDetail> = {}): TaskDetail => ({
+  id: overrides.id ?? "task-123",
+  title: overrides.title ?? "Implement pickup input",
+  status: overrides.status ?? "active",
+  priority: overrides.priority ?? "high",
+  projectId: overrides.projectId ?? "proj-1",
+  projectName: overrides.projectName ?? "Todu Pi Extensions",
+  labels: overrides.labels ?? ["ui"],
+  assigneeActorIds: overrides.assigneeActorIds ?? ["actor-user"],
+  assigneeDisplayNames: overrides.assigneeDisplayNames ?? ["Erik"],
+  assignees: overrides.assignees ?? ["Erik"],
+  description: overrides.description ?? "Select tasks from typed pickup commands",
+  descriptionApproval: overrides.descriptionApproval ?? null,
+  comments: overrides.comments ?? [],
+  outboundAssigneeWarnings: overrides.outboundAssigneeWarnings ?? [],
+});
+
+const createContext = () => ({
+  hasUI: true,
+  sessionManager: {
+    getBranch: vi.fn().mockReturnValue([]),
+  },
+  ui: {
+    notify: vi.fn(),
+    setStatus: vi.fn(),
+    setWidget: vi.fn(),
+  },
+});
+
+describe("resolvePickupTaskInputTaskId", () => {
+  it("finds task ids in supported pickup prompts", () => {
+    expect(resolvePickupTaskInputTaskId("pick up task-123")).toBe("task-123");
+    expect(resolvePickupTaskInputTaskId("pick up task task-123")).toBe("task-123");
+    expect(resolvePickupTaskInputTaskId("pickup task-123")).toBe("task-123");
+    expect(resolvePickupTaskInputTaskId("pickup task task-123")).toBe("task-123");
+  });
+
+  it("does not treat unrelated task references as pickup prompts", () => {
+    expect(resolvePickupTaskInputTaskId("show task task-123")).toBeNull();
+    expect(resolvePickupTaskInputTaskId("please pick task-123 later")).toBeNull();
+  });
+});
+
+describe("createPickupTaskInputHandler", () => {
+  it("sets the typed pickup task as current and lets the pipeline continue", async () => {
+    const task = createTaskDetail({ id: "task-1b1fdc9d" });
+    const taskService = {
+      getTask: vi.fn().mockResolvedValue(task),
+    } as unknown as Pick<TaskService, "getTask">;
+    const getTaskService = vi.fn().mockResolvedValue(taskService);
+    const setCurrentTask = vi.fn().mockResolvedValue(undefined);
+    const context = createContext();
+    const handler = createPickupTaskInputHandler({ getTaskService, setCurrentTask });
+
+    const result = await handler(
+      { type: "input", text: "pick up task task-1b1fdc9d", source: "interactive" },
+      context as never
+    );
+
+    expect(result).toEqual({ action: "continue" });
+    expect(getTaskService).toHaveBeenCalledTimes(1);
+    expect(taskService.getTask).toHaveBeenCalledWith(task.id);
+    expect(setCurrentTask).toHaveBeenCalledWith(context, task);
+  });
+
+  it("ignores extension-injected and unrelated input", async () => {
+    const getTaskService = vi.fn();
+    const setCurrentTask = vi.fn();
+    const context = createContext();
+    const handler = createPickupTaskInputHandler({ getTaskService, setCurrentTask });
+
+    await expect(
+      handler(
+        { type: "input", text: "pick up task task-123", source: "extension" },
+        context as never
+      )
+    ).resolves.toEqual({ action: "continue" });
+    await expect(
+      handler(
+        { type: "input", text: "show task task-123", source: "interactive" },
+        context as never
+      )
+    ).resolves.toEqual({ action: "continue" });
+
+    expect(getTaskService).not.toHaveBeenCalled();
+    expect(setCurrentTask).not.toHaveBeenCalled();
+  });
+
+  it("continues without selecting a task when the task cannot be loaded", async () => {
+    const taskService = {
+      getTask: vi.fn().mockResolvedValue(null),
+    } as unknown as Pick<TaskService, "getTask">;
+    const setCurrentTask = vi.fn();
+    const context = createContext();
+    const handler = createPickupTaskInputHandler({
+      getTaskService: vi.fn().mockResolvedValue(taskService),
+      setCurrentTask,
+    });
+
+    const result = await handler(
+      { type: "input", text: "pickup task task-missing", source: "interactive" },
+      context as never
+    );
+
+    expect(result).toEqual({ action: "continue" });
+    expect(setCurrentTask).not.toHaveBeenCalled();
+  });
+});

--- a/src/extension/pickup-task-input.ts
+++ b/src/extension/pickup-task-input.ts
@@ -1,0 +1,48 @@
+import type {
+  ExtensionContext,
+  InputEvent,
+  InputEventResult,
+} from "@earendil-works/pi-coding-agent";
+
+import type { TaskDetail, TaskId } from "../domain/task";
+import type { TaskService } from "../services/task-service";
+
+export interface PickupTaskInputDependencies {
+  getTaskService: () => Promise<Pick<TaskService, "getTask">>;
+  setCurrentTask: (ctx: ExtensionContext, task: TaskDetail) => Promise<void>;
+}
+
+const PICKUP_TASK_INPUT_PATTERN =
+  /^\s*(?:pick\s+up|pickup)\s+(?:task\s+)?(task-[a-z0-9][a-z0-9-]*)\b/i;
+
+const resolvePickupTaskInputTaskId = (text: string): TaskId | null => {
+  const match = PICKUP_TASK_INPUT_PATTERN.exec(text);
+  return match?.[1] ?? null;
+};
+
+const createPickupTaskInputHandler =
+  ({ getTaskService, setCurrentTask }: PickupTaskInputDependencies) =>
+  async (event: InputEvent, ctx: ExtensionContext): Promise<InputEventResult> => {
+    if (event.source === "extension") {
+      return { action: "continue" };
+    }
+
+    const taskId = resolvePickupTaskInputTaskId(event.text);
+    if (!taskId) {
+      return { action: "continue" };
+    }
+
+    try {
+      const taskService = await getTaskService();
+      const task = await taskService.getTask(taskId);
+      if (task) {
+        await setCurrentTask(ctx, task);
+      }
+    } catch {
+      // Let the pickup pipeline continue even if current-task context cannot refresh.
+    }
+
+    return { action: "continue" };
+  };
+
+export { createPickupTaskInputHandler, resolvePickupTaskInputTaskId };

--- a/src/extension/register-events.ts
+++ b/src/extension/register-events.ts
@@ -1,9 +1,11 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
+import { getDefaultToduTaskServiceRuntime } from "../services/todu/default-task-service";
 import {
   getDefaultCurrentTaskContextController,
   resetDefaultCurrentTaskContextController,
 } from "./current-task-context";
+import { createPickupTaskInputHandler } from "./pickup-task-input";
 import {
   getDefaultSyncStatusContextController,
   resetDefaultSyncStatusContextController,
@@ -13,6 +15,7 @@ import { resetDefaultTaskBrowseFilterContextController } from "./task-browse-fil
 const registerEvents = (pi: ExtensionAPI): void => {
   const currentTaskContext = getDefaultCurrentTaskContextController(pi);
   const syncStatusContext = getDefaultSyncStatusContextController(pi);
+  const taskServiceRuntime = getDefaultToduTaskServiceRuntime();
   const restoreUiContext = async (ctx: ExtensionContext): Promise<void> => {
     await Promise.all([currentTaskContext.restoreFromBranch(ctx), syncStatusContext.attach(ctx)]);
   };
@@ -24,6 +27,14 @@ const registerEvents = (pi: ExtensionAPI): void => {
   pi.on("session_tree", async (_event, ctx) => {
     await restoreUiContext(ctx);
   });
+
+  pi.on(
+    "input",
+    createPickupTaskInputHandler({
+      getTaskService: () => taskServiceRuntime.ensureConnected(),
+      setCurrentTask: (ctx, task) => currentTaskContext.setCurrentTask(ctx, task),
+    })
+  );
 
   pi.on("session_shutdown", async () => {
     await Promise.all([


### PR DESCRIPTION
## Summary

Select the current task when a user types a pickup prompt directly, matching the existing `/tasks` pickup behavior.

## Task

Task: #task-1b1fdc9d

## Changes

- Added pickup input detection for `pick up` / `pickup` task prompts.
- Loaded the referenced task and set current-task context before allowing the pipeline to continue.
- Added unit coverage for supported pickup prompt shapes and non-matching input.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [ ] Documentation updated (if needed)
- [x] No unrelated changes included
